### PR TITLE
Add Component methods as docblock properties to Intertia facade

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -4,6 +4,13 @@ namespace Inertia;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static \Illuminate\Contracts\View\View render($component, $props = [])
+ * @method static array share($key, $value)
+ * @method static void setRootView($name)
+ *
+ * @see \Inertia\Component
+ */
 class Inertia extends Facade
 {
     protected static function getFacadeAccessor()


### PR DESCRIPTION
Will be a great help for people using IDE's that want to use the Intertia facade and have autocomplete ont the methods.

I didn't provide any typehints on the method params, as the Component class also doesn't have them. 