### PR TITLE
Adds the ability to switch off some components from the provider

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'use_middleware' => true,
+    'use_router_macro' => true,
+    'use_blade_directive' => true,
+];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,18 +2,28 @@
 
 namespace Inertia;
 
-use Illuminate\Routing\Router;
 use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider
 {
+    private static $configPath = __DIR__ . '/../config/config.php';
+
     public function boot()
     {
-        $this->registerBladeDirective();
-        $this->registerRouterMacro();
-        $this->registerMiddleware();
+        $this->publishes([self::$configPath => config_path('inertia.php')], 'config');
+
+        if (config('inertia.use_blade_directive', true)) {
+            $this->registerBladeDirective();
+        }
+        if (config('inertia.use_router_macro', true)) {
+            $this->registerRouterMacro();
+        }
+        if (config('inertia.use_middleware', true)) {
+            $this->registerMiddleware();
+        }
     }
 
     protected function registerBladeDirective()
@@ -35,5 +45,11 @@ class ServiceProvider extends BaseServiceProvider
     protected function registerMiddleware()
     {
         $this->app[Kernel::class]->pushMiddleware(Middleware::class);
+    }
+
+    public function register()
+    {
+        parent::register();
+        $this->mergeConfigFrom(self::$configPath, 'inertia');
     }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -2,24 +2,53 @@
 
 namespace Inertia\Tests;
 
-use Inertia\Middleware;
-use Illuminate\Support\Facades\App;
+use Illuminate\Routing\Router;
 use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
+use Inertia\ServiceProvider;
+use Inertia\Middleware;
 
-class ServiceProviderTest extends TestCase
+class ServiceProviderTest extends \Orchestra\Testbench\TestCase
 {
-    public function test_blade_directive_is_registered()
-    {
-        $directives = Blade::getCustomDirectives();
+    protected $serviceProvider;
 
-        $this->assertArrayHasKey('inertia', $directives);
-        $this->assertEquals('<div id="app" data-page="{{ json_encode($page) }}"></div>', $directives['inertia']());
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->serviceProvider = new ServiceProvider($this->app);
+        $this->serviceProvider->register();
+        // Used to reset a macro between tests due to their nature of being static
+        Router::macro('unsetMacro', function ($key) {
+            unset(self::$macros[$key]);
+        });
     }
 
-    public function test_route_macro_is_registered()
+    public function test_publishing_config()
     {
+        if (File::exists(config_path('inertia.php'))) {
+            File::delete(config_path('inertia.php'));
+        }
+
+        $this->serviceProvider->boot();
+        $this->artisan('vendor:publish', [
+            '--provider' => ServiceProvider::class,
+            '--tag' => 'config',
+            '--force' => true,
+        ])
+            ->assertExitCode(0);
+
+        $this->assertTrue(File::exists(config_path('inertia.php')));
+    }
+
+    public function test_router_macro_can_be_register()
+    {
+        Router::unsetMacro('inertia');
+        $this->serviceProvider->boot();
+        $this->assertTrue(Router::hasMacro('inertia'));
+
         $route = Route::inertia('/', 'User/Edit', ['user' => ['name' => 'Jonathan']]);
         $routes = Route::getRoutes();
 
@@ -27,14 +56,58 @@ class ServiceProviderTest extends TestCase
         $this->assertEquals($route, $routes->getRoutes()[0]);
         $this->assertEquals(['GET', 'HEAD'], $route->methods);
         $this->assertEquals('/', $route->uri);
-        $this->assertEquals(['uses' => '\Inertia\Controller@__invoke', 'controller' => '\Inertia\Controller'], $route->action);
-        $this->assertEquals(['component' => 'User/Edit', 'props' => ['user' => ['name' => 'Jonathan']]], $route->defaults);
+        $this->assertEquals(
+            ['uses' => '\Inertia\Controller@__invoke', 'controller' => '\Inertia\Controller'],
+            $route->action
+        );
+        $this->assertEquals(
+            ['component' => 'User/Edit', 'props' => ['user' => ['name' => 'Jonathan']]],
+            $route->defaults
+        );
     }
 
-    public function test_middleware_is_registered()
+    public function test_middleware_can_be_registered()
     {
-        $kernel = App::make(Kernel::class);
+        $this->serviceProvider->boot();
 
+        $kernel = App::make(Kernel::class);
         $this->assertTrue($kernel->hasMiddleware(Middleware::class));
+    }
+
+    public function test_blade_directive_can_be_registered()
+    {
+        $this->serviceProvider->boot();
+        $directives = Blade::getCustomDirectives();
+        $this->assertArrayHasKey('inertia', $directives);
+        $this->assertEquals(
+            '<div id="app" data-page="{{ json_encode($page) }}"></div>',
+            $directives['inertia']()
+        );
+    }
+
+    public function test_router_macro_can_be_disabled()
+    {
+        Router::unsetMacro('inertia');
+        config()->set('inertia.use_router_macro', false);
+
+        $this->serviceProvider->boot();
+        $this->assertFalse(Router::hasMacro('inertia'));
+    }
+
+    public function test_blade_directive_can_be_disabled()
+    {
+        config()->set('inertia.use_blade_directive', false);
+
+        $this->serviceProvider->boot();
+        $this->assertArrayNotHasKey('inertia', Blade::getCustomDirectives());
+    }
+
+    public function test_middleware_can_be_disabled()
+    {
+        config()->set('inertia.use_middleware', false);
+
+        $this->serviceProvider->boot();
+        $kernel = App::make(Kernel::class);
+        $this->assertFalse($kernel->hasMiddleware(Middleware::class));
     }
 }


### PR DESCRIPTION
I thought it might be useful as sometimes the end user will want to switch off particular parts of the package if they want to extend it further. By default everything is enabled but if the user wants to they can publish the config and disable the components.

I prefer this personally over having to disable auto discovery and extend the service provider for a package like this, but it's a valid alternative.