### PR TITLE
Add lazy props feature

### DIFF
--- a/src/LazyProp.php
+++ b/src/LazyProp.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Inertia;
+
+use Illuminate\Support\Facades\App;
+
+class LazyProp
+{
+    protected $callback;
+
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    public function __invoke()
+    {
+        return App::call($this->callback);
+    }
+}

--- a/src/Response.php
+++ b/src/Response.php
@@ -54,9 +54,15 @@ class Response implements Responsable
 
         $props = ($only && $request->header('X-Inertia-Partial-Component') === $this->component)
             ? Arr::only($this->props, $only)
-            : $this->props;
+            : array_filter($this->props, function ($prop) {
+                return ! ($prop instanceof LazyProp);
+            });
 
         array_walk_recursive($props, function (&$prop) use ($request) {
+            if ($prop instanceof LazyProp) {
+                $prop = App::call($prop);
+            }
+
             if ($prop instanceof Closure) {
                 $prop = App::call($prop);
             }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -54,6 +54,11 @@ class ResponseFactory
         return (string) $version;
     }
 
+    public function lazy(callable $callback)
+    {
+        return new LazyProp($callback);
+    }
+
     public function render($component, $props = [])
     {
         if ($props instanceof Arrayable) {

--- a/tests/LazyPropTest.php
+++ b/tests/LazyPropTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Illuminate\Http\Request;
+use Inertia\LazyProp;
+
+class LazyPropTest extends TestCase
+{
+    public function test_can_invoke()
+    {
+        $lazyProp = new LazyProp(function () {
+            return 'A lazy value';
+        });
+
+        $this->assertSame('A lazy value', $lazyProp());
+    }
+
+    public function test_can_resolve_bindings_when_invoked()
+    {
+        $lazyProp = new LazyProp(function (Request $request) {
+            return $request;
+        });
+
+        $this->assertInstanceOf(Request::class, $lazyProp());
+    }
+}

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Response;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
+use Inertia\LazyProp;
 use Inertia\ResponseFactory;
 use Inertia\Tests\Stubs\ExampleMiddleware;
 
@@ -68,5 +69,15 @@ class ResponseFactoryTest extends TestCase
                 'foo' => 'bar',
             ],
         ]);
+    }
+
+    public function test_can_create_lazy_prop()
+    {
+        $factory = new ResponseFactory();
+        $lazyProp = $factory->lazy(function () {
+            return 'A lazy value';
+        });
+
+        $this->assertInstanceOf(LazyProp::class, $lazyProp);
     }
 }


### PR DESCRIPTION
This PR implements the new "lazy props" feature, as discussed here: https://github.com/inertiajs/inertia/issues/287

This feature allows you to define optional (lazy) properties that are not included on the initial visit to a page. These properties are only ever included when using partial reloads (the `only` option).

You mark a prop as lazy using the new `Inertia::lazy()` method, which behind the scenes wraps the prop in a new `LazyProp` class:

```php
return Inertia::render('Users/Index', [
    'users' => User::paginate('id', 'name', 'email'),
    'companies' => Inertia::lazy(fn () => Company::get('id', 'name')),
]);
```

Then, to load this prop later on, you perform a partial reload from your page component:

```js
<inertia-link class="hover:underline" href="/users" :only="['companies']">Load companies</inertia-link>
```

Or programatically:

```js
Inertia.reload({ only: ['companies'] })
```

![Lazy Props](https://user-images.githubusercontent.com/882133/97555475-8b7a8b00-19ae-11eb-8ea8-301d71efef9e.gif)