### PR TITLE
Enable "dot" notation for Objects

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -81,7 +81,7 @@ class Response implements Responsable
 
         foreach ($props as $key => $value) {
             if (str_contains($key, '.')) {
-                Arr::set($props, $key, $value);
+                data_set($props, $key, $value);
                 unset($props[$key]);
             }
         }


### PR DESCRIPTION
Currently when doing something like shown in the example below you will end up with an array containing only the values defined with the "dot" notation. This is due to the limitations of `Arr::set()` only working on arrays and the fact that the API Resource returns a `stdClass` rather than an array. Changing `Arr::set()` to `data_set` will allow you to use the "dot" notation on Objects as well.

In the example you could probably handle the relation in the `OrderResource` itself but you would miss out on the partial reload or lazy data feature in such cases.

```php
<?php

use App\Http\Resources\AddressResource;
use App\Http\Resources\OrderResource;

return inertia('Orders/Show', [

    'order' => OrderResource::make($order),

    'order.address' => fn () => AddressResource::make($order->address),

]);

// Resulting data using Arr::set()
[
    'order' => [
        'address' => [
            // …
        ]
    ],
]

// Resulting data using data_set()
[
    'order' => [
        'id' => 1,
        'number' => 350647,
        // …
        'address' => [
            // …
        ]
    ],
]

```