### PR TITLE
Add `Arrayable` docblock for static analysis

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -5,7 +5,7 @@ if (!function_exists('inertia')) {
      * Inertia helper.
      *
      * @param null|string $component
-     * @param array       $props
+     * @param array|\Illuminate\Contracts\Support\Arrayable $props
      *
      * @return \Inertia\ResponseFactory|\Inertia\Response
      */

--- a/helpers.php
+++ b/helpers.php
@@ -4,7 +4,7 @@ if (!function_exists('inertia')) {
     /**
      * Inertia helper.
      *
-     * @param null|string $component
+     * @param null|string                                   $component
      * @param array|\Illuminate\Contracts\Support\Arrayable $props
      *
      * @return \Inertia\ResponseFactory|\Inertia\Response


### PR DESCRIPTION
`$instance->render($component, $props);` can deal with arrays and arrayable objects, though the docblock on the `inertia` helper function only specifies `array` as a possible type. This causes static analysis tools to complain when you pass in an arrayable.