### PR TITLE
Support invokable classes for response props. Added test.

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -57,7 +57,7 @@ class Response implements Responsable
             : $this->props;
 
         array_walk_recursive($props, function (&$prop) use ($request) {
-            if ($prop instanceof Closure) {
+            if (is_callable($prop)) {
                 $prop = App::call($prop);
             }
 


### PR DESCRIPTION
I'm working on an app where I have lots of `shared` props to `lazy load` coming from different sources (modules). I've noticed I have a growing number of `Closures` that I want to test properly in isolation (per module and per property). I want to replace these closures into invokable classes to be able to use them like this:

## Sample Use Case
```php
// Share data in the service provider or anywhere
Inertia::share('user', new GetAuthUser());

// Some Invokable class
class GetAuthUser {
    public function __invoke(AuthInteface $auth) 
    {
        if ($auth->getUser() === null) {
            return new GuestUser();
        }

        return $auth->getUser();
    }
}
```

## Testing
```php
// Contoller Testing
    public function test() {
        // Do a request call to a controller route that returns an Inertia response.
        ...
        // Then assert only if key prop exist wince value returned is already tested in unit test.
        static::assertNotNull($response->page->user);
    } 

// Unit Testing
    public function testHasUser() {
        // Do fake login
        ...
        $user = App::call(new GetAuthUser());
        // Do assertions
        ...
    }
```

This approach only works if the props check in Inertia response is using `is_callable($prop)` instead of `$prop instanceof Closure`.
I think this way we have separated the logic of `sharing` and `retrieving` data. 😄