### PR TITLE
Use Response factory to build view

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -3,11 +3,12 @@
 namespace Inertia;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\App;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Support\Facades\Response as ResponseFacade;
+use Illuminate\Support\Facades\Response as ResponseFactory;
 
 class Response implements Responsable
 {
@@ -52,7 +53,7 @@ class Response implements Responsable
         $only = array_filter(explode(',', $request->header('X-Inertia-Partial-Data')));
 
         $props = ($only && $request->header('X-Inertia-Partial-Component') === $this->component)
-            ? array_only($this->props, $only)
+            ? Arr::only($this->props, $only)
             : $this->props;
 
         array_walk_recursive($props, function (&$prop) {
@@ -75,6 +76,6 @@ class Response implements Responsable
             ]);
         }
 
-        return ResponseFacade::view($this->rootView, $this->viewData + ['page' => $page]);
+        return ResponseFactory::view($this->rootView, $this->viewData + ['page' => $page]);
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -3,8 +3,8 @@
 namespace Inertia;
 
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Response;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Facades\Response as ResponseFacade;
 
 class Response implements Responsable
 {
@@ -56,6 +56,6 @@ class Response implements Responsable
             ]);
         }
 
-        return Response::view($this->rootView, $this->viewData + ['page' => $page]);
+        return ResponseFacade::view($this->rootView, $this->viewData + ['page' => $page]);
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -3,7 +3,7 @@
 namespace Inertia;
 
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\View;
+use Illuminate\Support\Facades\Response;
 use Illuminate\Contracts\Support\Responsable;
 
 class Response implements Responsable
@@ -56,6 +56,6 @@ class Response implements Responsable
             ]);
         }
 
-        return View::make($this->rootView, $this->viewData + ['page' => $page]);
+        return Response::view($this->rootView, $this->viewData + ['page' => $page]);
     }
 }

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -20,6 +20,6 @@ class ControllerTest extends TestCase
                 'url' => '',
                 'version' => null,
             ],
-        ], $response->toResponse(new Request())->getData());
+        ], $response->toResponse(new Request())->getOriginalContent()->getData());
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -3,9 +3,9 @@
 namespace Tests;
 
 use Inertia\Response;
-use Illuminate\View\View;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response as BaseResponse;
 
 class ResponseTest extends TestCase
 {
@@ -21,14 +21,9 @@ class ResponseTest extends TestCase
         );
 
         $response = $response->toResponse($request);
-        $page = $response->getData()['page'];
 
-        $this->assertInstanceOf(View::class, $response);
-        $this->assertSame('User/Edit', $page['component']);
-        $this->assertSame('Jonathan', $page['props']['user']['name']);
-        $this->assertSame('/user/123', $page['url']);
-        $this->assertSame('123', $page['version']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;}"></div>'."\n", $response->render());
+        $this->assertInstanceOf(BaseResponse::class, $response);
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;}"></div>'."\n", $response->content());
     }
 
     public function test_xhr_response()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -3,6 +3,7 @@
 namespace Inertia\Tests;
 
 use Inertia\Response;
+use Illuminate\View\View;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response as BaseResponse;
@@ -21,9 +22,17 @@ class ResponseTest extends TestCase
         );
 
         $response = $response->toResponse($request);
+        $view = $response->getOriginalContent();
+        $page = $view->getData()['page'];
 
         $this->assertInstanceOf(BaseResponse::class, $response);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;}"></div>'."\n", $response->content());
+        $this->assertInstanceOf(View::class, $view);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;}"></div>'."\n", $view->render());
     }
 
     public function test_xhr_response()


### PR DESCRIPTION
Laravel `Responsable` trait has a type hint in its `toResponse` which states the return of this method should be a `\Symfony\Component\HttpFoundation\Response` object.

My use case is that I am using Inertia witth Spatie [Laravel View Models](https://github.com/spatie/laravel-view-models) package.

if I try to extend the view model `toResponse` method and return Inertia::render, I get an error because their package uses a return type hint.

Changing to use the Response facade instead of the view facade already wraps the view in a Request object and it aligns with the expected return type on the `Responsable` trait.