### PR TITLE
(Yet Another) Assertions implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,12 @@
             "Inertia\\Tests\\": "tests/"
         }
     },
+    "require": {
+        "laravel/framework": "^5.4|^6.0|^7.0"
+    },
     "require-dev": {
-        "orchestra/testbench": "~3.0"
+        "orchestra/testbench": "^3.4|^4.0|^5.0",
+        "phpunit/phpunit": "~5.7|~6.0|^7.0|^8.0|^9.0"
     },
     "extra": {
         "laravel": {

--- a/ide_helpers.php
+++ b/ide_helpers.php
@@ -1,0 +1,41 @@
+<?php
+
+/** @noinspection PhpUndefinedClassInspection */
+/** @noinspection PhpFullyQualifiedNameUsageInspection */
+/** @noinspection PhpUnusedAliasInspection */
+
+namespace Illuminate\Testing {
+
+    /**
+     * @see \Inertia\Assertions
+     *
+     * @method self assertInertia()
+     * @method self assertInertiaComponent($name)
+     * @method self assertInertiaHas($key, $value = null)
+     * @method self assertInertiaHasAll(array $bindings)
+     * @method self assertInertiaMissing($key)
+     * @method array inertiaProps()
+     */
+    class TestResponse
+    {
+        //
+    }
+}
+
+namespace Illuminate\Foundation\Testing {
+
+    /**
+     * @see \Inertia\Assertions
+     *
+     * @method self assertInertia()
+     * @method self assertInertiaComponent($name)
+     * @method self assertInertiaHas($key, $value = null)
+     * @method self assertInertiaHasAll(array $bindings)
+     * @method self assertInertiaMissing($key)
+     * @method array inertiaProps()
+     */
+    class TestResponse
+    {
+        //
+    }
+}

--- a/ide_helpers.php
+++ b/ide_helpers.php
@@ -9,8 +9,7 @@ namespace Illuminate\Testing {
     /**
      * @see \Inertia\Assertions
      *
-     * @method self assertInertia()
-     * @method self assertInertiaComponent($name)
+     * @method self assertInertia($component = null, $props = [])
      * @method self assertInertiaHas($key, $value = null)
      * @method self assertInertiaHasAll(array $bindings)
      * @method self assertInertiaMissing($key)
@@ -27,8 +26,7 @@ namespace Illuminate\Foundation\Testing {
     /**
      * @see \Inertia\Assertions
      *
-     * @method self assertInertia()
-     * @method self assertInertiaComponent($name)
+     * @method self assertInertia($component = null, $props = [])
      * @method self assertInertiaHas($key, $value = null)
      * @method self assertInertiaHasAll(array $bindings)
      * @method self assertInertiaMissing($key)

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -3,16 +3,16 @@
 namespace Inertia;
 
 use Closure;
-use Illuminate\Support\Arr;
-use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\Assert as PHPUnit;
 
 class Assertions
 {
     public function assertInertia()
     {
-        return function () {
+        return function ($component = null, $props = []) {
             $this->assertViewHas('page');
 
             tap($this->viewData('page'), function ($view) {
@@ -21,6 +21,12 @@ class Assertions
                 PHPUnit::assertArrayHasKey('url', $view);
                 PHPUnit::assertArrayHasKey('version', $view);
             });
+
+            if (! is_null($component)) {
+                PHPUnit::assertEquals($component, $this->viewData('page')['component']);
+            }
+
+            $this->assertInertiaHasAll($props);
 
             return $this;
         };
@@ -32,17 +38,6 @@ class Assertions
             $this->assertInertia();
 
             return $this->viewData('page')['props'];
-        };
-    }
-
-    public function assertInertiaComponent()
-    {
-        return function ($name) {
-            $this->assertInertia();
-
-            PHPUnit::assertEquals($name, $this->viewData('page')['component']);
-
-            return $this;
         };
     }
 

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Inertia;
+
+use Closure;
+use Illuminate\Support\Arr;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class Assertions
+{
+    public function assertInertia()
+    {
+        return function () {
+            $this->assertViewHas('page');
+
+            tap($this->viewData('page'), function ($view) {
+                PHPUnit::assertArrayHasKey('component', $view);
+                PHPUnit::assertArrayHasKey('props', $view);
+                PHPUnit::assertArrayHasKey('url', $view);
+                PHPUnit::assertArrayHasKey('version', $view);
+            });
+
+            return $this;
+        };
+    }
+
+    public function inertiaProps()
+    {
+        return function () {
+            $this->assertInertia();
+
+            return $this->viewData('page')['props'];
+        };
+    }
+
+    public function assertInertiaComponent()
+    {
+        return function ($name) {
+            $this->assertInertia();
+
+            PHPUnit::assertEquals($name, $this->viewData('page')['component']);
+
+            return $this;
+        };
+    }
+
+    public function assertInertiaHas()
+    {
+        return function ($key, $value = null) {
+            if (is_array($key)) {
+                return $this->assertInertiaHasAll($key);
+            }
+
+            if (is_null($value)) {
+                PHPUnit::assertArrayHasKey($key, $this->inertiaProps());
+            } elseif ($value instanceof Closure) {
+                PHPUnit::assertTrue($value(Arr::get($this->inertiaProps(), $key)));
+            } elseif ($value instanceof Model) {
+                PHPUnit::assertEquals($value->toArray(), Arr::get($this->inertiaProps(), $key));
+            } else {
+                PHPUnit::assertEquals($value, Arr::get($this->inertiaProps(), $key));
+            }
+
+            return $this;
+        };
+    }
+
+    // TODO: Test.
+    public function assertInertiaHasAll()
+    {
+        return function (array $bindings) {
+            foreach ($bindings as $key => $value) {
+                if (is_int($key)) {
+                    $this->assertInertiaHas($value);
+                } else {
+                    $this->assertInertiaHas($key, $value);
+                }
+            }
+
+            return $this;
+        };
+    }
+
+    // TODO: Test.
+    public function assertInertiaMissing()
+    {
+        return function ($key) {
+            $this->assertInertia();
+
+            PHPUnit::assertArrayNotHasKey($key, $this->inertiaProps());
+
+            return $this;
+        };
+    }
+}

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Responsable;
 
 class Assertions
 {
@@ -58,6 +59,8 @@ class Assertions
                 PHPUnit::assertTrue($value(Arr::get($this->inertiaProps(), $key)));
             } elseif ($value instanceof Arrayable) {
                 PHPUnit::assertEquals($value->toArray(), Arr::get($this->inertiaProps(), $key));
+            } elseif ($value instanceof Responsable) {
+                PHPUnit::assertEquals($value->toResponse($this)->getData(), Arr::get($this->inertiaProps(), $key));
             } else {
                 PHPUnit::assertEquals($value, Arr::get($this->inertiaProps(), $key));
             }

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -53,7 +53,7 @@ class Assertions
             }
 
             if (is_null($value)) {
-                PHPUnit::assertArrayHasKey($key, $this->inertiaProps());
+                PHPUnit::assertTrue(Arr::has($this->inertiaProps(), $key));
             } elseif ($value instanceof Closure) {
                 PHPUnit::assertTrue($value(Arr::get($this->inertiaProps(), $key)));
             } elseif ($value instanceof Model) {
@@ -66,7 +66,6 @@ class Assertions
         };
     }
 
-    // TODO: Test.
     public function assertInertiaHasAll()
     {
         return function (array $bindings) {
@@ -82,13 +81,12 @@ class Assertions
         };
     }
 
-    // TODO: Test.
     public function assertInertiaMissing()
     {
         return function ($key) {
             $this->assertInertia();
 
-            PHPUnit::assertArrayNotHasKey($key, $this->inertiaProps());
+            PHPUnit::assertFalse(Arr::has($this->inertiaProps(), $key));
 
             return $this;
         };

--- a/src/Assertions.php
+++ b/src/Assertions.php
@@ -4,8 +4,8 @@ namespace Inertia;
 
 use Closure;
 use Illuminate\Support\Arr;
-use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Illuminate\Contracts\Support\Arrayable;
 
 class Assertions
 {
@@ -56,7 +56,7 @@ class Assertions
                 PHPUnit::assertTrue(Arr::has($this->inertiaProps(), $key));
             } elseif ($value instanceof Closure) {
                 PHPUnit::assertTrue($value(Arr::get($this->inertiaProps(), $key)));
-            } elseif ($value instanceof Model) {
+            } elseif ($value instanceof Arrayable) {
                 PHPUnit::assertEquals($value->toArray(), Arr::get($this->inertiaProps(), $key));
             } else {
                 PHPUnit::assertEquals($value, Arr::get($this->inertiaProps(), $key));

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -80,7 +80,7 @@ class ServiceProvider extends BaseServiceProvider
 
         throw new LogicException('Could not detect TestResponse class.');
     }
-    
+
     protected function shareValidationErrors()
     {
         if (Inertia::getShared('errors')) {

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -9,20 +9,21 @@ use PHPUnit\Framework\AssertionFailedError;
 
 class AssertionsTest extends TestCase
 {
-    private function makeMockResponse($view)
-    {
-        app('router')->get('/', function () use ($view) {
-            return $view;
-        });
-
-        return $this->get('/');
-    }
-
-    public function test_the_view_is_inertia()
+    public function test_the_view_is_served_by_inertia()
     {
         $response = $this->makeMockResponse(
             Inertia::render('test')
         );
+
+        $response->assertInertia();
+    }
+
+    public function test_the_view_is_not_served_by_inertia()
+    {
+        $response = $this->makeMockResponse(view('welcome'));
+        $response->assertOk(); // Make sure we can render the built-in Orchestra 'welcome' view..
+
+        $this->expectException(AssertionFailedError::class);
 
         $response->assertInertia();
     }
@@ -38,12 +39,13 @@ class AssertionsTest extends TestCase
 
     public function test_the_inertia_component_does_not_match()
     {
-        $this->expectException(AssertionFailedError::class);
         $response = $this->makeMockResponse(
             Inertia::render('test-component')
         );
 
-        $response->assertInertiaComponent('wrong-component');
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaComponent('another-component');
     }
 
     public function test_the_inertia_page_has_a_prop()
@@ -57,6 +59,47 @@ class AssertionsTest extends TestCase
         $response->assertInertiaHas('example-prop');
     }
 
+    public function test_the_inertia_page_does_not_have_a_prop()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example-prop' => 'example-value',
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaHas('another-prop');
+    }
+
+    public function test_the_inertia_page_has_a_nested_prop()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => [
+                    'nested' => 'nested-value',
+                ],
+            ])
+        );
+
+        $response->assertInertiaHas('example.nested');
+    }
+
+    public function test_the_inertia_page_does_not_have_a_nested_prop()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => [
+                    'nested' => 'nested-value',
+                ],
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaHas('example.another');
+    }
+
     public function test_the_inertia_page_has_a_prop_that_matches_a_value()
     {
         $response = $this->makeMockResponse(
@@ -68,17 +111,45 @@ class AssertionsTest extends TestCase
         $response->assertInertiaHas('example-prop', 'example-value');
     }
 
+    public function test_the_inertia_page_has_a_prop_that_does_not_match_a_value()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example-prop' => 'example-value',
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaHas('example-prop', 'anohter-value');
+    }
+
     public function test_the_inertia_page_has_a_nested_prop_that_matches_a_value()
     {
         $response = $this->makeMockResponse(
             Inertia::render('test-component', [
                 'example' => [
-                    'nested' => 'nested-value'
+                    'nested' => 'nested-value',
                 ],
             ])
         );
 
         $response->assertInertiaHas('example.nested', 'nested-value');
+    }
+
+    public function test_the_inertia_page_has_a_nested_prop_that_does_not_match_a_value()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => [
+                    'nested' => 'nested-value',
+                ],
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaHas('example.nested', 'another-value');
     }
 
     public function test_the_inertia_page_has_a_prop_with_a_value_using_a_closure()
@@ -94,6 +165,53 @@ class AssertionsTest extends TestCase
         });
     }
 
+    public function test_the_inertia_page_does_not_have_a_prop_with_a_value_using_a_closure()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example-prop' => 'example-value',
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaHas('example-prop', function ($value) {
+            return $value === 'another-value';
+        });
+    }
+
+    public function test_the_inertia_page_has_a_nested_prop_with_a_value_using_a_closure()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => [
+                    'nested' => 'example-value',
+                ],
+            ])
+        );
+
+        $response->assertInertiaHas('example.nested', function ($value) {
+            return $value === 'example-value';
+        });
+    }
+
+    public function test_the_inertia_page_does_not_have_a_nested_prop_with_a_value_using_a_closure()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => [
+                    'nested' => 'example-value',
+                ],
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaHas('example.nested', function ($value) {
+            return $value === 'another-value';
+        });
+    }
+
     public function test_the_inertia_page_has_a_prop_with_a_value_using_a_model()
     {
         Model::unguard();
@@ -106,6 +224,167 @@ class AssertionsTest extends TestCase
         );
 
         $response->assertInertiaHas('example-prop', $user);
-        $response->assertInertiaHas('example-prop', ['name' => 'Example']);
+    }
+
+    public function test_the_inertia_page_does_not_have_a_prop_with_a_value_using_a_model()
+    {
+        Model::unguard();
+        $userA = User::make(['name' => 'Example']);
+        $userB = User::make(['name' => 'Another']);
+
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example-prop' => $userA,
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaHas('example-prop', $userB);
+    }
+
+    public function test_the_inertia_page_has_a_nested_prop_with_a_value_using_a_model()
+    {
+        Model::unguard();
+        $user = User::make(['name' => 'Example']);
+
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => [
+                    'nested' => $user,
+                ],
+            ])
+        );
+
+        $response->assertInertiaHas('example.nested', $user);
+    }
+
+    public function test_the_inertia_page_does_not_have_a_nested_prop_with_a_value_using_a_model()
+    {
+        Model::unguard();
+        $userA = User::make(['name' => 'Example']);
+        $userB = User::make(['name' => 'Another']);
+
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => [
+                    'nested' => $userA,
+                ],
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaHas('example.nested', $userB);
+    }
+
+    public function test_the_inertia_page_has_all_the_given_props()
+    {
+        Model::unguard();
+        $user = User::make(['name' => 'Example']);
+
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'foo' => 'bar',
+                'baz' => [
+                    'nested' => 'value',
+                    'another' => $user,
+                    'closure' => 'test',
+                ],
+            ])
+        );
+
+        $response->assertInertiaHasAll([
+            'foo',
+            'foo' => 'bar',
+            'baz.nested' => 'value',
+            'baz.another' => $user,
+            'baz.closure' => function ($value) {
+                return $value === 'test';
+            },
+        ]);
+    }
+
+    public function test_the_inertia_page_does_not_have_all_the_given_props()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'foo' => 'bar',
+                'baz' => [
+                    'nested' => 'value',
+                ],
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaHasAll([
+            'foo' => 'bar',
+            'baz.nested' => 'value',
+            'missing-key',
+        ]);
+    }
+
+    public function test_the_inertia_page_is_missing_a_prop()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'foo' => 'bar',
+            ])
+        );
+
+        $response->assertInertiaMissing('baz');
+    }
+
+    public function test_the_inertia_page_is_not_missing_a_prop()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'foo' => 'bar',
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaMissing('foo');
+    }
+
+    public function test_the_inertia_page_is_missing_a_nested_prop()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'foo' => 'bar',
+                'baz' => [
+                    'another' => 'value',
+                ],
+            ])
+        );
+
+        $response->assertInertiaMissing('baz.nested');
+    }
+
+    public function test_the_inertia_page_is_not_missing_a_nested_prop()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'foo' => 'bar',
+                'baz' => [
+                    'nested' => 'value',
+                ],
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaMissing('baz.nested');
+    }
+
+    private function makeMockResponse($view)
+    {
+        app('router')->get('/', function () use ($view) {
+            return $view;
+        });
+
+        return $this->get('/');
     }
 }

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Inertia\Inertia;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\AssertionFailedError;
+
+class AssertionsTest extends TestCase
+{
+    private function makeMockResponse($view)
+    {
+        app('router')->get('/', function () use ($view) {
+            return $view;
+        });
+
+        return $this->get('/');
+    }
+
+    public function test_the_view_is_inertia()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test')
+        );
+
+        $response->assertInertia();
+    }
+
+    public function test_the_inertia_component_matches()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component')
+        );
+
+        $response->assertInertiaComponent('test-component');
+    }
+
+    public function test_the_inertia_component_does_not_match()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component')
+        );
+
+        $response->assertInertiaComponent('wrong-component');
+    }
+
+    public function test_the_inertia_page_has_a_prop()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example-prop' => 'example-value',
+            ])
+        );
+
+        $response->assertInertiaHas('example-prop');
+    }
+
+    public function test_the_inertia_page_has_a_prop_that_matches_a_value()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example-prop' => 'example-value',
+            ])
+        );
+
+        $response->assertInertiaHas('example-prop', 'example-value');
+    }
+
+    public function test_the_inertia_page_has_a_nested_prop_that_matches_a_value()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => [
+                    'nested' => 'nested-value'
+                ],
+            ])
+        );
+
+        $response->assertInertiaHas('example.nested', 'nested-value');
+    }
+
+    public function test_the_inertia_page_has_a_prop_with_a_value_using_a_closure()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example-prop' => 'example-value',
+            ])
+        );
+
+        $response->assertInertiaHas('example-prop', function ($value) {
+            return $value === 'example-value';
+        });
+    }
+
+    public function test_the_inertia_page_has_a_prop_with_a_value_using_a_model()
+    {
+        Model::unguard();
+        $user = User::make(['name' => 'Example']);
+
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example-prop' => $user,
+            ])
+        );
+
+        $response->assertInertiaHas('example-prop', $user);
+        $response->assertInertiaHas('example-prop', ['name' => 'Example']);
+    }
+}

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -212,7 +212,7 @@ class AssertionsTest extends TestCase
         });
     }
 
-    public function test_the_inertia_page_has_a_prop_with_a_value_using_a_model()
+    public function test_the_inertia_page_has_a_prop_with_a_value_using_an_arrayable()
     {
         Model::unguard();
         $user = User::make(['name' => 'Example']);
@@ -226,7 +226,7 @@ class AssertionsTest extends TestCase
         $response->assertInertiaHas('example-prop', $user);
     }
 
-    public function test_the_inertia_page_does_not_have_a_prop_with_a_value_using_a_model()
+    public function test_the_inertia_page_does_not_have_a_prop_with_a_value_using_an_arrayable()
     {
         Model::unguard();
         $userA = User::make(['name' => 'Example']);
@@ -243,7 +243,7 @@ class AssertionsTest extends TestCase
         $response->assertInertiaHas('example-prop', $userB);
     }
 
-    public function test_the_inertia_page_has_a_nested_prop_with_a_value_using_a_model()
+    public function test_the_inertia_page_has_a_nested_prop_with_a_value_using_an_arrayable()
     {
         Model::unguard();
         $user = User::make(['name' => 'Example']);
@@ -259,7 +259,7 @@ class AssertionsTest extends TestCase
         $response->assertInertiaHas('example.nested', $user);
     }
 
-    public function test_the_inertia_page_does_not_have_a_nested_prop_with_a_value_using_a_model()
+    public function test_the_inertia_page_does_not_have_a_nested_prop_with_a_value_using_an_arrayable()
     {
         Model::unguard();
         $userA = User::make(['name' => 'Example']);

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -6,6 +6,7 @@ use Inertia\Inertia;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\AssertionFailedError;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class AssertionsTest extends TestCase
 {
@@ -276,6 +277,73 @@ class AssertionsTest extends TestCase
         $this->expectException(AssertionFailedError::class);
 
         $response->assertInertiaHas('example.nested', $userB);
+    }
+
+    public function test_the_inertia_page_has_a_prop_with_a_value_using_a_responsable()
+    {
+        Model::unguard();
+        $user = User::make(['name' => 'Example']);
+        $resource = JsonResource::collection([$user, $user]);
+
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => $resource,
+            ])
+        );
+
+        $response->assertInertiaHas('example', $resource);
+    }
+
+    public function test_the_inertia_page_does_not_have_a_prop_with_a_value_using_a_responsable()
+    {
+        Model::unguard();
+        $resourceA = JsonResource::make(User::make(['name' => 'Another']));
+        $resourceB = JsonResource::make(User::make(['name' => 'Example']));
+
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => $resourceA,
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaHas('example', $resourceB);
+    }
+
+    public function test_the_inertia_page_has_a_nested_prop_with_a_value_using_a_responsable()
+    {
+        Model::unguard();
+        $resource = JsonResource::make(User::make(['name' => 'Another']));
+
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => [
+                    'nested' => $resource,
+                ],
+            ])
+        );
+
+        $response->assertInertiaHas('example.nested', $resource);
+    }
+
+    public function test_the_inertia_page_does_not_have_a_nested_prop_with_a_value_using_a_responsable()
+    {
+        Model::unguard();
+        $resourceA = JsonResource::make(User::make(['name' => 'Another']));
+        $resourceB = JsonResource::make(User::make(['name' => 'Example']));
+
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', [
+                'example' => [
+                    'nested' => $resourceA,
+                ],
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertiaHas('example.nested', $resourceB);
     }
 
     public function test_the_inertia_page_has_all_the_given_props()

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -2,11 +2,11 @@
 
 namespace Inertia\Tests;
 
-use Inertia\Inertia;
-use Illuminate\Foundation\Auth\User;
 use Illuminate\Database\Eloquent\Model;
-use PHPUnit\Framework\AssertionFailedError;
+use Illuminate\Foundation\Auth\User;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Inertia\Inertia;
+use PHPUnit\Framework\AssertionFailedError;
 
 class AssertionsTest extends TestCase
 {
@@ -35,7 +35,7 @@ class AssertionsTest extends TestCase
             Inertia::render('test-component')
         );
 
-        $response->assertInertiaComponent('test-component');
+        $response->assertInertia('test-component');
     }
 
     public function test_the_inertia_component_does_not_match()
@@ -46,7 +46,33 @@ class AssertionsTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $response->assertInertiaComponent('another-component');
+        $response->assertInertia('another-component');
+    }
+
+    public function test_the_inertia_component_and_props_match()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', $props = [
+                'foo' => 'bar',
+            ])
+        );
+
+        $response->assertInertia('test-component', $props);
+    }
+
+    public function test_the_inertia_component_and_props_do_not_match()
+    {
+        $response = $this->makeMockResponse(
+            Inertia::render('test-component', $props = [
+                'foo' => 'bar',
+            ])
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertInertia('test-component', [
+            'foo' => 'baz',
+        ]);
     }
 
     public function test_the_inertia_page_has_a_prop()


### PR DESCRIPTION
## Motivation
Like others, I've been in search of a way to test the backend outputs towards an Inertia view. While Macros are the obvious solution that others have also already discovered & suggested via PR, there were some things there that just didn't feel 'right' to me.

For example, while I do believe https://github.com/inertiajs/inertia-laravel/pull/51 to be a great implementation, I wasn't a big fan of the idea of having to swap out the `TestCase` class in our own projects. Similarly, while the suggestions made in https://github.com/inertiajs/inertia-laravel/pull/105 aren't bad either, but having to run `Inertia::fake()` was kind of a dealbreaker to me.

So, here's my attempt.

## Usage

This PR suggests a couple of assertion helpers that are available out of the box once you update to whatever version this PR ships in. To use, simply chain them on your `TestResponse` responses. 

![Screenshot 2020-09-02 at 19 44 39](https://user-images.githubusercontent.com/1752195/92017928-c10b4b00-ed54-11ea-95b4-ccff11d89d06.png)

## Available Methods
The methods made available by this PR closely reflect those available in Laravel itself.
(_In fact, I just got a notification that [a few changes I suggested were just merged into the framework](https://github.com/laravel/framework/pull/33566)_)

---

Assert whether the given page is an Inertia-rendered view
```php
$response->assertInertia();

// or, also check whether the page is a specific component
$response->assertInertia('example');

// or, also check whether all of the given props match
$response->assertInertia('example', [
    'foo' => 'bar'
]);
```

Return all the available Inertia props for the page
``` php
$response->inertiaProps(); 
```

Assert whether the Inertia-rendered view has a specific property set
```php
$response->assertInertiaHas('key');

// or, against deeply nested values
$response->assertInertiaHas('deeply.nested.key');
```

Apart from checking whether the property is set, the same method can be used to assert that the values match
```php
$response->assertInertiaHas('key', 'matches-this-value');

// or, for deeply nested values
$response->assertInertiaHas('deeply.nested.key', 'also-match-against-this-value');
```

It's also possible to assert directly against a Laravel Model (or any other `Arrayable` or `Responsable` class)
```php
$user = UserFactory::new()->create(['name' => 'John Doe']);

// ... (Make HTTP request etc.)

$response->assertInertiaHas('user', $user);
$response->assertInertiaHas('deeply.nested.user', $user);
```

It's also possible to check against a closure
```php
$response->assertInertiaHas('foo', function ($value) {
    return $value === 'bar';
});

// or, again, for deeply nested values
$response->assertInertiaHas('deeply.nested.foo', function ($value) {
    return $value === 'bar';
});
```

Next, you can also check against a whole array of properties. It'll simply loop over them using the `assertInertiaHas` method described above:
```php
$response->assertInertiaHasAll([
    'foo',
    'bar.baz',
    'another.nested.key' => 'example-value'
]);
```

Finally, you can assert that a property was not set:
```php
$response->assertInertiaMissing('key');

// or, for deeply nested values
$response->assertInertiaMissing('deeply.nested.key');
```

## Details & (Breaking) Changes
This PR bootstraps the Macros directly onto the `TestResponse` from the ServiceProvider, and only does so if we're running in a testing environment. 

I've also made it compatible with Laravel 6 and earlier, as that's where the `TestResponse` namespace was changed from `Illuminate\Foundation\Testing\TestResponse` to `Illuminate\Testing\TestResponse`.

Finally, I've changed the package constraints of this repo to be only compatible with Laravel 5.4 and up, because [Laravel 5.3 depends upon `phpunit/phpunit: ~5.4`](https://github.com/laravel/framework/blob/5.3/composer.json#L79), which was when the non-namespaced PHPUnit classes (e.g. [`PHPUnit_Framework_Assert`](https://github.com/sebastianbergmann/phpunit/blob/5.4.0/src/Framework/Assert.php#L16)) were still used. ([Laravel 5.4 changed this](https://github.com/laravel/framework/blob/5.4/composer.json#L78)).

While this might seem like a breaking change, I'm fairly confident it isn't, as on those versions other things in this package already likely wouldn't have worked 😅

Let me know if this is something you're happy with, or whether you want me to tweak certain things.
(Or, alternatively, there's no hard feelings if you decide to just decline this PR altogether, so feel free to do so..)