### PR TITLE
use fullUrl() instead of url() method when assets change

### DIFF
--- a/src/CheckInertiaVersion.php
+++ b/src/CheckInertiaVersion.php
@@ -13,7 +13,7 @@ class CheckInertiaVersion
             && $request->header('X-Inertia')
             && $request->header('X-Inertia-Version') !== Inertia::getVersion()
         ) {
-            return Response::make('', 409, ['X-Inertia-Location' => $request->url()]);
+            return Response::make('', 409, ['X-Inertia-Location' => $request->fullUrl()]);
         }
 
         return $next($request);


### PR DESCRIPTION
By now, the redirection when assets are changed also returns the query string.