### PR TITLE
Add simple XHR response

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -84,6 +84,10 @@ class Response implements Responsable
             ]);
         }
 
+        if ($request->isXmlHttpRequest()) {
+            return new JsonResponse($props);
+        }
+
         return ResponseFactory::view($this->rootView, $this->viewData + ['page' => $page]);
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -53,6 +53,20 @@ class ResponseTest extends TestCase
         $this->assertSame('123', $page->version);
     }
 
+    public function test_xhr_non_inertia_response()
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Requested-With' => 'XMLHttpRequest']);
+
+        $user = (object) ['name' => 'Jonathan'];
+        $response = new Response('User/Edit', ['user' => $user], 'app', '123');
+        $response = $response->toResponse($request);
+        $data = $response->getData();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame('Jonathan', $data->user->name);
+    }
+
     public function test_resource_response()
     {
         $request = Request::create('/user/123', 'GET');


### PR DESCRIPTION
This tiny PR adds an ability to re-use the same controllers for simple XHR requests as well as for Inertia ones.
Not sure if that's really a missing feature, but I just faced a case when I had to duplicate multiple controllers just to allow fetching data using axios without extra headers on input and extra data on output.

Example usage:
– Search
– Dynamic selects (v-select, select2)