### PR TITLE
Allow passing Arrayable objects

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\View;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
 
 class Response implements Responsable
@@ -19,7 +20,7 @@ class Response implements Responsable
     public function __construct($component, $props, $rootView = 'app', $version = null)
     {
         $this->component = $component;
-        $this->props = $props;
+        $this->props = $props instanceof Arrayable ? $props->toArray() : $props;
         $this->rootView = $rootView;
         $this->version = $version;
     }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -5,6 +5,7 @@ namespace Inertia;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
+use Illuminate\Contracts\Support\Arrayable;
 
 class ResponseFactory
 {
@@ -47,6 +48,10 @@ class ResponseFactory
 
     public function render($component, $props = [])
     {
+        if ($props instanceof Arrayable) {
+            $props = $props->toArray();
+        }
+
         return new Response(
             $component,
             array_merge($this->sharedProps, $props),


### PR DESCRIPTION
Instead of manually passing an array with data:

```php
class EventsController extends Controller
{
    public function show(Event $event)
    {
        return Inertia::render('Event', [
            'event' => $event->only('id', 'title', 'start_date', 'description'),
        ]);
    }
}
```

we can use an `Arrayable` object (for example, like `Collection`) to pass the data:

```php
use Illuminate\Contracts\Support\Arrayable;

class EventProps implements Arrayable
{
    public $event;

    public function __construct(Event $event)
    {
        $this->event = $event;
    }

    public function toArray()
    {
        return ['event' => $this->event->only('id', 'title', 'start_date', 'description')];
    }
}

class EventsController extends Controller
{
    public function show(Event $event)
    {
        return Inertia::render('Event', new EventProps($event));
    }
}
```

This way we can reuse the logic and simplify the code.

Similar functionality is already present in Laravel:

- https://github.com/laravel/framework/blob/5.8/src/Illuminate/View/View.php#L76
- https://github.com/laravel/framework/blob/5.8/src/Illuminate/View/Factory.php#L238-L241