### PR TITLE
Customize blade directive to allow changing the div id

### DIFF
--- a/src/BladeDirective.php
+++ b/src/BladeDirective.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Inertia;
+
+class BladeDirective
+{
+    public function render(string $id = 'app')
+    {
+        return new class($id) {
+            private $id;
+
+            private $page;
+
+            public function __construct(string $id)
+            {
+                $this->id = $id;
+            }
+
+            public function withPage($page)
+            {
+                $this->page = $page;
+
+                return $this;
+            }
+
+            public function __toString()
+            {
+                return '<div id="'.$this->id.'" data-page="'.e(json_encode($this->page)).'"></div>';
+            }
+        };
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -12,6 +12,7 @@ class ServiceProvider extends BaseServiceProvider
     public function register()
     {
         $this->app->singleton(ResponseFactory::class);
+        $this->app->singleton(BladeDirective::class);
     }
 
     public function boot()
@@ -24,8 +25,8 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function registerBladeDirective()
     {
-        Blade::directive('inertia', function () {
-            return '<div id="app" data-page="{{ json_encode($page) }}"></div>';
+        Blade::directive('inertia', function ($expression = '') {
+            return '<?php echo app(\Inertia\BladeDirective::class)->render('.$expression.')->withPage($page); ?>';
         });
     }
 

--- a/tests/BladeDirectiveTest.php
+++ b/tests/BladeDirectiveTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Mockery as m;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeDirectiveTest extends TestCase
+{
+    protected function compileBlade(string $expression, $page = ['foo' => 'bar'])
+    {
+        $compiler = new BladeCompiler(m::mock(Filesystem::class), __DIR__);
+        $compiler->directive('inertia', Blade::getCustomDirectives()['inertia']);
+
+        $compiled = tap($compiler->compileString($expression), function () {
+            m::close();
+        });
+
+        ob_start(function () {
+            // This closure exists to prevent 'eval' output from getting sent to
+            // STDOUT, which in turn causes PHPUnit to complain about it.
+            return '';
+        });
+
+        eval("?>$compiled<?php ");
+
+        return ob_get_flush();
+    }
+
+    public function test_directive_is_rendered_with_the_default_options()
+    {
+        $this->assertSame(
+            '<div id="app" data-page="{&quot;foo&quot;:&quot;bar&quot;}"></div>',
+            $this->compileBlade('@inertia')
+        );
+    }
+
+    public function test_directive_is_rendered_with_a_custom_div_id()
+    {
+        $this->assertSame(
+            '<div id="foo" data-page="{&quot;foo&quot;:&quot;bar&quot;}"></div>',
+            $this->compileBlade("@inertia('foo')")
+        );
+    }
+}

--- a/tests/BladeDirectiveTest.php
+++ b/tests/BladeDirectiveTest.php
@@ -2,10 +2,10 @@
 
 namespace Inertia\Tests;
 
-use Mockery as m;
-use Illuminate\Support\Facades\Blade;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\View\Compilers\BladeCompiler;
+use Mockery as m;
 
 class BladeDirectiveTest extends TestCase
 {

--- a/tests/BladeDirectiveTest.php
+++ b/tests/BladeDirectiveTest.php
@@ -44,4 +44,12 @@ class BladeDirectiveTest extends TestCase
             $this->compileBlade("@inertia('foo')")
         );
     }
+
+    public function test_directive_is_rendered_with_a_custom_div_id_with_shorthand_if_expression()
+    {
+        $this->assertSame(
+            '<div id="foo" data-page="{&quot;foo&quot;:&quot;bar&quot;}"></div>',
+            $this->compileBlade("@inertia(true ? 'foo' : 'bar')")
+        );
+    }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -13,7 +13,7 @@ class ServiceProviderTest extends TestCase
         $directives = Blade::getCustomDirectives();
 
         $this->assertArrayHasKey('inertia', $directives);
-        
+
         $this->assertEquals('<?php echo app(\Inertia\BladeDirective::class)->render()->withPage($page); ?>', $directives['inertia']());
         $this->assertEquals('<?php echo app(\Inertia\BladeDirective::class)->render("foo")->withPage($page); ?>', $directives['inertia']('"foo"'));
     }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -13,7 +13,9 @@ class ServiceProviderTest extends TestCase
         $directives = Blade::getCustomDirectives();
 
         $this->assertArrayHasKey('inertia', $directives);
-        $this->assertEquals('<div id="app" data-page="{{ json_encode($page) }}"></div>', $directives['inertia']());
+        
+        $this->assertEquals('<?php echo app(\Inertia\BladeDirective::class)->render()->withPage($page); ?>', $directives['inertia']());
+        $this->assertEquals('<?php echo app(\Inertia\BladeDirective::class)->render("foo")->withPage($page); ?>', $directives['inertia']('"foo"'));
     }
 
     public function test_request_macro_is_registered()


### PR DESCRIPTION
While reading through #141 and #178 I noticed the `$expression` that's passed by the blade compiler wasn't treated as a PHP expression, but rather as a string. I think this should be treated as an expression to follow blade standards and this will allow people to conditionally change the id like so `@inertia(true ? 'foo' : 'bar')`.

This means `@inertia(foo)` is not allowed, since that's not a valid expression. However, all directives mentioned in the [blade docs](https://laravel.com/docs/8.x/blade) have valid PHP as parameter for the blade directives (`'title'`, `count($records) === 1`) and for example `yield(content)` wouldn't work either since that doesn't contain a valid PHP expression.

The easiest solution is to output the expression in the directive directly to pass that to a method call, so the directive would return this `'<?php echo app(\MyClass::class)->render('.$expression.'); ?>'`. This works as expected, unfortunately Inertia also needs to output the `$page` variable which is passed as view data. I've tried to come up with a solution for this, but this is far from perfect, since I don't really like the usage of an anonymous class for this. Maybe someone can help me figure out a better solution, or this PR can be used to improve one of the other PR's

Oh and I used @claudiodekker's tests from #141, so I added you as co-author :)