### PR TITLE
Call Callable before checking for Responsable

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -59,7 +59,9 @@ class Response implements Responsable
         array_walk_recursive($props, function (&$prop) use ($request) {
             if ($prop instanceof Closure) {
                 $prop = App::call($prop);
-            } else if ($prop instanceof Responsable) {
+            }
+
+            if ($prop instanceof Responsable) {
                 $prop = $prop->toResponse($request)->getData();
             }
         });


### PR DESCRIPTION
With the introduction of Responsable props in v0.2.0 it opens the possibility of simplifying the return of paginated resources.

Before this feature I was also using a custom Paginated Resource similar to what @reinink showed in one of his comments regarding this.

While migrating one of my apps to take advantage of this nice addition I noticed that there is a if clause that checked if a prop is either a Callable or a Responsable, preventing a Responsable returned by a callable to take advantage of this new feature.

This would be handy when we have a callable that returns a Paginated Resource. 

I use this to partial load only the paginated resources from a page. To make this possible one must use callable props so Inertia will evaluate props lazily. So it would be handy to have the Responsable check after the callable is evaluated.

This PR makes a small change, removing the else clause when evaluating lazy props.

I also added a test case to showcase the use-case this PR addresses.
