### PR TITLE
Add inertia() request macro

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Inertia;
 
+use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Blade;
@@ -12,6 +13,7 @@ class ServiceProvider extends BaseServiceProvider
     public function boot()
     {
         $this->registerBladeDirective();
+        $this->registerRequestMacro();
         $this->registerRouterMacro();
         $this->registerMiddleware();
     }
@@ -20,6 +22,13 @@ class ServiceProvider extends BaseServiceProvider
     {
         Blade::directive('inertia', function () {
             return '<div id="app" data-page="{{ json_encode($page) }}"></div>';
+        });
+    }
+
+    protected function registerRequestMacro()
+    {
+        Request::macro('inertia', function () {
+            return boolval($this->header('X-Inertia'));
         });
     }
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace Inertia\Tests;
 
 use Inertia\Middleware;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Blade;
@@ -16,6 +17,17 @@ class ServiceProviderTest extends TestCase
 
         $this->assertArrayHasKey('inertia', $directives);
         $this->assertEquals('<div id="app" data-page="{{ json_encode($page) }}"></div>', $directives['inertia']());
+    }
+
+    public function test_request_macro_is_registered()
+    {
+        $request = Request::create('/user/123', 'GET');
+
+        $this->assertFalse($request->inertia());
+
+        $request->headers->add(['X-Inertia' => 'true']);
+
+        $this->assertTrue($request->inertia());
     }
 
     public function test_route_macro_is_registered()


### PR DESCRIPTION
Closes #80

This update is inspired by #80, but takes a slightly different approach. This adds a new `inertia()` macro to the Laravel `Request` class, so you can check if a request is an Inertia request:

```php
if ($request->inertia()) {
    // do thing
}
```

This is similar to [the pjax check](https://github.com/laravel/framework/blob/66eb5d01609f1021baed99a3f5d9d16bec6dcfcb/src/Illuminate/Http/Request.php#L248-L251) in Laravel core.