### PR TITLE
Add support for partial reloads

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -48,11 +48,15 @@ class Response implements Responsable
 
     public function toResponse($request)
     {
-        $only = array_filter(explode(',', $request->header('X-Inertia-Only')));
+        $only = array_filter(explode(',', $request->header('X-Inertia-Partial-Data')));
+
+        $props = ($only && $request->header('X-Inertia-Partial-Component') === $this->component)
+            ? array_only($this->props, $only)
+            : $this->props;
 
         $props = array_map(function ($prop) {
             return $prop instanceof Closure ? App::call($prop) : $prop;
-        }, $only ? array_only($this->props, $only) : $this->props);
+        }, $props);
 
         $page = [
             'component' => $this->component,

--- a/src/Response.php
+++ b/src/Response.php
@@ -49,13 +49,10 @@ class Response implements Responsable
     public function toResponse($request)
     {
         $only = array_filter(explode(',', $request->header('X-Inertia-Only')));
-        $props = $only ? array_only($this->props, $only) : $this->props;
 
-        array_walk_recursive($props, function (&$prop) {
-            if ($prop instanceof Closure) {
-                $prop = App::call($prop);
-            }
-        });
+        $props = array_map(function ($prop) {
+            return $prop instanceof Closure ? App::call($prop) : $prop;
+        }, $only ? array_only($this->props, $only) : $this->props);
 
         $page = [
             'component' => $this->component,

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -10,7 +10,6 @@ class ResponseFactory
 {
     protected $rootView = 'app';
     protected $sharedProps = [];
-    protected $sharedPropsCallbacks = [];
     protected $version = null;
 
     public function setRootView($name)
@@ -20,8 +19,8 @@ class ResponseFactory
 
     public function share($key, $value = null)
     {
-        if ($key instanceof Closure) {
-            $this->sharedPropsCallbacks[] = $key;
+        if (is_array($key)) {
+            $this->sharedProps = array_merge($this->sharedProps, $key);
         } else {
             Arr::set($this->sharedProps, $key, $value);
         }
@@ -48,18 +47,11 @@ class ResponseFactory
 
     public function render($component, $props = [])
     {
-        $props = array_merge($this->sharedProps, $props);
-
-        foreach ($this->sharedPropsCallbacks as $callback) {
-            $props = array_merge($props, App::call($callback));
-        }
-
-        array_walk_recursive($props, function (&$prop) {
-            if ($prop instanceof Closure) {
-                $prop = App::call($prop);
-            }
-        });
-
-        return new Response($component, $props, $this->rootView, $this->getVersion());
+        return new Response(
+            $component,
+            array_merge($this->sharedProps, $props),
+            $this->rootView,
+            $this->getVersion()
+        );
     }
 }


### PR DESCRIPTION
This PR adds support for [partial reloads](https://github.com/inertiajs/inertia/issues/60). It required some changes to how sharing works.

```php
Inertia::share(function () {
    return [
        'auth' => [
            'user' => Auth::user()->only('id', name)
        ];
    ];
});

// After
Inertia::share([
    'auth' => function () {
        return [
            'user' => Auth::user()->only('id', name)
        ];
    },
]);
```

This change is necessary, since we want to know the shared keys without having to evaluate all the shared data (since we may want to omit certain keys).

What's also nice is the sharing API now works the same as the controller API. Any props that are in a closure will be lazily evaluated, which is especially useful if they don't even get included with the request.

```php
class UsersController extends Controller
{
    public function index()
    {
        return Inertia::render('Users', [
            // Lazily evaluated, and won't ever be run
            // if excluded on partial reloads.
            'companies' => function () {
                return Company::orderBy('name')
                    ->get()
                    ->only('id', 'name');
            },
            // Evaluated immediately.
            'organizations' => User::orderBy('name')
                ->paginate()
                ->only('id', 'name'),
        ]);
    }
}
```