### PR TITLE
Make Response macroable

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -9,9 +9,12 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Response as ResponseFactory;
+use Illuminate\Support\Traits\Macroable;
 
 class Response implements Responsable
 {
+    use Macroable;
+
     protected $component;
     protected $props;
     protected $rootView;

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -17,6 +17,16 @@ use Inertia\Response;
 
 class ResponseTest extends TestCase
 {
+    public function test_can_macro()
+    {
+        $response = new Response('User/Edit', []);
+        $response->macro('foo', function () {
+            return 'bar';
+        });
+
+        $this->assertEquals('bar', $response->foo());
+    }
+
     public function test_server_response()
     {
         $request = Request::create('/user/123', 'GET');


### PR DESCRIPTION
Make Response macroable would be useful when we need to set the same view data very often:

For example, I'm not using vue meta, so meta data need to pass into Blade:

```php
Inertia::render('Dashboard')
       ->withViewData('noindex', true);﻿
```

Would be nice if we can just add a `withNoIndex()` method:
```php
Inertia\Response::macro('withNoIndex', fn () => $this->withViewData('noindex', true));
```

then we can instead just:
```php
Inertia::render('Dashboard')->withNoIndex();
```
