### PR TITLE
Preserve url hash on navigation

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -70,10 +70,12 @@ class Response implements Responsable
             }
         });
 
+        $hash = $request->header('X-Inertia-Hash', '');
+
         $page = [
             'component' => $this->component,
             'props' => $props,
-            'url' => $request->getRequestUri(),
+            'url' => $request->getRequestUri() . $hash,
             'version' => $this->version,
         ];
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -183,4 +183,18 @@ class ResponseTest extends TestCase
         $this->assertSame('/user/123', $page->url);
         $this->assertSame('123', $page->version);
     }
+
+    public function test_xhr_with_hash_in_url()
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Hash' => '#some-hash']);
+
+        $response = new Response('Some/Component', [], 'app', '123');
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame('/user/123#some-hash', $page->url);
+    }
 }


### PR DESCRIPTION
This PR is an attempt at fixing https://github.com/inertiajs/inertia/issues/85.

It goes with its inertiajs/inertia counterpart: https://github.com/inertiajs/inertia/pull/244

It simply appends the content of the `X-Inertia-Hash` header to the URL that is returned to the frontend.

This ensures that navigating to `/foo/bar#some-hash` results in the URL being `/foo/bar#some-hash` and not just `/foo/bar`.

---

If you are happy with the proposed changes, here are a few things that will need to be done too:
- [ ] Support the same behavior in inertiajs/inertia-rails
- [ ] Update PingCRM to demonstrate this behavior

---

Feel free to suggest any improvement :)