### PR TITLE
Allow ResponseFactory location to be called with a redirect response

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response as BaseResponse;
 use Illuminate\Support\Traits\Macroable;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class ResponseFactory
 {
@@ -84,15 +83,15 @@ class ResponseFactory
     }
 
     public function location($url)
-    { 
+    {
         if ($url instanceof RedirectResponse) {
             $url = $url->getTargetUrl();
         }
-      
+
         if (Request::inertia()) {
             return BaseResponse::make('', 409, ['X-Inertia-Location' => $url]);
         }
-      
+
         return new RedirectResponse($url);
     }
 }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Response as BaseResponse;
 use Illuminate\Support\Traits\Macroable;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class ResponseFactory
 {
@@ -82,6 +83,10 @@ class ResponseFactory
 
     public function location($url)
     {
+        if ($url instanceof RedirectResponse) {
+            $url = $url->getTargetUrl();
+        }
+
         return BaseResponse::make('', 409, ['X-Inertia-Location' => $url]);
     }
 }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -9,6 +9,7 @@ use Inertia\Inertia;
 use Inertia\LazyProp;
 use Inertia\ResponseFactory;
 use Inertia\Tests\Stubs\ExampleMiddleware;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class ResponseFactoryTest extends TestCase
 {
@@ -25,6 +26,16 @@ class ResponseFactoryTest extends TestCase
     public function test_location_response()
     {
         $response = (new ResponseFactory())->location('https://inertiajs.com');
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(409, $response->getStatusCode());
+        $this->assertEquals('https://inertiajs.com', $response->headers->get('X-Inertia-Location'));
+    }
+
+    public function test_location_response_from_redirect()
+    {
+        $redirect = new RedirectResponse('https://inertiajs.com');
+        $response = (new ResponseFactory())->location($redirect);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(409, $response->getStatusCode());

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -11,7 +11,6 @@ use Inertia\Inertia;
 use Inertia\LazyProp;
 use Inertia\ResponseFactory;
 use Inertia\Tests\Stubs\ExampleMiddleware;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class ResponseFactoryTest extends TestCase
 {
@@ -37,7 +36,7 @@ class ResponseFactoryTest extends TestCase
         $this->assertEquals(Response::HTTP_CONFLICT, $response->getStatusCode());
         $this->assertEquals('https://inertiajs.com', $response->headers->get('X-Inertia-Location'));
     }
-  
+
     public function test_location_response_for_non_inertia_requests()
     {
         Request::macro('inertia', function () {
@@ -51,14 +50,28 @@ class ResponseFactoryTest extends TestCase
         $this->assertEquals('https://inertiajs.com', $response->headers->get('location'));
     }
 
-    public function test_location_response_from_redirect_response()
+    public function test_location_response_for_inertia_requests_using_redirect_response()
     {
+        Request::macro('inertia', function () {
+            return true;
+        });
+
         $redirect = new RedirectResponse('https://inertiajs.com');
         $response = (new ResponseFactory())->location($redirect);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(409, $response->getStatusCode());
         $this->assertEquals('https://inertiajs.com', $response->headers->get('X-Inertia-Location'));
+    }
+
+    public function test_location_response_for_non_inertia_requests_using_redirect_response()
+    {
+        $redirect = new RedirectResponse('https://inertiajs.com');
+        $response = (new ResponseFactory())->location($redirect);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
+        $this->assertEquals('https://inertiajs.com', $response->headers->get('location'));
     }
 
     public function test_the_version_can_be_a_closure()


### PR DESCRIPTION
This change allows the `Inertia::location()` method to accept a `RedirectResponse`.

In an app I'm developing using multiple subdomains I ran into the issue that I needed an external redirect after the authentication. Since I want to keep using the `redirect()->intended()` feature it feels natural to just pass in the whole `RedirectResponse` in the `location` method instead of manually getting the target url from the redirect.

Usage example:
```php
// Some controller action

return Inertia::location(
    redirect()->intended(RouteServiceProvider::HOME)
);
```

Please note that I'm using Symfony's `RedirectResponse` since Laravel's implementation just extends it.

Let me know what you think!