### PR TITLE
refactor!: add `with` to `Response` and rename `with` to `withProperty`

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -9,6 +9,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Response as ResponseFactory;
+use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Traits\Macroable;
 
 class Response implements Responsable
@@ -29,7 +30,19 @@ class Response implements Responsable
         $this->version = $version;
     }
 
-    public function with($key, $value = null)
+    /**
+     * Flashes data to the session.
+     *
+     * @param string $key
+     */
+    public function with($key, $value = true)
+    {
+        Session::flash($key, $value);
+        
+        return $this;
+    }
+
+    public function withProperty($key, $value = null)
     {
         if (is_array($key)) {
             $this->props = array_merge($this->props, $key);

--- a/src/Response.php
+++ b/src/Response.php
@@ -33,12 +33,12 @@ class Response implements Responsable
     /**
      * Flashes data to the session.
      *
-     * @param string $key
+     * @param  string  $key
      */
     public function with($key, $value = true)
     {
         Session::flash($key, $value);
-        
+
         return $this;
     }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -72,7 +72,8 @@ class ResponseTest extends TestCase
 
         $user = (object) ['name' => 'Jonathan'];
 
-        $resource = new class($user) extends JsonResource {
+        $resource = new class($user) extends JsonResource
+        {
             public static $wrap = null;
 
             public function toArray($request)
@@ -106,7 +107,8 @@ class ResponseTest extends TestCase
         $callable = function () use ($users) {
             $page = new LengthAwarePaginator($users->take(2), $users->count(), 2);
 
-            return new class($page, JsonResource::class) extends ResourceCollection {
+            return new class($page, JsonResource::class) extends ResourceCollection
+            {
             };
         };
 
@@ -151,7 +153,8 @@ class ResponseTest extends TestCase
 
         $user = (object) ['name' => 'Jonathan'];
 
-        $resource = new class($user) implements Arrayable {
+        $resource = new class($user) implements Arrayable
+        {
             public $user;
 
             public function __construct($user)
@@ -266,7 +269,7 @@ class ResponseTest extends TestCase
             ->getOriginalContent();
 
         $name = $view->getData()['page']['props']['name'];
-        
+
         $this->assertEquals('Makise Kurisu', $name);
     }
 
@@ -278,9 +281,7 @@ class ResponseTest extends TestCase
             ->toResponse($request)
             ->getOriginalContent();
 
-
         $this->assertEmpty($view->getData()['page']['props']);
         $this->assertEquals('This functionality works', Session::get('success'));
     }
 }
-;


### PR DESCRIPTION
**Disclaimer**: this PR is totally a breaking change and I don't expect it to be merged right now, but I do believe it should be at some point. 

Basically, I've been bitten multiple times by using `with` on Inertia's `Response`, thinking it would behave the same as Laravel's `Response`. 

The difference is that Laravel's `Response@with` flashes the given data to the session, while Inertia's `Response@with` adds the given data to the response's props. 

To fix that issue, this PR renames Inertia's `Response@with` to `withProperty` and adds a new `with` that behaves the same as Laravel's `Response@with`.

```diff
- return Inertia::render('Users/List')->with('user', $user);
+ return Inertia::render('Users/List')->withProperty('user', $user);
```

```diff
- Session::flash('success', $successMessage);

- return Inertia::render('Users/List');
+ return Inertia::render('Users/List')->with('success', $successMessage);
```

I'm totally aware that this will be confusing for whoever actually uses `with` instead of passing the props to the second argument of the render method, that's why I'm wondering how we should go about this. Thankfully, this adapter is in 0.x so at some point that change can be done. 

I'd also like to point out that I'm not super comfortable with my implementation, I think that the session/request should be injected in another way than by using the facade, but I didn't want to make too much changes right away.