### PR TITLE
Add error bag support

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -147,8 +147,14 @@ class Middleware
             return (object) collect($bag->messages())->map(function ($errors) {
                 return $errors[0];
             })->toArray();
-        })->pipe(function ($bags) {
-            return $bags->has('default') ? $bags->get('default') : $bags->toArray();
+        })->pipe(function ($bags) use ($request) {
+            if ($bags->has('default') && $request->header('x-inertia-error-bag')) {
+                return [$request->header('x-inertia-error-bag') => $bags->get('default')];
+            } else if ($bags->has('default')) {
+                return $bags->get('default');
+            } else {
+                return $bags->toArray();
+            }
         });
     }
 }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -150,7 +150,7 @@ class Middleware
         })->pipe(function ($bags) use ($request) {
             if ($bags->has('default') && $request->header('x-inertia-error-bag')) {
                 return [$request->header('x-inertia-error-bag') => $bags->get('default')];
-            } else if ($bags->has('default')) {
+            } elseif ($bags->has('default')) {
                 return $bags->get('default');
             } else {
                 return $bags->toArray();


### PR DESCRIPTION
This PR adds support for the new error bag feature in Inertia core (https://github.com/inertiajs/inertia/pull/362). If an `errorBag` is defined on an Inertia visit and sent via the `X-Inertia-Error-Bag` header, this adapter will automatically scope the errors to the error bag key that's been defined.

Note, it will **only** use Inertia defined error bag name for the `default` error bag. Meaning, if you manually defined a named error bag server-side, that will still take precedence.