### PR TITLE
Automatically register middleware in "web" group

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
@@ -51,7 +52,10 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function registerMiddleware()
     {
-        $this->app[Kernel::class]->appendMiddlewareToGroup('web', Middleware::class);
+        $this->app[Kernel::class]->appendMiddlewareToGroup(
+            Config::get('inertia.middleware_group', 'web'),
+            Middleware::class
+        );
     }
 
     protected function shareValidationErrors()

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -51,7 +51,7 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function registerMiddleware()
     {
-        $this->app[Kernel::class]->pushMiddleware(Middleware::class);
+        $this->app[Kernel::class]->appendMiddlewareToGroup('web', Middleware::class);
     }
 
     protected function shareValidationErrors()


### PR DESCRIPTION
This PR updates the service provider to register the Inertia middleware in the `web` middleware group, instead of the global middleware stack.

The primary motivation for this change is because the current session reflashing behaviour does not work right now, and that's because the middleware is run before the session is started. Moving it to the end of the `web` middleware group fixes this.

https://github.com/inertiajs/inertia-laravel/blob/0a9af997c0a2e141984d9c8fc3b2a9911512f63f/src/Middleware.php#L20-L22

Also, it feels odd to register the Inertia middleware globally, when it should really only run on the `web` endpoints, and not, for example, on the `api` endpoints.