### PR TITLE
Add default return to getShared function

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -30,10 +30,10 @@ class ResponseFactory
         }
     }
 
-    public function getShared($key = null)
+    public function getShared($key = null, $default = null)
     {
         if ($key) {
-            return Arr::get($this->sharedProps, $key);
+            return Arr::get($this->sharedProps, $key, $default);
         }
 
         return $this->sharedProps;


### PR DESCRIPTION
Just allows `Inertia::getShared('some-key', 'A default value')` similar to `Session::get('some-key', 'A default value');`