### PR TITLE
Assertion Tests & Implementation

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Inertia\Testing;
+
+use Inertia\Testing\TestResponse;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+	/**
+	 * Create the test response instance from the given response.
+	 *
+	 * @param  \Illuminate\Http\Response $response
+	 *
+	 * @return \Illuminate\Foundation\Testing\TestResponse
+	 */
+	protected function createTestResponse($response)
+	{
+	    return TestResponse::fromBaseResponse($response);
+	}
+}

--- a/src/Testing/TestResponse.php
+++ b/src/Testing/TestResponse.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Inertia\Testing;
+
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Foundation\Testing\TestResponse as BaseResponse;
+
+class TestResponse extends BaseResponse
+{
+	public function assertHasProp($prop)
+	{
+		PHPUnit::assertTrue(Arr::has($this->props(), $prop));
+
+		return $this;
+	}
+
+	public function assertPropValue($prop, $value)
+	{
+		$this->assertHasProp($prop);
+
+		if (is_callable($value)) {
+			$value($this->props($prop));
+		} else {
+			PHPUnit::assertEquals($this->props($prop), $value);
+		}
+
+		return $this;
+	}
+
+	public function assertPropCount($prop, $count)
+	{
+		$this->assertHasProp($prop);
+
+		PHPUnit::assertCount($count, $this->props($prop));
+
+		return $this;
+	}
+
+	protected function props($key = null)
+	{
+		$props = json_decode(json_encode($this->original['page']['props']), JSON_OBJECT_AS_ARRAY);
+
+		if ($key) {
+			return Arr::get($props, $key);
+		}
+
+		return $props;
+	}
+}

--- a/src/Testing/TestResponse.php
+++ b/src/Testing/TestResponse.php
@@ -37,6 +37,13 @@ class TestResponse extends BaseResponse
 		return $this;
 	}
 
+	public function assertComponent($component)
+	{
+		PHPUnit::assertEquals($component, $this->original['page']['component']);
+
+		return $this;
+	}
+
 	protected function props($key = null)
 	{
 		$props = json_decode(json_encode($this->original['page']['props']), JSON_OBJECT_AS_ARRAY);

--- a/tests/TestResponseTest.php
+++ b/tests/TestResponseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Http\Response;
+use Inertia\Testing\TestResponse;
+use PHPUnit\Framework\TestCase;
+
+class TestResponseTest extends TestCase
+{
+    public function test_assert_has_prop()
+    {
+        $response = $this->makeMockResponse([
+        	'prop' => 'value'
+        ]);
+
+        $response->assertHasProp('prop');
+    }
+
+    public function test_assert_prop_value()
+    {
+        $response = $this->makeMockResponse([
+        	'prop' => 'value'
+        ]);
+
+        $response->assertPropValue('prop', 'value');
+    }
+
+    public function test_assert_prop_count()
+    {
+        $response = $this->makeMockResponse([
+        	'prop' => [1, 2, 3],
+        ]);
+
+        $response->assertPropCount('prop', 3);
+    }
+
+    private function makeMockResponse($content)
+    {
+    	$baseResponse = tap(new Response, function ($response) use ($content) {
+            $response->setContent([
+            	'page' => [
+            		'props' => $content
+            	]
+            ]);
+        });
+
+        return TestResponse::fromBaseResponse($baseResponse);
+    }
+}

--- a/tests/TestResponseTest.php
+++ b/tests/TestResponseTest.php
@@ -33,13 +33,21 @@ class TestResponseTest extends TestCase
         $response->assertPropCount('prop', 3);
     }
 
-    private function makeMockResponse($content)
+    public function test_assert_component()
+    {
+        $response = $this->makeMockResponse();
+
+        $response->assertComponent('mock');
+    }
+
+    private function makeMockResponse($content = [])
     {
     	$baseResponse = tap(new Response, function ($response) use ($content) {
             $response->setContent([
             	'page' => [
-            		'props' => $content
-            	]
+            		'props' => $content,
+                    'component' => 'mock'
+            	],
             ]);
         });
 


### PR DESCRIPTION
# Assertions in the Inertia Laravel Adapter
I'm pretty sure that most of us that are testing are making use of the neat macros that was made for PingCRM, so I thought I'd make a PR merging those assertions into the adapter.

# Motivations
I don't really want my TestCase.php to be bloated with a ton of macros, so I decided to make these assertions and override the default Laravel TestResponse with these. (You will of course be able to use all assertions that comes with Laravel as well.)

# Usage
Simply extend the Inertia TestCase instead of the default Laravel one.

## Before
```php
<?php

namespace Tests;

use Illuminate\Support\Arr;
use PHPUnit\Framework\Assert;
use Illuminate\Foundation\Testing\TestResponse;
use Illuminate\Foundation\Testing\TestCase as BaseTestCase;

abstract class TestCase extends BaseTestCase
{
    use CreatesApplication;

    protected function setUp(): void
    {
        parent::setUp();

        TestResponse::macro('props', function ($key = null) {
            $props = json_decode(json_encode($this->original->getData()['page']['props']), JSON_OBJECT_AS_ARRAY);
            if ($key) {
                return Arr::get($props, $key);
            }
            return $props;
        });

        TestResponse::macro('assertHasProp', function ($key) {
            Assert::assertTrue(Arr::has($this->props(), $key));
            return $this;
        });

        TestResponse::macro('assertPropValue', function ($key, $value) {
            $this->assertHasProp($key);
            if (is_callable($value)) {
                $value($this->props($key));
            } else {
                Assert::assertEquals($this->props($key), $value);
            }
            return $this;
        });

        TestResponse::macro('assertPropCount', function ($key, $count) {
            $this->assertHasProp($key);
            Assert::assertCount($count, $this->props($key));
            return $this;
        });
    }
}
```

## After

```php
<?php

namespace Tests;

use Tests\CreatesApplication;
use Inertia\Testing\TestCase as BaseTestCase;

abstract class TestCase extends BaseTestCase
{
    use CreatesApplication;
}
```

See? Much cleaner than before! 

### Docs

If this get merged I'll sit down and write some documentation for this as well. 😄 