### PR TITLE
Add responsable response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 .DS_Store
+.phpunit.result.cache
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,6 @@
             "Tests\\": "tests/"
         }
     },
-    "require": {
-        "illuminate/contracts": "^5.8",
-        "illuminate/support": "^5.8"
-    },
     "require-dev": {
         "orchestra/testbench": "~3.0"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.4/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,21 @@ class EventsController extends Controller
 }
 ~~~
 
+Alternatively, you can use the `with()` method to include component data (props):
+
+~~~php
+use Inertia\Inertia;
+
+class EventsController extends Controller
+{
+    public function show(Event $event)
+    {
+        return Inertia::render('Event')
+            ->with('event', $event->only('id', 'title', 'start_date', 'description'));
+    }
+}
+~~~
+
 ## Following redirects
 
 When making a non-GET Inertia request, via `<inertia-link>` or manually, be sure to still respond with a proper Inertia response. For example, if you're creating a new user, have your "store" endpoint return a redirect back to a standard GET endpoint, such as your user index page. Inertia will automatically follow this redirect and update the page accordingly. Here's a simplified example.
@@ -133,17 +148,16 @@ There are situations where you may want to access your prop data in your root Bl
 <meta name="twitter:title" content="{{ $page['props']['event']->title }}">
 ~~~
 
-Sometimes you may even want to provide data that will not be sent to your JavaScript component. You can do this using the `with()` view helper, since `Inertia::render()` returns a `View` instance.
+Sometimes you may even want to provide data that will not be sent to your JavaScript component. You can do this using the `withViewData()` method.
 
 ~~~php
-return Inertia::render('Event', ['event' => $event])
-                ->with(['meta_description' => $event->meta_description]);
+return Inertia::render('Event', ['event' => $event])->withViewData(['meta' => $event->meta]);
 ~~~
 
 You can then access this variable like a regular Blade variable.
 
 ~~~blade
-<meta name="description" content="{{ $meta_description }}">
+<meta name="description" content="{{ $meta }}">
 ~~~
 
 ## Asset versioning

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -5,16 +5,19 @@ namespace Inertia;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static \Illuminate\Contracts\View\View render($component, $props = [])
- * @method static array share($key, $value)
  * @method static void setRootView($name)
+ * @method static void share($key, $value)
+ * @method static array getShared($key = null)
+ * @method static void version($version)
+ * @method static int|string getVersion()
+ * @method static \Inertia\Response render($component, $props = [])
  *
- * @see \Inertia\Component
+ * @see \Inertia\ResponseFactory
  */
 class Inertia extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return Component::class;
+        return ResponseFactory::class;
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -24,7 +24,7 @@ class Response implements Responsable
         $this->version = $version;
     }
 
