### PR TITLE
Add `views/pages` to the default testing page paths

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -21,6 +21,7 @@ return [
         'page_paths' => [
 
             resource_path('js/Pages'),
+            resource_path('views/pages'),
 
         ],
 


### PR DESCRIPTION
This PR adds the `resources/views/pages` path to the default testing page paths. 

The reason for this is that I personally believe pages should be in the `resources/views/pages` directory instead of the `resources/js/Pages` one: 
- Having `js` as the main directory does not make much sense, as it is common to not have any JavaScript files
- I dig the `kebab-case` convention (but this is compatible with `camelCase` too), inspired by codebases like [Vite](https://github.com/vitejs/vite/tree/main/packages/vite/src/node), [Vue](https://github.com/vuejs/vue-next/tree/master/packages/runtime-core/src) and the default [Laravel blade](https://github.com/laravel/breeze/tree/1.x/stubs/default/resources/views) one
- I'm promoting this architecture with [Laravel Vite](https://github.com/innocenzi/laravel-vite/blob/main/config/vite.php#L12), but I kept `resources/js` in the defaults too
- My [Inertia preset](https://github.com/laravel-presets/inertia) scaffolds this architecture as well

Note that this is just a convenience addition to avoid having to fix it up manually. It doesn't change the previous behavior and should not bring any false positives either. 

- Related: https://ninjaparadedigital.com/blog/inertia-js-testing-configurations