### PR TITLE
Use a string for the X-Inertia header value

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -63,7 +63,7 @@ class Component
         if (Request::header('X-Inertia')) {
             return Response::json($page, 200, [
                 'Vary' => 'Accept',
-                'X-Inertia' => true,
+                'X-Inertia' => 'true',
             ]);
         }
 


### PR DESCRIPTION
[Diactoros](https://github.com/zendframework/zend-diactoros) give you a hard time when supplying header values that are not strings or numbers for security reasons. This PR changes `true` to `'true'`.

The error message we got:

```
Fatal error: Uncaught Zend\Diactoros\Exception\InvalidArgumentException: Invalid header value type; must be a string or numeric; received boolean in /var/task/vendor/zendframework/zend-diactoros/src/HeaderSecurity.php:139
```

For now, we're using a custom middleware, but it's not an ideal solution.

```php
class TemporaryInertiaHeaderOverride
{
    public function handle($request, Closure $next)
    {
        $response = $next($request);

        if ($response->headers->has('X-Inertia')) {
            $response->headers->set('X-Inertia', 'true', true);
        }

        return $response;
    }
}
```