-    public function with($key, $value)
+    public function withViewData($key, $value)
     {
         $this->viewData[$key] = $value;
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Inertia;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\View;
+use Illuminate\Contracts\Support\Responsable;
+
+class Response implements Responsable
+{
+    protected $rootView;
+    protected $sharedProps;
+    protected $version;
+    protected $component;
+    protected $props;
+    protected $viewData = [];
+
+    public function __construct($rootView, $sharedProps = [], $version, $component, $props)
+    {
+        $this->rootView = $rootView;
+        $this->sharedProps = $sharedProps;
+        $this->version = $version;
+        $this->component = $component;
+        $this->props = $props;
+    }
+
+    public function with($key, $value)
+    {
+        $this->viewData[$key] = $value;
+
+        return $this;
+    }
+
+    public function toResponse($request)
+    {
+        $page = [
+            'component' => $this->component,
+            'props' => array_merge($this->sharedProps, $this->props),
+            'url' => $request->getRequestUri(),
+            'version' => $this->version,
+        ];
+
+        if ($request->header('X-Inertia')) {
+            return new JsonResponse($page, 200, [
+                'Vary' => 'Accept',
+                'X-Inertia' => 'true',
+            ]);
+        }
+
+        return View::make($this->rootView, $this->viewData + ['page' => $page]);
+    }
+}

--- a/src/Response.php
+++ b/src/Response.php
@@ -8,20 +8,20 @@ use Illuminate\Contracts\Support\Responsable;
 
 class Response implements Responsable
 {
+    protected $component;
+    protected $props;
     protected $rootView;
     protected $sharedProps;
     protected $version;
-    protected $component;
-    protected $props;
     protected $viewData = [];
 
-    public function __construct($rootView, $sharedProps = [], $version, $component, $props)
+    public function __construct($component, $props, $rootView = 'app', $sharedProps = [], $version = null)
     {
+        $this->component = $component;
+        $this->props = $props;
         $this->rootView = $rootView;
         $this->sharedProps = $sharedProps;
         $this->version = $version;
-        $this->component = $component;
-        $this->props = $props;
     }
 
     public function with($key, $value)

--- a/src/Response.php
+++ b/src/Response.php
@@ -24,6 +24,17 @@ class Response implements Responsable
         $this->version = $version;
     }
 
+    public function with($key, $value = null)
+    {
+        if (is_array($key)) {
+            $this->props = array_merge($this->props, $key);
+        } else {
+            $this->props[$key] = $value;
+        }
+
+        return $this;
+    }
+
     public function withViewData($key, $value)
     {
         $this->viewData[$key] = $value;

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -4,16 +4,11 @@ namespace Inertia;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\View;
-use Illuminate\Support\Facades\Request;
-use Illuminate\Support\Facades\Response;
 
-class Component
+class ResponseFactory
 {
     protected $rootView = 'app';
-
     protected $sharedProps = [];
-
     protected $version = null;
 
     public function setRootView($name)
@@ -23,7 +18,7 @@ class Component
 
     public function share($key, $value)
     {
-        return Arr::set($this->sharedProps, $key, $value);
+        Arr::set($this->sharedProps, $key, $value);
     }
 
     public function getShared($key = null)
@@ -53,20 +48,6 @@ class Component
             }
         });
 
-        $page = [
-            'component' => $component,
-            'props' => array_merge($this->sharedProps, $props),
-            'url' => Request::getRequestUri(),
-            'version' => $this->getVersion(),
-        ];
-
-        if (Request::header('X-Inertia')) {
-            return Response::json($page, 200, [
-                'Vary' => 'Accept',
-                'X-Inertia' => 'true',
-            ]);
-        }
-
-        return View::make($this->rootView, ['page' => $page]);
+        return new Response($this->rootView, $this->sharedProps, $this->getVersion(), $component, $props);
     }
 }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -48,6 +48,6 @@ class ResponseFactory
             }
         });
 
-        return new Response($this->rootView, $this->sharedProps, $this->getVersion(), $component, $props);
+        return new Response($component, $props, $this->rootView, $this->sharedProps, $this->getVersion());
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests;
+
+use Inertia\Response;
+use Illuminate\View\View;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class ResponseTest extends TestCase
+{
+    public function test_server_response()
+    {
+        $request = Request::create('/user/123', 'GET');
+
+        $response = new Response(
+            'User/Edit',
+            ['user' => ['name' => 'Jonathan']],
+            'app',
+            ['foo' => 'bar'],
+            '123'
+        );
+
+        $response = $response->toResponse($request);
+        $page = $response->getData()['page'];
+
+        $this->assertInstanceOf(View::class, $response);
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;,&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;}"></div>'."\n", $response->render());
+    }
+
+    public function test_xhr_response()
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+
+        $response = new Response(
+            'User/Edit',
+            ['user' => ['name' => 'Jonathan']],
+            'app',
+            ['foo' => 'bar'],
+            '123'
+        );
+
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame('User/Edit', $page->component);
+        $this->assertSame('Jonathan', $page->props->user->name);
+        $this->assertSame('bar', $page->props->foo);
+        $this->assertSame('/user/123', $page->url);
+        $this->assertSame('123', $page->version);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Support\Facades\View;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+abstract class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app)
+    {
+        return ['Inertia\ServiceProvider'];
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        View::addLocation(__DIR__.'/views');
+    }
+}

--- a/tests/views/app.blade.php
+++ b/tests/views/app.blade.php
@@ -1,0 +1,1 @@
+@inertia


### PR DESCRIPTION
This adds a new responsable Inertia response, which can have additional methods added to it (ie. `with()`.

For example, if you wanted to send Blade specific values:

```php
return Inertia::render('Dashboard/Index', $props)->with('foo', 'bar');
```

Not convinced this method should be called `with()`. I'm inclined to use that as an alternative way to set prop data, similar to how normal views work in Laravel. Maybe it should just be `withViewData()`. 🤔 

Resolves #20