### PR TITLE
Adds support for adding middleware to multiple middleware groups

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Inertia;
 
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Collection;
@@ -53,15 +54,17 @@ class ServiceProvider extends BaseServiceProvider
     protected function registerMiddleware()
     {
         $kernel = $this->app[Kernel::class];
-        $group = Config::get('inertia.middleware_group', 'web');
+        $groups = Config::get('inertia.middleware_group', ['web']);
 
-        // Laravel >= 6.9.0
-        if (method_exists($kernel, 'appendMiddlewareToGroup')) {
-            $kernel->appendMiddlewareToGroup($group, Middleware::class);
+        foreach (Arr::wrap($groups) as $group) {
+            // Laravel >= 6.9.0
+            if (method_exists($kernel, 'appendMiddlewareToGroup')) {
+                $kernel->appendMiddlewareToGroup($group, Middleware::class);
 
-        // Laravel >= 5.4.4 && < 6.9.0
-        } elseif ($this->app[Router::class]->hasMiddlewareGroup($group)) {
-            $this->app[Router::class]->pushMiddlewareToGroup($group, Middleware::class);
+                // Laravel >= 5.4.4 && < 6.9.0
+            } elseif ($this->app[Router::class]->hasMiddlewareGroup($group)) {
+                $this->app[Router::class]->pushMiddlewareToGroup($group, Middleware::class);
+            }
         }
     }
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -5,12 +5,12 @@ namespace Inertia\Tests;
 use Closure;
 use Inertia\Inertia;
 use Inertia\Middleware;
+use Inertia\ServiceProvider;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\ViewErrorBag;
-use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
@@ -49,7 +49,7 @@ class ServiceProviderTest extends TestCase
         $this->assertEquals(['component' => 'User/Edit', 'props' => ['user' => ['name' => 'Jonathan']]], $route->defaults);
     }
 
-    public function test_middleware_is_registered_to_the_web_group()
+    public function test_middleware_is_registered_to_the_web_group_by_default()
     {
         $webRoute = Route::middleware('web')->get('/');
         $apiRoute = Route::middleware('api')->get('/');
@@ -59,6 +59,22 @@ class ServiceProviderTest extends TestCase
 
         $this->assertContains(Middleware::class, $webMiddleware);
         $this->assertNotContains(Middleware::class, $apiMiddleware);
+    }
+
+    public function test_middleware_can_be_assigned_to_multiple_groups()
+    {
+        $serviceProvider = new ServiceProvider($this->app);
+        config()->set(['inertia.middleware_group' => ['web', 'api']]);
+        $serviceProvider->boot();
+
+        $webRoute = Route::middleware('web')->get('/');
+        $apiRoute = Route::middleware('api')->get('/');
+
+        $webMiddleware = App::make(Router::class)->gatherRouteMiddleware($webRoute);
+        $apiMiddleware = App::make(Router::class)->gatherRouteMiddleware($apiRoute);
+
+        $this->assertContains(Middleware::class, $webMiddleware);
+        $this->assertContains(Middleware::class, $apiMiddleware);
     }
 
     public function test_validation_errors_are_registered()


### PR DESCRIPTION
In one of my projects I needed to add a custom middleware group--in addition to `web`--that also needed to work with Inertia. Currently I have to manually add Inertia's middleware to my custom middleware stack. 

This PR adds support for specifying a list of middleware groups that the middleware should be pushed to. The default behavior did not change and it is still possible to assign a single value to `inertia.middleware_group`.

Getting the test to run was a bit finicky because I have to overwrite the config value. By the time the test runs, however, the ServiceProvider has already been registered and changing the config inside the test won't have an effect anymore. The only way I could get the test to run was to manually instantiate the service provider again and run the `boot` method. If anyone knows a better way to do this, please let me know.