### PR TITLE
Add support for (multiple) error bags

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -64,13 +64,7 @@ class ServiceProvider extends BaseServiceProvider
         Inertia::share('errors', function () {
             $errors = Session::get('errors', new ViewErrorBag());
 
-            if (is_array($errors) && count($errors) > 0 && is_array($errors[array_keys($errors)[0]])) {
-                $errors = tap(new ViewErrorBag(), function ($bag) use ($errors) {
-                    foreach ($errors as $key => $messages) {
-                        $bag->put($key, new MessageBag($messages));
-                    }
-                });
-            } elseif (is_array($errors) && count($errors) > 0) {
+            if (is_array($errors) && count($errors) > 0) {
                 $errors = (new ViewErrorBag())->put('default', new MessageBag($errors));
             } elseif ($errors instanceof MessageBag && $errors->any()) {
                 $errors = (new ViewErrorBag())->put('default', $errors);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -64,7 +64,13 @@ class ServiceProvider extends BaseServiceProvider
         Inertia::share('errors', function () {
             $errors = Session::get('errors', new ViewErrorBag());
 
-            if (is_array($errors) && count($errors) > 0) {
+            if (is_array($errors) && count($errors) > 0 && is_array($errors[array_keys($errors)[0]])) {
+                $errors = tap(new ViewErrorBag(), function ($bag) use ($errors) {
+                    foreach ($errors as $key => $messages) {
+                        $bag->put($key, new MessageBag($messages));
+                    }
+                });
+            } elseif (is_array($errors) && count($errors) > 0) {
                 $errors = (new ViewErrorBag())->put('default', new MessageBag($errors));
             } elseif ($errors instanceof MessageBag && $errors->any()) {
                 $errors = (new ViewErrorBag())->put('default', $errors);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace Inertia;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Collection;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Session;
@@ -64,13 +65,13 @@ class ServiceProvider extends BaseServiceProvider
                 return (object) [];
             }
 
-            return (object) collect(Session::get('errors')->getBags())->map(function ($bag) {
-                return collect($bag->messages())->map(function ($errors) {
+            return (object) Collection::make(Session::get('errors')->getBags())->map(function ($bag) {
+                return (object) Collection::make($bag->messages())->map(function ($errors) {
                     return $errors[0];
-                });
+                })->toArray();
             })->pipe(function ($bags) {
-                return $bags->has('default') ? $bags->get('default') : $bags;
-            })->toArray();
+                return $bags->has('default') ? $bags->get('default') : $bags->toArray();
+            });
         });
     }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -117,22 +117,9 @@ class ServiceProviderTest extends TestCase
         $this->assertSame('The email must be a valid email address.', $errors->email);
     }
 
-    public function multipleErrorBagsValidationErrorsProvider()
+    public function test_validation_exceptions_can_have_multiple_error_bags()
     {
-        $array = [
-            'default' => [
-                'name' => [
-                    'The name field is required.',
-                ],
-                'email' => 'The email must be a valid email address.',
-            ],
-            'example' => [
-                'name' => 'The name field is required.',
-                'email' => 'The email must be a valid email address.',
-            ],
-        ];
-
-        $viewErrorBag = tap(new ViewErrorBag(), function ($errorBag) {
+        Session::put('errors', tap(new ViewErrorBag(), function ($errorBag) {
             $errorBag->put('default', new MessageBag([
                 'name' => 'The name field is required.',
                 'email' => 'The email must be a valid email address.',
@@ -143,18 +130,7 @@ class ServiceProviderTest extends TestCase
                     'The email must be a valid email address.',
                 ],
             ]));
-        });
-
-        return [
-            [$array],
-            [$viewErrorBag],
-        ];
-    }
-
-    /** @dataProvider multipleErrorBagsValidationErrorsProvider */
-    public function test_validation_exceptions_can_have_multiple_error_bags($errors)
-    {
-        Session::put('errors', $errors);
+        }));
 
         $errors = Inertia::getShared('errors')();
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -117,7 +117,7 @@ class ServiceProviderTest extends TestCase
         $this->assertSame('The email must be a valid email address.', $errors->email);
     }
 
-    public function test_validation_exceptions_can_have_multiple_error_bags()
+    public function test_validation_errors_can_have_multiple_error_bags()
     {
         Session::put('errors', tap(new ViewErrorBag(), function ($errorBag) {
             $errorBag->put('default', new MessageBag([
@@ -139,7 +139,7 @@ class ServiceProviderTest extends TestCase
         $this->assertSame('The email must be a valid email address.', $errors->example['email']);
     }
 
-    public function test_validation_exceptions_will_be_empty_when_an_invalid_value_was_set_to_the_session()
+    public function test_validation_errors_will_be_empty_when_an_invalid_value_was_set_to_the_session()
     {
         Session::put('errors', new Request());
         $errors = Inertia::getShared('errors')();


### PR DESCRIPTION
## Added
- Support for multiple error bags
- Prevent passing unexpected values.
- Extra testing for 'default' (no-errors) scenario
- [**EXTRA / SUGGESTED**: `Response::withErrors(..)`.](https://github.com/claudiodekker/inertia-laravel/pull/1/files#diff-9cd62f6ac47a5969c6156a947d50b7e4R191)

## Fixed
- Use `ViewErrorBag` instead of `MessageBag` (it works [due to proxy-calls](https://github.com/laravel/framework/blob/17777a92da9b3cf0026f26462d289d596420e6d0/src/Illuminate/Support/ViewErrorBag.php#L93-L96), but [it's not really intended to be used that way](https://github.com/laravel/framework/blob/7.x/src/Illuminate/View/View.php#L212-L230))

## Remaining / newly found issues
- When an actual `ValidationException` gets thrown, error messages **won't** get formatted correctly due to the way the ValidationException is defined/handled by the ExceptionHandler. [Here's a failing test that demonstrates the issue](https://github.com/inertiajs/inertia-laravel/compare/validation-errors...claudiodekker:validation-errors-failing-validator).

There's a few solutions to this that I can tell, and neither of them aren't really pretty:
- Extend the Application's ExceptionHandler, then swap it out in the container. This will allow us to intercept the ValidationException and re-format the messages.

- Swap out the Validator for our own, so we can throw a custom ValidationException.

- Tell the user to add a call to their Application's ExceptionHandler, so we don't have to override/extend any core-logic (less maintenance, more work for the end-user)