### PR TITLE
Share a prop original content with the blade view

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -56,9 +56,13 @@ class Response implements Responsable
             ? Arr::only($this->props, $only)
             : $this->props;
 
-        array_walk_recursive($props, function (&$prop) use ($request) {
+        array_walk_recursive($props, function (&$prop, $key) use ($request) {
             if ($prop instanceof Closure) {
                 $prop = App::call($prop);
+            }
+
+            if ($prop instanceof ShouldShareWithView) {
+                $this->withViewData($key, $prop);
             }
 
             if ($prop instanceof Responsable) {

--- a/src/ShouldShareWithView.php
+++ b/src/ShouldShareWithView.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Inertia;
+
+interface ShouldShareWithView
+{
+}

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -164,6 +164,29 @@ class ResponseTest extends TestCase
         $this->assertSame('123', $page->version);
     }
 
+    public function test_xhr_partial_response()
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Partial-Component' => 'User/Edit']);
+        $request->headers->add(['X-Inertia-Partial-Data' => 'partial']);
+
+        $user = (object) ['name' => 'Jonathan'];
+        $response = new Response('User/Edit', ['user' => $user, 'partial' => 'partial-data'], 'app', '123');
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $props = get_object_vars($page->props);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame('User/Edit', $page->component);
+        $this->assertFalse(isset($props['user']));
+        $this->assertCount(1, $props);
+        $this->assertSame('partial-data', $page->props->partial);
+        $this->assertSame('/user/123', $page->url);
+        $this->assertSame('123', $page->version);
+    }
+
     public function test_sharable_prop_response()
     {
         $request = Request::create('/user/123', 'GET');


### PR DESCRIPTION
This PR adds the ability to share a prop original content with a view.

My use case is to have some sort of Server-Side Rendered meta tags for SEO.

So I have the following (simplified) class:

~~~php
use Illuminate\Contracts\Support\Arrayable;
use Illuminate\Contracts\Support\Renderable;
use Inertia\ShouldShareWithView; // Added in this PR

class Metadata implements Arrayable, Renderable, ShouldShareWithView {
  public $title;

  public function __construct($title) {
    $this->title = $title;
  }

  public function toArray() {
    return ['title' => $this->title];
  }

  public function render() {
    $title = e($this->title);
    return "<title>{$title}</title>";
  }
}
~~~

And use this in a controller:

~~~php
return Inertia::render('HomePage', [
  'metadata' => new Metadata('Welcome to my site'),
]);
~~~

As the `Metadata` instance implements the `Arrayable` interface, Inertia will call its `toArray()` method before serializing it as prop.

Now, as this class also implements the `ShouldShareWithView` interface added with this PR the original object instance will be available to the the view as a variable, so I could add the following snippet to the blade template:

~~~blade
@isset($metadata)
{!! $metadata !!}
@else
<title>My default title</title>
@endif
~~~

This way if the user lands on a page the title will be rendered with the same data as the prop passed to `vue-meta`.

This helps, for example, working with SEO engines which parses the HTML source for meta tags.

The reason why I added it in the props resolution closure is to take advantage of the container call which is already made when resolving closure props, so an instance that depends on the IoC can be resolved as needed before sharing with the view.

I added a test case for testing this new feature.

@reinink If you find this addition useful, please let me know if you prefer another name to the interface or another approach on implementation or testing. I'll be glad to fix them.