### PR TITLE
Make response factory macroable

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -5,10 +5,13 @@ namespace Inertia;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
 
 class ResponseFactory
 {
+    use Macroable;
+
     protected $rootView = 'app';
     protected $sharedProps = [];
     protected $version = null;

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Inertia\ResponseFactory;
+
+class ResponseFactoryTest extends TestCase
+{
+    public function test_can_macro()
+    {
+        $factory = new ResponseFactory();
+        $factory->macro('foo', function () {
+            return 'bar';
+        });
+
+        $this->assertEquals('bar', $factory->foo());
+    }
+}


### PR DESCRIPTION
Closes #84

This makes the `ResponseFactory`, and subsequently the `Inertia` facade, macroable.

```php
Inertia::macro('foo', function () {
    return 'bar';
});
```