### PR TITLE
Move tests under main inertia namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/"
+            "Inertia\\Tests\\": "tests/"
         }
     },
     "require-dev": {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Inertia\Tests;
 
 use Inertia\Response;
 use Illuminate\View\View;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Inertia\Tests;
 
 use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase as Orchestra;


### PR DESCRIPTION
The current structure of the test namespace have problems with autocompletion, member resolution and inheritance analysis for IDEs like phpstorm. Тhe reason is multiple declarations of Tests\TestCase namepsace in inertia-laravel package and Tests\TestCase in standard Laravel app.
