### PR TITLE
Fix page.url doesn't contain url prefix

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -96,7 +96,7 @@ class Response implements Responsable
         $page = [
             'component' => $this->component,
             'props' => $props,
-            'url' => $request->getRequestUri(),
+            'url' => $request->getBaseUrl().$request->getRequestUri(),
             'version' => $this->version,
         ];
 


### PR DESCRIPTION
[Laravel PR 40014](https://github.com/laravel/framework/pull/40014)

Same issue. This PR fixes the URL prefix problem in `src/Response.php`. Making us deploy Laravel + Inertia project in a subfolder of domain possible.