### PR TITLE
Add Arrayable support for nested props

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -64,6 +64,10 @@ class Response implements Responsable
             if ($prop instanceof Responsable) {
                 $prop = $prop->toResponse($request)->getData();
             }
+
+            if ($prop instanceof Arrayable) {
+                $prop = $prop->toArray();
+            }
         });
 
         $page = [


### PR DESCRIPTION
This PR adds support for converting Arrayable props into arrays.  

Currently if you pass a single Arrayable instance to the Inertia render method as the props this will be converted to an array as expected.  However the same if not true if you pass an Arrayable instance as a nested prop:

```php
return Inertia::render('Messages/Pages/Drafts/Index', [
    'topic' => $myArrayableInstance,
]);
```

This will just dump out the class instance as JSON.

I've built a flexible presenter class (will be releasing into the wild soon) that is specifically designed for use with Inertia to get around the problem of sending more data than is required to a view (which is often what happens when using Laravel Resource classes - you end up with a bunch of  values you don't need in your UI layer or you have to resort to messy conditionals or lots of hyper-specific resource classes).

These presenter classes are Arrayable and I'd love to be able to do something like this:

```php
return Inertia::render('Messages/Pages/Drafts/Index', [
    'topic' => TopicPresenter::make($topic)->only(['id', 'title']),
]);
```

Rather than having to tack on `->toArray()` (or a public method on base presenter class called `->get()` which does the same thing) e.g.

```
TopicPresenter::make($topic)->only(['id', 'title'])->toArray()
```

I've tried to keep this PR pretty light touch by adding the array conversion below both the checks for `Closure` and `Responsable`.  I can't see that this would be a breaking change but I might be missing something.

