### PR TITLE
Make Inertia::share support Arrayable classes

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -25,6 +25,8 @@ class ResponseFactory
     {
         if (is_array($key)) {
             $this->sharedProps = array_merge($this->sharedProps, $key);
+        } elseif($key instanceof Arrayable) {
+            $this->sharedProps = array_merge($this->sharedProps, $key->toArray());
         } else {
             Arr::set($this->sharedProps, $key, $value);
         }


### PR DESCRIPTION
Right now we can do `Inertia::render('Page', new SomeArrayableClass());` and it works.

Unfortunately `Inertia::share` doesn't work the same and we need to do `Inertia::share((new SomeArrayableClass())->toArray())`.

This PR allows `share` to automatically transform an Arrayable class.