### PR TITLE
Allow a custom root view per response

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -37,6 +37,13 @@ class Response implements Responsable
         return $this;
     }
 
+    public function withRootView($rootView)
+    {
+        $this->rootView = $rootView;
+
+        return $this;
+    }
+
     public function withViewData($key, $value = null)
     {
         if (is_array($key)) {


### PR DESCRIPTION
I have an application where the layout / assets differs on different controller groups. This PR allows to set a different layout within the controller action while returning the Inertia response.

```php
return Inertia::render('Event/Show', [
    'event' => $event->only(
        'id',
        'title',
        'start_date',
        'description'
    ),
])->withRootView('custom');
```