### PR TITLE
isInertiaRequest function

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -5,6 +5,7 @@ namespace Inertia;
 use Illuminate\Support\Facades\Facade;
 
 /**
+ * @method static bool isInertiaRequest($request)
  * @method static void setRootView($name)
  * @method static void share($key, $value = null)
  * @method static array getShared($key = null)

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -12,7 +12,7 @@ class Middleware
     {
         $response = $next($request);
 
-        if (!$request->header('X-Inertia')) {
+        if (!Inertia::isInertiaRequest($request)) {
             return $response;
         }
 

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -13,6 +13,11 @@ class ResponseFactory
     protected $sharedProps = [];
     protected $version = null;
 
+    public function isInertiaRequest($request)
+    {
+        return boolval($request->header('X-Inertia'));
+    }
+
     public function setRootView($name)
     {
         $this->rootView = $name;


### PR DESCRIPTION
For some specific use cases I would like to check if the given request is an Inertia Request. I can check for the Inertia header in the request object but to keep the header name 'dynamic' and changeable later without breaking the package user's code it would be better to create a function in the Facade that checks if a given request is an InertiaRequest. This PR adds the ```isInertiaRequest``` function to the Inertia facade (ResponseFactory). It can be used as follows:

```
class SomeController
{
    public function index(Request $request)
    {
        if (Inertia::isInertiaRequest($request)) {
            // Inertia Request
        }
    }
}
```