### PR TITLE
Remove array_only in favour of facade array helper

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -3,6 +3,7 @@
 namespace Inertia;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\View;
@@ -52,7 +53,7 @@ class Response implements Responsable
         $only = array_filter(explode(',', $request->header('X-Inertia-Partial-Data')));
 
         $props = ($only && $request->header('X-Inertia-Partial-Component') === $this->component)
-            ? array_only($this->props, $only)
+            ? Arr::only($this->props, $only)
             : $this->props;
 
         array_walk_recursive($props, function (&$prop) {


### PR DESCRIPTION
Hi, I saw on twitter the partial reload feature and it didn't work on my projects because they are on laravel 5.8 and 6.0.
https://twitter.com/inertiajs/status/1160182258478788608

So I noticed that the reason was that the code use 'array_only' helper that it was deprecated since laravel 5.8.

This pull use facade array helper in order to use laravel 5.8 and laravel 6.0