### PR TITLE
Add calling the closure from shared props using the Laravel container

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -22,7 +22,7 @@ class Component
     {
         array_walk_recursive($this->sharedProps, function (&$item, $key) {
             if (is_callable($item)) {
-                $item = $item();
+                $item = app()->call($item);
             }
         });
 


### PR DESCRIPTION
This will make it possible to add parameters to the shared props closure and let Laravel's container bind them.

For example:

```php
Inertia::share('user', function (Request $request) {
    return $request->user()->toArray();
});
```