### PR TITLE
Check if $errors index 0 exists

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -145,7 +145,7 @@ class Middleware
 
         return (object) collect($request->session()->get('errors')->getBags())->map(function ($bag) {
             return (object) collect($bag->messages())->map(function ($errors) {
-                return $errors[0];
+                return array_key_exists(0, $errors) ? $errors[0] : false;
             })->toArray();
         })->pipe(function ($bags) use ($request) {
             if ($bags->has('default') && $request->header('x-inertia-error-bag')) {


### PR DESCRIPTION
**Context:**
I've created a helper in order to handle errors by class.
For some reasons, even though index 0 existed in $errors, the returned response was:
`Undefined array key 0 in file inertiajs\inertia-laravel\src\Middleware.php on line 148`

After using this fix no problems were encoutered.

**Fix:**
Added a simple check to see if index 0 exists in $errors.