### PR TITLE
Inertia fake / Inertia test helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /vendor
 .DS_Store
 .phpunit.result.cache

--- a/src/FakeResponseFactory.php
+++ b/src/FakeResponseFactory.php
@@ -1,0 +1,85 @@
+<?php
+
+
+namespace Inertia;
+
+
+use Illuminate\Contracts\Support\Arrayable;
+use PHPUnit\Framework\Assert;
+
+class FakeResponseFactory extends ResponseFactory
+{
+
+    private $component;
+    private $props;
+
+    public function render($component, $props = [])
+    {
+        if($props instanceof Arrayable) {
+            $props = $props->toArray();
+        }
+
+        $this->component = $component;
+        $this->props     = $props;
+
+        return new Response(
+            $component,
+            array_merge($this->sharedProps, $props),
+            $this->rootView,
+            $this->getVersion()
+        );
+    }
+
+    public function assertHasProps($props = [])
+    {
+        $allProps = array_keys($this->getAllProps());
+
+        foreach($props as $prop) {
+            Assert::assertTrue(
+                in_array($prop, $allProps),
+                "Failed asserting that prop $prop exists"
+            );
+        }
+    }
+
+    public function assertHasProp($prop = '')
+    {
+        $this->assertHasProps([$prop]);
+    }
+
+    public function assertPropsEqual($expected)
+    {
+        $allProps = $this->getAllProps();
+
+        Assert::assertEquals($expected, $allProps);
+    }
+
+    public function assertPropEquals($key, $value)
+    {
+        $this->assertHasProp($key);
+
+        $prop = $this->getProp($key);
+
+        Assert::assertEquals($value, $prop);
+    }
+
+    public function assertComponentIs($component = '')
+    {
+        Assert::assertEquals(
+            $component,
+            $this->component,
+            "Failed asserting that $component was rendered. When $this->component was rendered."
+        );
+    }
+
+    public function getAllProps()
+    {
+        return array_merge($this->sharedProps, $this->props);
+    }
+
+    public function getProp($key)
+    {
+        return $this->getAllProps()[$key];
+    }
+
+}

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -20,4 +20,10 @@ class Inertia extends Facade
     {
         return ResponseFactory::class;
     }
+
+    public static function fake()
+    {
+        static::swap(new FakeResponseFactory());
+    }
+
 }

--- a/tests/FakeResponseFactoryTest.php
+++ b/tests/FakeResponseFactoryTest.php
@@ -1,0 +1,124 @@
+<?php
+
+
+namespace Inertia\Tests;
+
+
+use Inertia\FakeResponseFactory;
+use PHPUnit\Framework\Constraint\ExceptionMessage;
+use PHPUnit\Framework\ExpectationFailedException;
+
+class FakeResponseFactoryTest extends TestCase
+{
+
+    /** @var FakeResponseFactory  */
+    private $fake;
+
+    public function setUp() : void
+    {
+        parent::setUp();
+        $this->fake = new FakeResponseFactory();
+        $this->fake->share('this', 10);
+        $this->fake->render('ComponentName', ['foo' => 'bar', 'shmeow' => ['dongle', 'banana']]);
+    }
+
+    /** @test */
+    public function getAllProps()
+    {
+        $props = $this->fake->getAllProps();
+
+        $this->assertEquals(
+            ['foo' => 'bar', 'shmeow' => ['dongle', 'banana'], 'this' => 10],
+            $props
+        );
+    }
+
+    /** @test */
+    public function getProp()
+    {
+        $prop = $this->fake->getProp('foo');
+
+        $this->assertEquals('bar', $prop);
+    }
+
+    /** @test */
+    public function assertComponentIs()
+    {
+        try {
+            $this->fake->assertComponentIs('ShmeowDongle');
+            $this->fail();
+        }
+        catch (ExpectationFailedException $exception) {
+            $this->assertThat($exception, new ExceptionMessage('Failed asserting that ShmeowDongle was rendered. When ComponentName was rendered.'));
+        }
+
+        $this->fake->assertComponentIs('ComponentName');
+    }
+
+    /** @test */
+    public function assertHasProps()
+    {
+        try {
+            $this->fake->assertHasProps(['dongle', 'inertia']);
+            $this->fail();
+        }
+        catch (ExpectationFailedException $exception) {
+            $this->assertThat($exception, new ExceptionMessage('Failed asserting that prop dongle exists'));
+        }
+
+        $this->fake->assertHasProps(['foo', 'shmeow']);
+    }
+
+    /** @test */
+    public function assertHasProp()
+    {
+        try {
+            $this->fake->assertHasProp('dongle');
+            $this->fail();
+        }
+        catch (ExpectationFailedException $exception) {
+            $this->assertThat($exception, new ExceptionMessage('Failed asserting that prop dongle exists'));
+        }
+
+        $this->fake->assertHasProp('foo');
+    }
+
+    /** @test */
+    public function assertPropsEqual()
+    {
+        try {
+            $this->fake->assertPropsEqual(['inertia' => 'Rocks']);
+            $this->fail();
+        }
+        catch (ExpectationFailedException $exception) {
+            $this->assertThat($exception, new ExceptionMessage('Failed asserting that two arrays are equal.'));
+        }
+
+        $this->fake->assertPropsEqual($this->fake->getAllProps());
+    }
+
+    /** @test */
+    public function assertPropEquals()
+    {
+        // will let user know if prop does not exist
+        try {
+            $this->fake->assertPropEquals('inertia', 'Rocks');
+            $this->fail();
+        }
+        catch (ExpectationFailedException $exception) {
+            $this->assertThat($exception, new ExceptionMessage('Failed asserting that prop inertia exists'));
+        }
+
+        // then asserts the value
+        try {
+            $this->fake->assertPropEquals('foo', 'socks');
+            $this->fail();
+        }
+        catch (ExpectationFailedException $exception) {
+            $this->assertThat($exception, new ExceptionMessage('Failed asserting that two strings are equal.'));
+        }
+
+        $this->fake->assertPropEquals('foo', 'bar');
+    }
+
+}

