### PR TITLE
Ability to chain the root view

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -51,6 +51,13 @@ class Response implements Responsable
         return $this;
     }
 
+    public function rootView($rootView)
+    {
+        $this->rootView = $rootView;
+
+        return $this;
+    }
+
     public function toResponse($request)
     {
         $only = array_filter(explode(',', $request->header('X-Inertia-Partial-Data')));


### PR DESCRIPTION
Very small change and mostly syntax-sugar.

I have a guest section of my app where I need a new root-view.

Instead of doing 
```
Inertia::setRootview('guest');

return Inertia::render('Guest/Home');
```

I can now do this instead: `return Inertia::setRootView('guest')->render('Guest/Home');`

Nothing much but I like it this way instead. What do you say?