### PR TITLE
Add Vite manifest to default version check

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -32,6 +32,10 @@ class Middleware
         if (file_exists($manifest = public_path('mix-manifest.json'))) {
             return md5_file($manifest);
         }
+        
+        if (file_exists($manifest = public_path('build/manifest.json'))) {
+            return md5_file($manifest);
+        }
     }
 
     /**


### PR DESCRIPTION
In the same spirit as https://github.com/inertiajs/inertia-laravel/pull/285, I'm trying to reduce friction for Vite users by enabling version checks by default on the Inertia side. 

This PR adds a fallback check for `public/build/manifest.json`, the same way the Mix manifest is checked. This path is the default for anyone using [Sebastian De Dayne's guide](https://sebastiandedeyne.com/vite-with-laravel/) or [Laravel Vite](https://laravel-vite.innocenzi.dev/guide/production.html#building-for-production). 

Notes:
- I think this change is good because this would be a "gotcha" in the sense that this functionality is easily forgotten (especially by newcomers), and that this doesn't cause a behavior change in any way
- I could've used an array instead of copying the three lines but I didn't want to add unnecessary complexity to the code
- Web manifests, usually `app.webmanifest` or `manifest.json`, are at the root of the public directory so they won't conflict