### PR TITLE
inject props in the blade template

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,10 +125,10 @@ Inertia::share('auth.user', function () {
 
 ## Accessing data in root template
 
-There are situations where you may want to access your prop data in your root Blade template. For example, you may want to add a meta description tag, Twitter card meta tags, or Facebook Open Graph meta tags. To do this, use the `Inertia::get()` helper.
+There are situations where you may want to access your prop data in your root Blade template. For example, you may want to add a meta description tag, Twitter card meta tags, or Facebook Open Graph meta tags. To do this, all props are injected in the blade file, as regular Blade variable.
 
 ~~~blade
-<meta name="twitter:title" content="{{ Inertia::get('event.title') }}">
+<meta name="twitter:title" content="{{ $event->title }}">
 ~~~
 
 Sometimes you may even want to provide data that will not be sent to your JavaScript component. You can do this using the `with()` view helper, since `Inertia::render()` returns a `View` instance.

--- a/src/Component.php
+++ b/src/Component.php
@@ -63,6 +63,8 @@ class Component
             ]);
         }
 
-        return View::make($this->rootView, ['page' => $page]);
+        return View::make($this->rootView, array_merge(
+            ['page' => $page], array_merge($this->sharedProps, $props)
+        ));
     }
 }


### PR DESCRIPTION
The documentation is wrong by default. It tells that the `Inertia::get()` method can retrieve props, but only can retrieve shared props. This PR is injecting props into the blade template, to use them. It seems logic to keep the `view->with()` documentation, but `Inertia::get()` seems useless for the template part...