### PR TITLE
Fixing methods getting ignored after redirect

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -158,7 +158,7 @@ class Middleware
             }
         });
     }
-    
+
     /**
      * Resolves and prepares the request methods, if they are being redirected.
      *
@@ -167,8 +167,10 @@ class Middleware
      */
     public function resolveRequestMethod(Request $request)
     {
-        if (! is_null($request->server('REDIRECT_REDIRECT_REQUEST_METHOD')))
+        if (! is_null($request->server('REDIRECT_REDIRECT_REQUEST_METHOD'))) {
             $request->setMethod($request->server('REDIRECT_REDIRECT_REQUEST_METHOD'));
+        }
+
         return $request;
     }
 }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -71,6 +71,7 @@ class Middleware
      */
     public function handle(Request $request, Closure $next)
     {
+        $request = $this->resolveRequestMethod($request);
         Inertia::version(function () use ($request) {
             return $this->version($request);
         });
@@ -156,5 +157,16 @@ class Middleware
                 return $bags->toArray();
             }
         });
+    }
+    
+    /**
+     * @param Request $request
+     * @return Request
+     */
+    public function resolveRequestMethod(Request $request)
+    {
+        if ($request->server('REDIRECT_REDIRECT_REQUEST_METHOD', false) !== false)
+            $request->setMethod($request->server('REDIRECT_REDIRECT_REQUEST_METHOD'));
+        return $request;
     }
 }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -160,12 +160,14 @@ class Middleware
     }
     
     /**
-     * @param Request $request
+     * Resolves and prepares the request methods, if they are being redirected.
+     *
+     * @param  Request  $request
      * @return Request
      */
     public function resolveRequestMethod(Request $request)
     {
-        if ($request->server('REDIRECT_REDIRECT_REQUEST_METHOD', false) !== false)
+        if (! is_null($request->server('REDIRECT_REDIRECT_REQUEST_METHOD')))
             $request->setMethod($request->server('REDIRECT_REDIRECT_REQUEST_METHOD'));
         return $request;
     }


### PR DESCRIPTION
### Subject

The inertia middleware ignores the methods comming from the vuejs to the laravel application, after they are redirected many times, they are all treated as `GET` methods.

### How to reproduce
 1- Fresh Laravel application with Jetstream installed.
 2- If cPanel available, activated the automatic `HTTP` to `HTTPS` redirect.
 3- Try activating the Two-Factor-Authentication via the Frontend.

### Solution

Since the redirected method is actually ignored but is represented in the header `REDIRECT_REDIRECT_REQUEST_METHOD` as the redirect method, we can actually override the current method, with the redirect one if it's existing.

which we can find in ``$request->server('REDIRECT_REDIRECT_REQUEST_METHOD')``.