### PR TITLE
FIX: php 8.1 explode deprecation

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -60,7 +60,7 @@ class Response implements Responsable
 
     public function toResponse($request)
     {
-        $only = array_filter(explode(',', $request->header('X-Inertia-Partial-Data')));
+        $only = array_filter(explode(',', $request->header('X-Inertia-Partial-Data','')));
 
         $props = ($only && $request->header('X-Inertia-Partial-Component') === $this->component)
             ? Arr::only($this->props, $only)


### PR DESCRIPTION
Hi, this fixes a PHP 8.1 deprecation where null isn't allowed as 2nd parameter in the explode finction.

ErrorException
explode(): Passing null to parameter #2 ($string) of type string is deprecated
