### PR TITLE
Add manifestPath property to middleware

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -15,10 +15,13 @@ class Middleware
      * @var string
      */
     protected $rootView = 'app';
-    
+
     /**
-     * The path to the manifest file relative to the public directory.
-     * Used to determine the current asset version
+     * The path to the manifest file relative to the public directory
+     * used to determine the current asset version.
+     *
+     * @see version
+     * @var string
      */
     protected $manifestPath = 'mix-manifest.json';
 

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -15,6 +15,12 @@ class Middleware
      * @var string
      */
     protected $rootView = 'app';
+    
+    /**
+     * The path to the manifest file relative to the public directory.
+     * Used to determine the current asset version
+     */
+    protected $manifestPath = 'mix-manifest.json';
 
     /**
      * Determines the current asset version.
@@ -29,7 +35,7 @@ class Middleware
             return md5(config('app.asset_url'));
         }
 
-        if (file_exists($manifest = public_path('mix-manifest.json'))) {
+        if (file_exists($manifest = public_path($this->manifestPath))) {
             return md5_file($manifest);
         }
     }


### PR DESCRIPTION
Presently the manifest path is hardcoded,
This property allows users who either aren't using mix (e.g. using encore by symfony or a custom webpack setup) or have mix outputting to a non-root directory to just override this one property rather than duplicating the current manifest logic.

I've left the property out of the stub as I figure it's not a common enough use case to need it in the stub, and those that are running a custom build process are likely comfortable enough to take a quick peek at the parent version method.