### PR TITLE
Fix request session check

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -17,7 +17,7 @@ class Middleware
         }
 
         if ($request->method() === 'GET' && $request->header('X-Inertia-Version') !== Inertia::getVersion()) {
-            if ($request->session()) {
+            if ($request->hasSession()) {
                 $request->session()->reflash();
             }
 


### PR DESCRIPTION
`$request->session()` throws an exception if no session is set, so this check doesn't work at the moment.

`hasSession` returns a boolean instead.