### PR TITLE
Add flushShared() method for clearing all shared data

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -40,6 +40,11 @@ class ResponseFactory
         return $this->sharedProps;
     }
 
+    public function flushShared()
+    {
+        $this->sharedProps = [];
+    }
+
     public function version($version)
     {
         $this->version = $version;

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -71,6 +71,14 @@ class ResponseFactoryTest extends TestCase
         ]);
     }
 
+    public function test_can_flush_shared_data()
+    {
+        Inertia::share('foo', 'bar');
+        $this->assertSame(['foo' => 'bar'], Inertia::getShared());
+        Inertia::flushShared();
+        $this->assertSame([], Inertia::getShared());
+    }
+
     public function test_can_create_lazy_prop()
     {
         $factory = new ResponseFactory();


### PR DESCRIPTION
This PR adds a new `Inertia::flushShared()` method, which can be used to completely clear all the shared data.