### PR TITLE
fix!: handle non-inertia `location` redirects

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -4,8 +4,10 @@ namespace Inertia;
 
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response as BaseResponse;
 use Illuminate\Support\Traits\Macroable;
 
@@ -82,6 +84,10 @@ class ResponseFactory
 
     public function location($url)
     {
-        return BaseResponse::make('', 409, ['X-Inertia-Location' => $url]);
+        if (Request::inertia()) {
+            return BaseResponse::make('', 409, ['X-Inertia-Location' => $url]);
+        }
+
+        return new RedirectResponse($url);
     }
 }


### PR DESCRIPTION
Sometimes, we want to perform an external redirect that can be initiated on the first visit or on an Inertia visit.

In such a case, Inertia's `location` won't work because it will only simply return a normal `409` response with the `X-Inertia-Location`, but since the front-end is not loaded the end result will be a blank page. 

To fix this, we need to check if the current request is an Inertia one, perform the `location` redirect, or return a classic `RedirectResponse` otherwise. 

This PR fixes that issue by performing that check internally so the developer doesn't have to.

This is *technically* a breaking change since I had to modify the original test, but it's a breaking change that is more likely to fix issues than to create some.

---

TL;DR: with this PR, instead of doing:

```php
if (request()->inertia()) {
    return inertia()->location($url);
}

return redirect()->to($url);
```

We can just do:
```php
return inertia()->location($url);
```

---

Fixes https://github.com/inertiajs/inertia-laravel/issues/295

