### PR TITLE
Auto register middleware

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,24 +3,38 @@
 namespace Inertia;
 
 use Illuminate\Routing\Router;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider
 {
-    /**
-     * Perform post-registration booting of services.
-     */
     public function boot()
+    {
+        $this->registerBladeDirective();
+        $this->registerRouterMacro();
+        $this->registerMiddleware();
+    }
+
+    protected function registerBladeDirective()
     {
         Blade::directive('inertia', function () {
             return '<div id="app" data-page="{{ json_encode($page) }}"></div>';
         });
+    }
 
+    protected function registerRouterMacro()
+    {
         Router::macro('inertia', function ($uri, $component, $props = []) {
             return $this->match(['GET', 'HEAD'], $uri, '\Inertia\Controller')
                 ->defaults('component', $component)
                 ->defaults('props', $props);
         });
+    }
+
+    protected function registerMiddleware()
+    {
+        $kernel = $this->app[Kernel::class];
+        $kernel->pushMiddleware(Middleware::class);
     }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Inertia\Middleware;
+use Illuminate\Support\Facades\App;
+use Illuminate\Contracts\Http\Kernel;
+
+class ServiceProviderTest extends TestCase
+{
+    public function test_middleware_is_registered()
+    {
+        $kernel = App::make(Kernel::class);
+
+        $this->assertTrue($kernel->hasMiddleware(Middleware::class));
+    }
+}


### PR DESCRIPTION
Currently the Laravel adapter requires you to manually register a middleware. This is an extra step, that makes it more difficult to get up and running. Further, it can be missed. It's also making the Inertia Laravel preset more difficult to maintain (see https://github.com/laravel-frontend-presets/inertiajs/pull/6).

This PR adds auto registering of the middleware by pushing the Inertia middleware to the end of the stack. Thanks to @barryvdh for suggesting this!

Note: This means the middleware will be registered for non-web requests as well (ie. api requests). This is fine, since the Inertia middleware only runs if the `X-Inertia` header is present. It looks like Laravel 5.8 has a new `pushMiddlewareToGroup()` method, so maybe we can switch to that in the future.