### PR TITLE
Add helper function inertia()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
     "autoload": {
         "psr-4": {
             "Inertia\\": "src"
-        }
+        },
+        "files": [
+            "helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/helpers.php
+++ b/helpers.php
@@ -1,8 +1,12 @@
 <?php
 
 if (! function_exists('inertia')) {
-    function inertia($component, $props)
+    function inertia($component = null, $props = [])
     {
-        return \Inertia\Inertia::render($component, $props);
+        if ($component) {
+            return (new \Inertia\ResponseFactory())->render($component, $props);
+        }
+
+        return new \Inertia\ResponseFactory();
     }
 }

--- a/helpers.php
+++ b/helpers.php
@@ -1,0 +1,8 @@
+<?php
+
+if (! function_exists('inertia')) {
+    function inertia($component, $props, $rootView = 'app', $version = null)
+    {
+        return new \Inertia\Response($component, $props, $rootView, $version);
+    }
+}

--- a/helpers.php
+++ b/helpers.php
@@ -3,10 +3,12 @@
 if (! function_exists('inertia')) {
     function inertia($component = null, $props = [])
     {
+        $factory = new \Inertia\ResponseFactory();
+
         if ($component) {
-            return (new \Inertia\ResponseFactory())->render($component, $props);
+            return $factory->render($component, $props);
         }
 
-        return new \Inertia\ResponseFactory();
+        return $factory;
     }
 }

--- a/helpers.php
+++ b/helpers.php
@@ -1,8 +1,8 @@
 <?php
 
 if (! function_exists('inertia')) {
-    function inertia($component, $props, $rootView = 'app', $version = null)
+    function inertia($component, $props)
     {
-        return new \Inertia\Response($component, $props, $rootView, $version);
+        return \Inertia\Inertia::render($component, $props);
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -6,6 +6,7 @@ use Inertia\Response;
 use Illuminate\View\View;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Inertia\ResponseFactory;
 
 class ResponseTest extends TestCase
 {
@@ -56,5 +57,10 @@ class ResponseTest extends TestCase
     public function test_the_helper_function_returns_a_response_instance()
     {
         $this->assertInstanceOf(Response::class, inertia('User/Edit', ['user' => ['name' => 'Jonathan']]));
+    }
+
+    public function test_if_no_parameters_are_passed_to_the_helper_function_it_returns_the_response_factory()
+    {
+        $this->assertInstanceOf(ResponseFactory::class, inertia());
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -53,21 +53,8 @@ class ResponseTest extends TestCase
         $this->assertSame('123', $page->version);
     }
 
-    public function test_server_response_with_helper_function()
+    public function test_the_helper_function_returns_a_response_instance()
     {
-        $request = Request::create('/user/123', 'GET');
-
-        $response = inertia('User/Edit', ['user' => ['name' => 'Jonathan']], 'app', '123');
-        $this->assertInstanceOf(Response::class, $response);
-
-        $response = $response->toResponse($request);
-        $page = $response->getData()['page'];
-
-        $this->assertInstanceOf(View::class, $response);
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;}"></div>'."\n", $response->render());
+        $this->assertInstanceOf(Response::class, inertia('User/Edit', ['user' => ['name' => 'Jonathan']]));
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -52,4 +52,22 @@ class ResponseTest extends TestCase
         $this->assertSame('/user/123', $page->url);
         $this->assertSame('123', $page->version);
     }
+
+    public function test_server_response_with_helper_function()
+    {
+        $request = Request::create('/user/123', 'GET');
+
+        $response = inertia('User/Edit', ['user' => ['name' => 'Jonathan']], 'app', '123');
+        $this->assertInstanceOf(Response::class, $response);
+
+        $response = $response->toResponse($request);
+        $page = $response->getData()['page'];
+
+        $this->assertInstanceOf(View::class, $response);
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;}"></div>'."\n", $response->render());
+    }
 }


### PR DESCRIPTION
When using the Laravel framework I personally find it cleaner to use the `view()`, so I'd also really like to be able to use the same approach with Intertia.

This pull request simply adds a helper function `inertia()`.

For example:

```php
return Intertia::render('Welcome', ['name' => 'George']);
```

becomes

```php
return inertia('Welcome', ['name' => 'George']);
```