### PR TITLE
Add check for appendMiddlewareToGroup() method when registering middleware

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -52,10 +52,14 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function registerMiddleware()
     {
-        $this->app[Kernel::class]->appendMiddlewareToGroup(
-            Config::get('inertia.middleware_group', 'web'),
-            Middleware::class
-        );
+        $kernel = $this->app[Kernel::class];
+
+        if (method_exists($kernel, 'appendMiddlewareToGroup')) {
+            $kernel->appendMiddlewareToGroup(
+                Config::get('inertia.middleware_group', 'web'),
+                Middleware::class
+            );
+        }
     }
 
     protected function shareValidationErrors()


### PR DESCRIPTION
Closes #151

Prior to Laravel [v6.9.0](https://github.com/laravel/framework/releases/tag/v6.9.0), the `appendMiddlewareToGroup()` method did not exist, which is causing an exception to be thrown when Inertia tries to register its middleware. This was caused by a recent change to how the Inertia middleware is registered, to fix an issue with session reflashing (see #147).

This PR adds a check for the existence of the `appendMiddlewareToGroup()` method when registering middleware. If it doesn't exist, Inertia will simply not register it's middleware, and this will have to be done manually in the `app/Http/Kernel.php`:

```diff
protected $middlewareGroups = [
    'web' => [
        \App\Http\Middleware\EncryptCookies::class,
        \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
        \Illuminate\Session\Middleware\StartSession::class,
        // \Illuminate\Session\Middleware\AuthenticateSession::class,
        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
        \App\Http\Middleware\VerifyCsrfToken::class,
        \Illuminate\Routing\Middleware\SubstituteBindings::class,
+       \Inertia\Middleware::class,
    ],

    'api' => [
        'throttle:api',
        \Illuminate\Routing\Middleware\SubstituteBindings::class,
    ],
];
```