### PR TITLE
Re-implement & test #139

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -28,8 +28,10 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function registerBladeDirective()
     {
-        Blade::directive('inertia', function () {
-            return '<div id="app" data-page="{{ json_encode($page) }}"></div>';
+        Blade::directive('inertia', function ($expression) {
+            $appId = $expression ?: "'app'";
+
+            return '<div id="{{ '.$appId.' }}" data-page="{{ json_encode($page) }}"></div>';
         });
     }
 

--- a/tests/BladeDirectiveTest.php
+++ b/tests/BladeDirectiveTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Mockery as m;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeDirectiveTest extends TestCase
+{
+    protected function compileBlade(string $expression, $page = ['foo' => 'bar'])
+    {
+        $compiler = new BladeCompiler(m::mock(Filesystem::class), __DIR__);
+        $compiler->directive('inertia', Blade::getCustomDirectives()['inertia']);
+
+        $compiled = tap($compiler->compileString($expression), function () {
+            m::close();
+        });
+
+        ob_start(function () {
+            // This closure exists to prevent 'eval' output from getting sent to
+            // STDOUT, which in turn causes PHPUnit to complain about it.
+            return '';
+        });
+
+        eval("?>$compiled<?php ");
+
+        return ob_get_flush();
+    }
+
+    public function test_directive_is_rendered_with_the_default_options()
+    {
+        $this->assertSame(
+            '<div id="app" data-page="{&quot;foo&quot;:&quot;bar&quot;}"></div>',
+            $this->compileBlade('@inertia')
+        );
+    }
+
+    public function test_directive_is_rendered_with_a_custom_div_id()
+    {
+        $this->assertSame(
+            '<div id="foo" data-page="{&quot;foo&quot;:&quot;bar&quot;}"></div>',
+            $this->compileBlade("@inertia('foo')")
+        );
+    }
+}

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -18,10 +18,7 @@ class ServiceProviderTest extends TestCase
 {
     public function test_blade_directive_is_registered()
     {
-        $directives = Blade::getCustomDirectives();
-
-        $this->assertArrayHasKey('inertia', $directives);
-        $this->assertEquals('<div id="app" data-page="{{ json_encode($page) }}"></div>', $directives['inertia']());
+        $this->assertArrayHasKey('inertia', Blade::getCustomDirectives());
     }
 
     public function test_request_macro_is_registered()


### PR DESCRIPTION
Fixes #139, #140 

This `compileBlade` function is mostly [based off of what Laravel uses in their own test suite](https://github.com/laravel/framework/blob/7.x/tests/View/Blade/AbstractBladeTestCase.php). 

I went with this, as rendering a view with conditions for both test-cases became too messy (and blade view caching kicks in as well, giving inconsistent test results): 