### PR TITLE
Automatically share validation errors

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Session;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider
@@ -21,6 +22,7 @@ class ServiceProvider extends BaseServiceProvider
         $this->registerRequestMacro();
         $this->registerRouterMacro();
         $this->registerMiddleware();
+        $this->shareValidationErrors();
     }
 
     protected function registerBladeDirective()
@@ -49,5 +51,18 @@ class ServiceProvider extends BaseServiceProvider
     protected function registerMiddleware()
     {
         $this->app[Kernel::class]->pushMiddleware(Middleware::class);
+    }
+
+    protected function shareValidationErrors()
+    {
+        if (Inertia::getShared('errors')) {
+            return;
+        }
+
+        Inertia::share('errors', function () {
+            return (object) array_map(function ($error) {
+                return $error[0];
+            }, Session::has('errors') ? Session::get('errors')->messages() : []);
+        });
     }
 }

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -28,7 +28,10 @@ class ControllerTest extends TestCase
         $this->assertEquals([
             'page' => [
                 'component' => 'User/Edit',
-                'props' => ['user' => ['name' => 'Jonathan']],
+                'props' => [
+                    'user' => ['name' => 'Jonathan'],
+                    'errors' => (object) [],
+                ],
                 'url' => '',
                 'version' => null,
             ],

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -70,13 +70,13 @@ class ServiceProviderTest extends TestCase
     {
         Session::put('errors', new MessageBag([
             'name' => 'The name field is required.',
-            'email' => 'Not a valid email address',
+            'email' => 'Not a valid email address.',
         ]));
 
         $errors = Inertia::getShared('errors')();
 
         $this->assertIsObject($errors);
         $this->assertSame('The name field is required.', $errors->name);
-        $this->assertSame('Not a valid email address', $errors->email);
+        $this->assertSame('Not a valid email address.', $errors->email);
     }
 }


### PR DESCRIPTION
This updates this adapter to automatically share validation errors with Inertia.js, instead of making Laravel users do this manually, like this:

```php
Inertia::share([
    'errors' => function () {
        return Session::get('errors')
            ? Session::get('errors')->getBag('default')->getMessages()
            : (object) [];
    },
]);
```

The key difference with the above method is that Inertia will automatically return only *one* error per field, instead of the Laravel default, which is an array of errors.

```js
{
  name: 'The name field is required.',
  email: 'Not a valid email address.',
}
```

This is simpler, and honestly, I've literally never displayed multiple errors per field. This seems to be the consensus [on Twitter](https://twitter.com/reinink/status/1300516500105842689) as well.

That said, if folks prefer the other behaviour (multiple errors per field), all they need to do is manually share the validation errors like before (using the snippet above). This package's service provider will only share the validation errors if the `errors` key has not already been used. This behaviour also makes this a non-breaking change.

The goal of this change is to make Inertia.js easier to setup in Laravel applications, and since sharing validation errors is so common, this seems worthwhile to bake into the adapter.