### PR TITLE
Fix CORS Issue with Laravel Passport

### DIFF
--- a/stubs/middleware.stub
+++ b/stubs/middleware.stub
@@ -2,8 +2,11 @@
 
 namespace {{ namespace }};
 
+use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Inertia\Middleware;
+use Inertia\Inertia;
 
 class {{ class }} extends Middleware
 {
@@ -39,5 +42,25 @@ class {{ class }} extends Middleware
         return array_merge(parent::share($request), [
             //
         ]);
+    }
+
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $response = parent::handle($request, $next);
+
+        $location = $response->headers->get('Location');
+
+        if (is_string($location) && !Str::of($location)->startsWith(config('app.url'))) {
+            return Inertia::location($location);
+        }
+
+        return $response;
     }
 }


### PR DESCRIPTION
Hello,

When using Laravel Passport on Jetstream powered with Inertia, I get a CORS issue because the callback URL is handled by Inertia with an AJAX Request.

![image](https://user-images.githubusercontent.com/6053012/143570510-f358851d-0a97-4069-b79f-c925480e59f5.png)

In order to solve it, I have modified my `HandleInertiaRequests` middleware to detect external locations and force redirections without AJAX.

