### PR TITLE
Change default value of $value to null on Inertia facade

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static void setRootView($name)
- * @method static void share($key, $value)
+ * @method static void share($key, $value = null)
  * @method static array getShared($key = null)
  * @method static void version($version)
  * @method static int|string getVersion()


### PR DESCRIPTION
Docblock method declaration did not match the actual implementation which made PhpStorm go wild :)