### PR TITLE
Add covers and uses annotations to tests

### DIFF
--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -7,6 +7,13 @@ use Inertia\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 
+/**
+ * @covers \Inertia\Controller
+ * @uses \Inertia\Inertia
+ * @uses \Inertia\Response
+ * @uses \Inertia\ResponseFactory
+ * @uses \Inertia\ServiceProvider
+ */
 class ControllerTest extends TestCase
 {
     public function test_controller_returns_an_inertia_response()

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -6,6 +6,13 @@ use Inertia\Inertia;
 use Inertia\Response;
 use Inertia\ResponseFactory;
 
+/**
+ * @covers ::inertia
+ * @uses \Inertia\Inertia
+ * @uses \Inertia\Response
+ * @uses \Inertia\ResponseFactory
+ * @uses \Inertia\ServiceProvider
+ */
 class HelperTest extends TestCase
 {
     public function test_the_helper_function_returns_an_instance_of_the_response_factory()

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -7,6 +7,13 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Middleware;
 
+/**
+ * @covers \Inertia\Middleware
+ * @uses \Inertia\Inertia
+ * @uses \Inertia\Response
+ * @uses \Inertia\ResponseFactory
+ * @uses \Inertia\ServiceProvider
+ */
 class MiddlewareTest extends TestCase
 {
     public function test_the_version_is_optional()

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -4,6 +4,11 @@ namespace Inertia\Tests;
 
 use Inertia\ResponseFactory;
 
+/**
+ * @covers \Inertia\ResponseFactory
+ * @uses \Inertia\Inertia
+ * @uses \Inertia\ServiceProvider
+ */
 class ResponseFactoryTest extends TestCase
 {
     public function test_can_macro()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -14,6 +14,12 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 
+/**
+ * @covers \Inertia\Response
+ * @uses \Inertia\Inertia
+ * @uses \Inertia\ServiceProvider
+ * @uses \Inertia\ResponseFactory
+ */
 class ResponseTest extends TestCase
 {
     public function test_server_response()

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -14,6 +14,12 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
 
+/**
+ * @covers \Inertia\ServiceProvider
+ * @uses \Inertia\Inertia::getFacadeAccessor
+ * @uses \Inertia\ResponseFactory::getShared
+ * @uses \Inertia\ResponseFactory::share
+ */
 class ServiceProviderTest extends TestCase
 {
     public function test_blade_directive_is_registered()


### PR DESCRIPTION
I've added `@covers` and `@uses` to the tests because it was not possible to generate code coverage reports, because `forceCoversAnnotation` and `beStrictAboutCoversAnnotation` are set to true in phpunit.xml.