### PR TITLE
Use array for responsable getData()

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -71,7 +71,7 @@ class Response implements Responsable
             }
 
             if ($prop instanceof Responsable) {
-                $prop = $prop->toResponse($request)->getData();
+                $prop = $prop->toResponse($request)->getData(true);
             }
 
             if ($prop instanceof Arrayable) {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -265,7 +265,8 @@ class ResponseTest extends TestCase
         $request = Request::create('/user/123', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $resource = new class implements Responsable {
+        $resource = new class implements Responsable
+        {
             public function toResponse($request)
             {
                 return JsonResponse::fromJsonString('{"\u0000*\u0000_invalid_key": "for object"}');

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -269,7 +269,7 @@ class ResponseTest extends TestCase
         {
             public function toResponse($request)
             {
-                return new JsonResponse(["\x00*\x00_invalid_key" => "for object"]);
+                return new JsonResponse(["\x00*\x00_invalid_key" => 'for object']);
             }
         };
 
@@ -278,7 +278,7 @@ class ResponseTest extends TestCase
         $page = $response->getData(true);
 
         $this->assertSame(
-            ["\x00*\x00_invalid_key" => "for object"],
+            ["\x00*\x00_invalid_key" => 'for object'],
             $page['props']['resource']
         );
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -269,7 +269,7 @@ class ResponseTest extends TestCase
         {
             public function toResponse($request)
             {
-                return JsonResponse::fromJsonString('{"\u0000*\u0000_invalid_key": "for object"}');
+                return new JsonResponse(["\x00*\x00_invalid_key" => "for object"]);
             }
         };
 
@@ -278,7 +278,7 @@ class ResponseTest extends TestCase
         $page = $response->getData(true);
 
         $this->assertSame(
-            json_decode('{"\u0000*\u0000_invalid_key": "for object"}', true),
+            ["\x00*\x00_invalid_key" => "for object"],
             $page['props']['resource']
         );
     }


### PR DESCRIPTION
At the moment when a `Responsable` prop is transformed, it is transformed to an object:

```php
if ($prop instanceof Responsable) {
    $prop = $prop->toResponse($request)->getData();
}
```

A PHP object has a few limitations, when it comes to naming keys. For example, this is valid json:

```json
{"\u0000*\u0000_invalid_key": "for object"}
```

It is also a valid PHP array:

```
[
  "\x00*\x00_invalid_key" => "for object"
]
```

But it is not a valid PHP object, `json_decode` will return `null`.

This PR changes how a `Responsable` is transformed, it will not transform it to an object like it is now but it will transform it to an `array` by changing the above code to this:

```php
if ($prop instanceof Responsable) {
    $prop = $prop->toResponse($request)->getData(true);
}
```

I've also included a test which showcases this example.