--- a/tests/FakeResponseFactoryTest.php
+++ b/tests/FakeResponseFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 class FakeResponseFactoryTest extends TestCase
 {
 
-    /** @var FakeResponseFactory  */
+    /** @var FakeResponseFactory */
     private $fake;
 
     public function setUp() : void
@@ -47,8 +47,7 @@ class FakeResponseFactoryTest extends TestCase
         try {
             $this->fake->assertComponentIs('ShmeowDongle');
             $this->fail();
-        }
-        catch (ExpectationFailedException $exception) {
+        } catch(ExpectationFailedException $exception) {
             $this->assertThat($exception, new ExceptionMessage('Failed asserting that ShmeowDongle was rendered. When ComponentName was rendered.'));
         }
 
@@ -61,8 +60,7 @@ class FakeResponseFactoryTest extends TestCase
         try {
             $this->fake->assertHasProps(['dongle', 'inertia']);
             $this->fail();
-        }
-        catch (ExpectationFailedException $exception) {
+        } catch(ExpectationFailedException $exception) {
             $this->assertThat($exception, new ExceptionMessage('Failed asserting that prop dongle exists'));
         }
 
@@ -75,8 +73,7 @@ class FakeResponseFactoryTest extends TestCase
         try {
             $this->fake->assertHasProp('dongle');
             $this->fail();
-        }
-        catch (ExpectationFailedException $exception) {
+        } catch(ExpectationFailedException $exception) {
             $this->assertThat($exception, new ExceptionMessage('Failed asserting that prop dongle exists'));
         }
 
@@ -89,8 +86,7 @@ class FakeResponseFactoryTest extends TestCase
         try {
             $this->fake->assertPropsEqual(['inertia' => 'Rocks']);
             $this->fail();
-        }
-        catch (ExpectationFailedException $exception) {
+        } catch(ExpectationFailedException $exception) {
             $this->assertThat($exception, new ExceptionMessage('Failed asserting that two arrays are equal.'));
         }
 
@@ -104,8 +100,7 @@ class FakeResponseFactoryTest extends TestCase
         try {
             $this->fake->assertPropEquals('inertia', 'Rocks');
             $this->fail();
-        }
-        catch (ExpectationFailedException $exception) {
+        } catch(ExpectationFailedException $exception) {
             $this->assertThat($exception, new ExceptionMessage('Failed asserting that prop inertia exists'));
         }
 
@@ -113,12 +108,39 @@ class FakeResponseFactoryTest extends TestCase
         try {
             $this->fake->assertPropEquals('foo', 'socks');
             $this->fail();
-        }
-        catch (ExpectationFailedException $exception) {
+        } catch(ExpectationFailedException $exception) {
             $this->assertThat($exception, new ExceptionMessage('Failed asserting that two strings are equal.'));
         }
 
         $this->fake->assertPropEquals('foo', 'bar');
+    }
+
+    /** @test */
+    public function propsAreTransformed()
+    {
+        $this->fake->render('Component', [
+            'func' => function() {
+                return 'something';
+            }
+        ]);
+
+        $this->assertEquals('something', $this->fake->getProp('func'));
+    }
+
+    /** @test */
+    public function expectedValuesAreTransformed()
+    {
+        $this->fake = new FakeResponseFactory();
+
+        $func = function() {
+            return 'something';
+        };
+
+        $this->fake->render('Component', ['func' => $func]);
+
+        $this->fake->assertPropsEqual(['func' => $func]);
+
+        $this->fake->assertPropEquals('func', $func);
     }
 
 }


### PR DESCRIPTION
I know @reinink has helpers coming, but I thought I'd make a PR if anyone wants to try out my fork and use some helpers now.

### To try this fork out in an existing project update composer.json.
```
  "require": {
        .....
        "inertiajs/inertia-laravel": "dev-master", // change to dev-master
    },
    "repositories": [
        { // use forked repo.
            "type" : "vcs",
            "url" : "https://github.com/ChristianPavilonis/inertia-laravel.git"
        }
    ],
```
Run `composer update`


### Usage:
In your test call the fake
```
Inertia::fake();
```

After that, you can use the assertions 

```
Inertia::assertHasProps(['prop1', 'prop2]);

Inertia::assertHasProp('prop_name');

Inertia::assertPropsEqual($expectedProps);

Inertia::assertPropEquals($key, $expectedValue);

Inertia::assertComponentIs('ComponentName');

// You can also access the props
Inertia::getAllProps();

Inertia::getProp($key);
```