### PR TITLE
Middleware: Allow --force option

### DIFF
--- a/src/Console/CreateMiddleware.php
+++ b/src/Console/CreateMiddleware.php
@@ -3,15 +3,16 @@
 namespace Inertia\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class CreateMiddleware extends GeneratorCommand
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'inertia:middleware {name=HandleInertiaRequests : Name of the Middleware that should be created}';
+    protected $name = 'inertia:middleware';
 
     /**
      * The console command description.
@@ -46,5 +47,29 @@ class CreateMiddleware extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Http\Middleware';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputOption::VALUE_REQUIRED, 'Name of the Middleware that should be created', 'HandleInertiaRequests'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', null, InputOption::VALUE_NONE, 'Create the class even if the Middleware already exists'],
+        ];
     }
 }


### PR DESCRIPTION
This will allow you (and Jetstream) to use --force, similar to all other Laravel generator commands.