### PR TITLE
Register macros on `register()` to avoid race condition

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,6 +22,10 @@ class ServiceProvider extends BaseServiceProvider
             __DIR__.'/../config/inertia.php',
             'inertia'
         );
+        
+        $this->registerRequestMacro();
+        $this->registerRouterMacro();
+        $this->registerTestingMacros();
 
         $this->app->bind('inertia.testing.view-finder', function ($app) {
             return new FileViewFinder(
@@ -36,9 +40,6 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->registerBladeDirective();
         $this->registerConsoleCommands();
-        $this->registerRequestMacro();
-        $this->registerRouterMacro();
-        $this->registerTestingMacros();
 
         $this->publishes([
             __DIR__.'/../config/inertia.php' => config_path('inertia.php'),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,7 +22,7 @@ class ServiceProvider extends BaseServiceProvider
             __DIR__.'/../config/inertia.php',
             'inertia'
         );
-        
+
         $this->registerRequestMacro();
         $this->registerRouterMacro();
         $this->registerTestingMacros();


### PR DESCRIPTION
Normally all routes will be registered during `boot()`, if a package service provider using Inertia get loaded first before `Inertia\ServiceProvider` they will face the following error:

```
InvalidArgumentException: Attribute [inertia] does not exist.
```

-----

Since `macro` uses static function it should be safe to register it earlier.