### PR TITLE
Add render url

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -20,6 +20,7 @@ class Response implements Responsable
     protected $rootView;
     protected $version;
     protected $viewData = [];
+    protected $renderUrl;
 
     public function __construct($component, $props, $rootView = 'app', $version = null)
     {
@@ -47,6 +48,13 @@ class Response implements Responsable
         } else {
             $this->viewData[$key] = $value;
         }
+
+        return $this;
+    }
+
+    public function renderUrl($renderUrl)
+    {
+        $this->renderUrl = $renderUrl;
 
         return $this;
     }
@@ -89,7 +97,7 @@ class Response implements Responsable
         $page = [
             'component' => $this->component,
             'props' => $props,
-            'url' => $request->getRequestUri(),
+            'url' => $this->renderUrl ?? $request->getRequestUri(),
             'version' => $this->version,
         ];
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -251,4 +251,22 @@ class ResponseTest extends TestCase
         $this->assertSame('Jonathan Reinink', $user['name']);
         $this->assertTrue($user['can']['deleteProducts']);
     }
+
+    public function test_can_set_render_url()
+    {
+        $request = Request::create('/products/123', 'PATCH');
+        $request->headers->add(['X-Inertia' => 'true']);
+
+        $product = (object) ['name' => 'My example product'];
+        $response = new Response('Products', ['product' => $product], 'app', '123');
+        $response = $response->renderUrl('/products');
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame('Products', $page->component);
+        $this->assertSame('My example product', $page->props->product->name);
+        $this->assertSame('/products', $page->url);
+        $this->assertSame('123', $page->version);
+    }
 }


### PR DESCRIPTION
This PR adds support for specifiying a custom render url which is returned by `Inertia::render` as `page.url`

When updating a resource, you do not always want to `Redirect::back()`. Instead render a component with prop(s) after the user has updated the resource.

```js
this.$inertia.patch('products/123'), data, {
    preserveState: true,
});
```
```php
return Inertia::render('Products', [
    'product' => $product,
]);
```
 
Currently Inertia will return `/products/123` as `page.url` as `Response` [is always using `$request->getRequestUri()`](https://github.com/inertiajs/inertia-laravel/blob/726b1e0d4fc399089dd29820a78e40d1c9aad2eb/src/Response.php#L92)

What if the url should be `/products`?

This PR allows you to specify the rendered url, e.g:

```php
return Inertia::render('Products', [
        'product' => $product,
    ])
    ->renderUrl('/products');
```
I believe that there a other use cases where you want to customize the rendered url as well.

 
