### PR TITLE
feat: trigger event before sending response

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -101,7 +101,9 @@ class Response implements Responsable
             'version' => $this->version,
         ];
 
-        Event::dispatch('inertia.collected', [$page]);
+        if (env('APP_DEBUG', false)) {
+            Event::dispatch('inertia.debug', [$page]);
+        }
 
         if ($request->header('X-Inertia')) {
             return new JsonResponse($page, 200, [

--- a/src/Response.php
+++ b/src/Response.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Response as ResponseFactory;
 use Illuminate\Support\Traits\Macroable;
 
@@ -99,6 +100,8 @@ class Response implements Responsable
             'url' => $request->getRequestUri(),
             'version' => $this->version,
         ];
+
+        Event::dispatch('inertia.collected', [$page]);
 
         if ($request->header('X-Inertia')) {
             return new JsonResponse($page, 200, [

--- a/src/Response.php
+++ b/src/Response.php
@@ -101,7 +101,7 @@ class Response implements Responsable
             'version' => $this->version,
         ];
 
-        if (env('APP_DEBUG', false)) {
+        if (config('app.debug')) {
             Event::dispatch('inertia.debug', [$page]);
         }
 


### PR DESCRIPTION
This PR will trigger an event before the actual Inertia response it sent. The name of the event is up to discussion and maybe you have a better idea. Having this event it will be easy to implement a widget for the Debugbar to inspect the props.