### PR TITLE
Add ability to use share() with only a callback

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -11,16 +11,14 @@ class Response implements Responsable
     protected $component;
     protected $props;
     protected $rootView;
-    protected $sharedProps;
     protected $version;
     protected $viewData = [];
 
-    public function __construct($component, $props, $rootView = 'app', $sharedProps = [], $version = null)
+    public function __construct($component, $props, $rootView = 'app', $version = null)
     {
         $this->component = $component;
         $this->props = $props;
         $this->rootView = $rootView;
-        $this->sharedProps = $sharedProps;
         $this->version = $version;
     }
 
@@ -46,7 +44,7 @@ class Response implements Responsable
     {
         $page = [
             'component' => $this->component,
-            'props' => array_merge($this->sharedProps, $this->props),
+            'props' => $this->props,
             'url' => $request->getRequestUri(),
             'version' => $this->version,
         ];

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -17,7 +17,6 @@ class ResponseTest extends TestCase
             'User/Edit',
             ['user' => ['name' => 'Jonathan']],
             'app',
-            ['foo' => 'bar'],
             '123'
         );
 
@@ -27,10 +26,9 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(View::class, $response);
         $this->assertSame('User/Edit', $page['component']);
         $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('bar', $page['props']['foo']);
         $this->assertSame('/user/123', $page['url']);
         $this->assertSame('123', $page['version']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;,&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;}"></div>'."\n", $response->render());
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;}"></div>'."\n", $response->render());
     }
 
     public function test_xhr_response()
@@ -42,7 +40,6 @@ class ResponseTest extends TestCase
             'User/Edit',
             ['user' => ['name' => 'Jonathan']],
             'app',
-            ['foo' => 'bar'],
             '123'
         );
 
@@ -52,7 +49,6 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertSame('User/Edit', $page->component);
         $this->assertSame('Jonathan', $page->props->user->name);
-        $this->assertSame('bar', $page->props->foo);
         $this->assertSame('/user/123', $page->url);
         $this->assertSame('123', $page->version);
     }


### PR DESCRIPTION
This adds ability to use share() with only a callback. For example:

```php
Inertia::share(function () {
    return [
        'flash' => [
            'success' => Session::get('success'),
        ],
        'errors' => Session::get('errors') ? Session::get('errors')->getBag('default')->getMessages() : (object) [],
        'auth' => [
            'user' => Auth::user() ? [
                'id' => Auth::user()->id,
                'first_name' => Auth::user()->first_name,
                'last_name' => Auth::user()->last_name,
                'email' => Auth::user()->email,
            ] : null
        ],
    ];
});
```

I also refactored the `Response` class to only take a single props array, and I moved the shared prop merging into the `ResponseFactory`.

Resolves #25