### PR TITLE
Add support for new "inline visits" feature

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -66,7 +66,7 @@ class Response implements Responsable
 
     public function toResponse($request)
     {
-        if (!$request->header('X-Inertia-Inline') && $this->base) {
+        if (! $request->header('X-Inertia-Inline') && $this->base) {
             return ($this->base)()
                 ->inline($this->component)
                 ->toResponse($request);
@@ -102,12 +102,12 @@ class Response implements Responsable
             'component' => $this->component,
             'props' => $props,
             'url' => $request->getRequestUri(),
-            'version' => $this->version,
             'inline' => $this->inline ? [
                 'component' => $this->inline,
                 'props' => $props,
                 'url' => $request->getRequestUri(),
             ] : null,
+            'version' => $this->version,
         ];
 
         if ($request->header('X-Inertia')) {

--- a/src/Response.php
+++ b/src/Response.php
@@ -17,6 +17,7 @@ class Response implements Responsable
     protected $rootView;
     protected $version;
     protected $viewData = [];
+    protected $inlineable;
     protected $inlineBase;
     protected $inlineComponent;
     protected $inlineProps;
@@ -40,6 +41,13 @@ class Response implements Responsable
     {
         $this->inlineComponent = $component;
         $this->inlineProps = $props;
+
+        return $this;
+    }
+
+    public function inlineable($inlineable)
+    {
+        $this->inlineable = $inlineable;
 
         return $this;
     }
@@ -110,6 +118,7 @@ class Response implements Responsable
                 'url' => $request->getRequestUri(),
             ] : null,
             'version' => $this->version,
+            'inlineable' => $this->inlineable,
         ];
 
         if ($request->header('X-Inertia')) {

--- a/src/Response.php
+++ b/src/Response.php
@@ -66,7 +66,7 @@ class Response implements Responsable
 
     public function toResponse($request)
     {
-        if (!$request->inertia() && $this->base) {
+        if (!$request->header('X-Inertia-Inline') && $this->base) {
             return ($this->base)()
                 ->inline($this->component)
                 ->toResponse($request);

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -61,7 +61,7 @@ class ResponseFactory
 
     public function inline(string $component, callable $default, array $props = [])
     {
-        return $this->render($component, $props)->withBase($default);
+        return $this->render($component, $props)->inlineBase($default);
     }
 
     public function render($component, $props = [])

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -59,6 +59,11 @@ class ResponseFactory
         return new LazyProp($callback);
     }
 
+    public function inline(string $component, callable $default, array $props = [])
+    {
+        return $this->render($component, $props)->withBase($default);
+    }
+
     public function render($component, $props = [])
     {
         if ($props instanceof Arrayable) {


### PR DESCRIPTION
See: https://github.com/inertiajs/inertia/pull/315

This PR adds support for the new "inline visits" feature coming to Inertia. For the most part, this is a client-side feature. However, there are two situations that need to be handled server-side:

## First (full) page visits

Consider a `/users/create` endpoint, which displays a create user modal on top of the current page. If you visit this endpoint directly (the the first page visit), you have two choices:

1. Show a full page version of the create user page, which uses the app layout.
2. Show the create user modal again, but with another page loaded in the background.

The first option here is easy, since you can conditionally render the modal version of full page version of your page component based on the new `$inline` global property (literally no server-side changes required at all).

However, the second option is more complicated, since you need to get the component and data for two pages: the create user modal, in this example, and the page you want to load in the background.

Inertia.js supports "double page visits" like this by allowing you to provide a page object that includes an `inline` key. When you do this, the main page is treated as the background, and the `inline` page as the inlined page (naturally).

```json
{
  "component": "Users/Index",
  "props": {
    "users": [],
  },
  "url": "/users",
  "inline": {
    "component": "Users/Create",
    "props": {},
    "url": "/users/create",
  },
  "version": "c32b8e4965f418ad16eaebba1d4e960f",
}
```

To make a response like this, you can use the new `Inertia::inline()` option, which takes the inline page as the first argument, the base page as the second argument, and any props for the inline page as the third argument. I am totally not sold on this API yet, this is a WIP.

```php
return Inertia::inline('Users/Create', function () {
    return Inertia::render('Users/Index', [
        'users' => User::all(),
    ]);
}, ['foo' => 'bar']);

// Shorthand (by using existing controller method)
return Inertia::inline('Users/Create', fn () => $this->index(), ['foo' => 'bar']);
```

Note how thee base page is lazily evaluated. This is because we don't want to load the base page on inline visits.

## Non-inline Inertia modal visits

The second situation is similar to the full page visits, but this time for standard non-inline Inertia modal visits. For example, imagine you click on the `/users/create` link to create a new user, but your session has expired, and you get logged out. You log back in, and then Laravel redirects you (in an Inertia request) back to the intended URL, `/users/create`.

In these situations, you don't want the create modal page to appear on the login page, nor do you necessary want to have to create a full page version of the create user page. What you probably want here is show the create user modal with a logical base page in the background.

By using the new `Inertia::inline()` helper, this adapter will check to see if the request is an inline visit, and if it's not, will automatically return a "double page" response instead.