### PR TITLE
Add new Inertia::location($url) method

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void version($version)
  * @method static int|string getVersion()
  * @method static \Inertia\Response render($component, $props = [])
+ * @method static \Illuminate\Http\Response location($url)
  *
  * @see \Inertia\ResponseFactory
  */

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -5,6 +5,7 @@ namespace Inertia;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Response as BaseResponse;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
 
@@ -65,5 +66,10 @@ class ResponseFactory
             $this->rootView,
             $this->getVersion()
         );
+    }
+
+    public function location($url)
+    {
+        return BaseResponse::make('', 409, ['X-Inertia-Location' => $url]);
     }
 }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Inertia\Tests;
 
 use Inertia\ResponseFactory;
+use Illuminate\Http\Response;
 
 class ResponseFactoryTest extends TestCase
 {
@@ -14,5 +15,14 @@ class ResponseFactoryTest extends TestCase
         });
 
         $this->assertEquals('bar', $factory->foo());
+    }
+
+    public function test_location_response()
+    {
+        $response = (new ResponseFactory())->location('https://inertiajs.com');
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(409, $response->getStatusCode());
+        $this->assertEquals('https://inertiajs.com', $response->headers->get('X-Inertia-Location'));
     }
 }


### PR DESCRIPTION
Closes #57.

This PR adds a new `Inertia::location($url)` method, which returns a "409 Conflict" response with the `X-Inertia-Location` header set. This will cause a full page visit (`location.href = url`) to happen client-side by Inertia. This works since this behaviour is already in place for automatic asset refreshing.

```php
return Inertia::location('https://www.google.com');
```

I really struggled with naming this method, but in the end decided that `location()` made the most sense, because:

1. There is no confusion here with this being a redirect. I was worried that adding a method with the word "redirect" it in might cause developers to use this method instead of just regular redirects (even when a regular redirect is totally the right approach).
2. It doesn’t feel like you’re doing something wrong. We considered `hardVisit($url)` and `abortTo($url)`, but that almost implied that you were doing something incorrect.
3. It’s short.
4. It aligns really well with what's actually happening (a `window.location = url`) visit.
5. It even matches the header we are already using for this (`X-Inertia-Location`).

Credit to @adamwathan for coming up with this method name. 🥰