### PR TITLE
Add inertia() helper function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
     "autoload": {
         "psr-4": {
             "Inertia\\": "src"
-        }
+        },
+        "files": [
+            "./helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/helpers.php
+++ b/helpers.php
@@ -1,0 +1,20 @@
+<?php
+
+if (! function_exists('inertia')) {
+    /**
+     * Inertia helper.
+     *
+     * @param null|string $component
+     * @param array $props
+     * @return \Inertia\ResponseFactory|\Inertia\Response
+     */
+    function inertia($component = null, $props = []) {
+        $instance = \Inertia\Inertia::getFacadeRoot();
+
+        if ($component) {
+            return $instance->render($component, $props);
+        }
+
+        return $instance;
+    }
+}

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests;
+
+use Inertia\Inertia;
+use Inertia\ResponseFactory;
+use Inertia\Response;
+
+class HelperTest extends TestCase
+{
+    public function test_the_helper_function_returns_an_instance_of_the_response_factory()
+    {
+        $this->assertInstanceOf(ResponseFactory::class, inertia());
+    }
+
+    public function test_the_helper_function_returns_a_response_instance()
+    {
+        $this->assertInstanceOf(Response::class, inertia('User/Edit', ['user' => ['name' => 'George']]));
+    }
+
+    public function test_the_instance_is_the_same_as_the_facade_instance()
+    {
+        Inertia::share('key', 'value');
+        $this->assertEquals('value', inertia()->getShared('key'));
+    }
+}


### PR DESCRIPTION
@reinink This is a re-open on my previous PR #29.

---------------------------------------------------

When using the Laravel framework I personally find it cleaner to use the `view()`, so I'd also really like to be able to use the same approach with Intertia.

This pull request simply adds a helper function `inertia()`.

For example:

```php
return Intertia::render('Welcome', ['name' => 'George']);
```

becomes

```php
return inertia('Welcome', ['name' => 'George']);
```

You can also access the `ResponseFactory` instance by not passing any parameters to the function. This allows you to make calls to other methods such as `share`.

```php
inertia()->share('name', 'George');
```