### PR TITLE
Add optional id argument to the blade directive

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -24,8 +24,8 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function registerBladeDirective()
     {
-        Blade::directive('inertia', function () {
-            return '<div id="app" data-page="{{ json_encode($page) }}"></div>';
+        Blade::directive('inertia', function ($id = '') {
+            return sprintf('<div id="%s" data-page="{{ json_encode($page) }}"></div>', $id ?: 'app');
         });
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -25,6 +25,8 @@ class ServiceProvider extends BaseServiceProvider
     protected function registerBladeDirective()
     {
         Blade::directive('inertia', function ($id = '') {
+            $id = trim($id, '\'"');
+
             return sprintf('<div id="%s" data-page="{{ json_encode($page) }}"></div>', $id ?: 'app');
         });
     }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -22,6 +22,8 @@ class ServiceProviderTest extends TestCase
 
         $this->assertArrayHasKey('inertia', $directives);
         $this->assertEquals('<div id="application" data-page="{{ json_encode($page) }}"></div>', $directives['inertia']('application'));
+        $this->assertEquals('<div id="application" data-page="{{ json_encode($page) }}"></div>', $directives['inertia']("'application'"));
+        $this->assertEquals('<div id="application" data-page="{{ json_encode($page) }}"></div>', $directives['inertia']('"application"'));
     }
 
     public function test_request_macro_is_registered()

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -16,6 +16,14 @@ class ServiceProviderTest extends TestCase
         $this->assertEquals('<div id="app" data-page="{{ json_encode($page) }}"></div>', $directives['inertia']());
     }
 
+    public function test_blade_directive_can_take_div_id_as_argument()
+    {
+        $directives = Blade::getCustomDirectives();
+
+        $this->assertArrayHasKey('inertia', $directives);
+        $this->assertEquals('<div id="application" data-page="{{ json_encode($page) }}"></div>', $directives['inertia']('application'));
+    }
+
     public function test_request_macro_is_registered()
     {
         $request = Request::create('/user/123', 'GET');


### PR DESCRIPTION
Hi,

I had a situation where a div with id="app" already existed where I wanted to use the @inertia directive. 
I solved it by changing the other div, but I thought it would be good to be able to pass the id as an optional argument to the directive like @interia('div-id')

This PR implements the above mentioned feature, and adds a test to it.

Please let me know what do you think.
