### PR TITLE
feat: add X-Inertia-Include-Data header

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -58,7 +58,7 @@ class Response implements Responsable
 
         $props = ($only && $request->header('X-Inertia-Partial-Component') === $this->component)
             ? Arr::only($this->props, $only)
-            : array_filter($this->props, function ($prop, $key) {
+            : array_filter($this->props, function ($prop, $key) use ($include) {
                 return ! ($prop instanceof LazyProp) || Arr::has($include, $key);
             }, ARRAY_FILTER_USE_BOTH);
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -54,12 +54,13 @@ class Response implements Responsable
     public function toResponse($request)
     {
         $only = array_filter(explode(',', $request->header('X-Inertia-Partial-Data')));
+        $include = array_filter(explode(',', $request->header('X-Inertia-Include-Data')));
 
         $props = ($only && $request->header('X-Inertia-Partial-Component') === $this->component)
             ? Arr::only($this->props, $only)
-            : array_filter($this->props, function ($prop) {
-                return ! ($prop instanceof LazyProp);
-            });
+            : array_filter($this->props, function ($prop, $key) {
+                return ! ($prop instanceof LazyProp) || Arr::has($include, $key);
+            }, ARRAY_FILTER_USE_BOTH);
 
         array_walk_recursive($props, function (&$prop) use ($request) {
             if ($prop instanceof LazyProp) {


### PR DESCRIPTION
This PR will support a new header called `X-Inertia-Include-Data` which allows users to explicitly request lazy data. If you think that this is a good idea we could not only check the header but also a specific key within the session (that was set with flash).

My specific use case is this:
1. Page loads without lazy data
2. User clicks on a button and lazy data is loaded (via `reload`)
3. User submits form that triggers a controller method that redirects `back`
4. Inertia replaces previously loaded lazy data with undefined because it's lazy and thus ignored in the new request

My idea would be to use the `back` method but flash some data:
```php
back(303)->flash('Inertia-Include-Data', 'lazyDataKey');
```

and use a custom middleware:
````php
$request->headers->set('X-Inertia-Include-Data', ($request->header('X-Inertia-Include-Data') ?? '') . ',' . (Session::get('Inertia-Include-Data') ?? ''), true);
````

Ideally, we could also create an Inertia helper that would do this magically:
```
Inertia::back()->include('lazyDataKey');
```

What do you think? Or is this use case considered somehow else?