### PR TITLE
Migrate to AssertableJson (Laravel-core)

### DIFF
--- a/src/Testing/Assert.php
+++ b/src/Testing/Assert.php
@@ -38,7 +38,7 @@ class Assert implements Arrayable
         echo "\033[0;31m - If you are seeing this error while using \$response->assertInertia(...), please upgrade to Laravel 8.32.0 or higher.\033[0m\n";
         echo "\033[0;31m - If you are using the 'Assert' class directly, please adapt your tests to use the 'AssertableInertia' class instead.\033[0m\n";
         echo "\033[0;31mFor more information and questions, please see https://github.com/inertiajs/inertia-laravel/pull/338 \033[0m\n\n";
-        @trigger_error("Inertia's built-in 'Assert' library will be removed in a future version of inertia-laravel", \E_USER_DEPRECATED);
+        @trigger_error("Inertia's built-in 'Assert' library will be removed in a future version of inertia-laravel: https://github.com/inertiajs/inertia-laravel/pull/338", \E_USER_DEPRECATED);
 
         $this->path = $path;
 

--- a/src/Testing/Assert.php
+++ b/src/Testing/Assert.php
@@ -34,6 +34,12 @@ class Assert implements Arrayable
 
     protected function __construct(string $component, array $props, string $url, string $version = null, string $path = null)
     {
+        echo "\033[0;31mInertia's built-in 'Assert' library will be removed in a future version of inertia-laravel:\033[0m\n";
+        echo "\033[0;31m - If you are seeing this error while using \$response->assertInertia(...), please upgrade to Laravel 8.32.0 or higher.\033[0m\n";
+        echo "\033[0;31m - If you are using the 'Assert' class directly, please adapt your tests to use the 'AssertableInertia' class instead.\033[0m\n";
+        echo "\033[0;31mFor more information and questions, please see https://github.com/inertiajs/inertia-laravel/pull/334 \033[0m\n\n";
+        @trigger_error("Inertia's built-in 'Assert' library will be removed in a future version of inertia-laravel", \E_USER_DEPRECATED);
+
         $this->path = $path;
 
         $this->component = $component;

--- a/src/Testing/Assert.php
+++ b/src/Testing/Assert.php
@@ -37,7 +37,7 @@ class Assert implements Arrayable
         echo "\033[0;31mInertia's built-in 'Assert' library will be removed in a future version of inertia-laravel:\033[0m\n";
         echo "\033[0;31m - If you are seeing this error while using \$response->assertInertia(...), please upgrade to Laravel 8.32.0 or higher.\033[0m\n";
         echo "\033[0;31m - If you are using the 'Assert' class directly, please adapt your tests to use the 'AssertableInertia' class instead.\033[0m\n";
-        echo "\033[0;31mFor more information and questions, please see https://github.com/inertiajs/inertia-laravel/pull/334 \033[0m\n\n";
+        echo "\033[0;31mFor more information and questions, please see https://github.com/inertiajs/inertia-laravel/pull/338 \033[0m\n\n";
         @trigger_error("Inertia's built-in 'Assert' library will be removed in a future version of inertia-laravel", \E_USER_DEPRECATED);
 
         $this->path = $path;

--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Inertia\Testing;
+
+use Illuminate\Testing\Fluent\AssertableJson;
+use Illuminate\Testing\TestResponse;
+use InvalidArgumentException;
+use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\AssertionFailedError;
+
+class AssertableInertia extends AssertableJson
+{
+    /** @var string */
+    private $component;
+
+    /** @var string */
+    private $url;
+
+    /** @var string|null */
+    private $version;
+
+    public static function fromTestResponse(TestResponse $response): self
+    {
+        try {
+            $response->assertViewHas('page');
+            $page = json_decode(json_encode($response->viewData('page')), true);
+
+            PHPUnit::assertIsArray($page);
+            PHPUnit::assertArrayHasKey('component', $page);
+            PHPUnit::assertArrayHasKey('props', $page);
+            PHPUnit::assertArrayHasKey('url', $page);
+            PHPUnit::assertArrayHasKey('version', $page);
+        } catch (AssertionFailedError $e) {
+            PHPUnit::fail('Not a valid Inertia response.');
+        }
+
+        $instance = static::fromArray($page['props']);
+        $instance->component = $page['component'];
+        $instance->url = $page['url'];
+        $instance->version = $page['version'];
+
+        return $instance;
+    }
+
+    public function component(string $value = null, $shouldExist = null): self
+    {
+        PHPUnit::assertSame($value, $this->component, 'Unexpected Inertia page component.');
+
+        if ($shouldExist || (is_null($shouldExist) && config('inertia.testing.ensure_pages_exist', true))) {
+            try {
+                app('inertia.testing.view-finder')->find($value);
+            } catch (InvalidArgumentException $exception) {
+                PHPUnit::fail(sprintf('Inertia page component file [%s] does not exist.', $value));
+            }
+        }
+
+        return $this;
+    }
+
+    public function url(string $value): self
+    {
+        PHPUnit::assertSame($value, $this->url, 'Unexpected Inertia page url.');
+
+        return $this;
+    }
+
+    public function version(string $value): self
+    {
+        PHPUnit::assertSame($value, $this->version, 'Unexpected Inertia asset version.');
+
+        return $this;
+    }
+
+    public function toArray()
+    {
+        return [
+            'component' => $this->component,
+            'props' => $this->prop(),
+            'url' => $this->url,
+            'version' => $this->version,
+        ];
+    }
+}

--- a/src/Testing/TestResponseMacros.php
+++ b/src/Testing/TestResponseMacros.php
@@ -3,13 +3,18 @@
 namespace Inertia\Testing;
 
 use Closure;
+use Illuminate\Testing\Fluent\AssertableJson;
 
 class TestResponseMacros
 {
     public function assertInertia()
     {
         return function (Closure $callback = null) {
-            $assert = Assert::fromTestResponse($this);
+            if (class_exists(AssertableJson::class)) {
+                $assert = AssertableInertia::fromTestResponse($this);
+            } else {
+                $assert = Assert::fromTestResponse($this);
+            }
 
             if (is_null($callback)) {
                 return $this;
@@ -24,6 +29,10 @@ class TestResponseMacros
     public function inertiaPage()
     {
         return function () {
+            if (class_exists(AssertableJson::class)) {
+                return AssertableInertia::fromTestResponse($this)->toArray();
+            }
+
             return Assert::fromTestResponse($this)->toArray();
         };
     }

--- a/tests/Testing/AssertTest.php
+++ b/tests/Testing/AssertTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Collection;
+use Illuminate\Testing\Fluent\AssertableJson;
 use Inertia\Inertia;
 use Inertia\Testing\Assert;
 use Inertia\Tests\TestCase;
@@ -15,146 +16,13 @@ use TypeError;
 
 class AssertTest extends TestCase
 {
-    /** @test */
-    public function the_view_is_served_by_inertia(): void
+    public function setUp(): void
     {
-        $response = $this->makeMockRequest(
-            Inertia::render('foo')
-        );
+        parent::setUp();
 
-        $response->assertInertia();
-    }
-
-    /** @test */
-    public function the_view_is_not_served_by_inertia(): void
-    {
-        $response = $this->makeMockRequest(view('welcome'));
-        $response->assertOk(); // Make sure we can render the built-in Orchestra 'welcome' view..
-
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Not a valid Inertia response.');
-
-        $response->assertInertia();
-    }
-
-    /** @test */
-    public function the_component_matches(): void
-    {
-        $response = $this->makeMockRequest(
-            Inertia::render('foo')
-        );
-
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->component('foo');
-        });
-    }
-
-    /** @test */
-    public function the_component_does_not_match(): void
-    {
-        $response = $this->makeMockRequest(
-            Inertia::render('foo')
-        );
-
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unexpected Inertia page component.');
-
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->component('bar');
-        });
-    }
-
-    /** @test */
-    public function the_component_exists_on_the_filesystem(): void
-    {
-        $response = $this->makeMockRequest(
-            Inertia::render('Stubs/ExamplePage')
-        );
-
-        config()->set('inertia.testing.ensure_pages_exist', true);
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->component('Stubs/ExamplePage');
-        });
-    }
-
-    /** @test */
-    public function the_component_does_not_exist_on_the_filesystem(): void
-    {
-        $response = $this->makeMockRequest(
-            Inertia::render('foo')
-        );
-
-        config()->set('inertia.testing.ensure_pages_exist', true);
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Inertia page component file [foo] does not exist.');
-
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->component('foo');
-        });
-    }
-
-    /** @test */
-    public function it_can_force_enable_the_component_file_existence(): void
-    {
-        $response = $this->makeMockRequest(
-            Inertia::render('foo')
-        );
-
-        config()->set('inertia.testing.ensure_pages_exist', false);
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Inertia page component file [foo] does not exist.');
-
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->component('foo', true);
-        });
-    }
-
-    /** @test */
-    public function it_can_force_disable_the_component_file_existence_check(): void
-    {
-        $response = $this->makeMockRequest(
-            Inertia::render('foo')
-        );
-
-        config()->set('inertia.testing.ensure_pages_exist', true);
-
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->component('foo', false);
-        });
-    }
-
-    /** @test */
-    public function the_component_does_not_exist_on_the_filesystem_when_it_does_not_exist_relative_to_any_of_the_given_paths(): void
-    {
-        $response = $this->makeMockRequest(
-            Inertia::render('fixtures/ExamplePage')
-        );
-
-        config()->set('inertia.testing.ensure_pages_exist', true);
-        config()->set('inertia.testing.page_paths', [realpath(__DIR__)]);
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Inertia page component file [fixtures/ExamplePage] does not exist.');
-
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->component('fixtures/ExamplePage');
-        });
-    }
-
-    /** @test */
-    public function the_component_does_not_exist_on_the_filesystem_when_it_does_not_have_one_of_the_configured_extensions(): void
-    {
-        $response = $this->makeMockRequest(
-            Inertia::render('fixtures/ExamplePage')
-        );
-
-        config()->set('inertia.testing.ensure_pages_exist', true);
-        config()->set('inertia.testing.page_extensions', ['bin', 'exe', 'svg']);
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Inertia page component file [fixtures/ExamplePage] does not exist.');
-
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->component('fixtures/ExamplePage');
-        });
+        if (class_exists(AssertableJson::class)) {
+            $this->markTestSkipped("These tests are not applicable on Laravel 8.32 or newer, as Laravel's built-in AssertableJson is used instead.");
+        }
     }
 
     /** @test */
@@ -1199,64 +1067,6 @@ class AssertTest extends TestCase
                 'bar' => 2,
                 'baz' => 1,
             ]);
-        });
-    }
-
-    /** @test */
-    public function the_page_url_matches(): void
-    {
-        $response = $this->makeMockRequest(
-            Inertia::render('foo')
-        );
-
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->url('/example-url');
-        });
-    }
-
-    /** @test */
-    public function the_page_url_does_not_match(): void
-    {
-        $response = $this->makeMockRequest(
-            Inertia::render('foo')
-        );
-
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unexpected Inertia page url.');
-
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->url('/invalid-page');
-        });
-    }
-
-    /** @test */
-    public function the_asset_version_matches(): void
-    {
-        Inertia::version('example-version');
-
-        $response = $this->makeMockRequest(
-            Inertia::render('foo')
-        );
-
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->version('example-version');
-        });
-    }
-
-    /** @test */
-    public function the_asset_version_does_not_match(): void
-    {
-        Inertia::version('example-version');
-
-        $response = $this->makeMockRequest(
-            Inertia::render('foo')
-        );
-
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unexpected Inertia asset version.');
-
-        $response->assertInertia(function (Assert $inertia) {
-            $inertia->version('different-version');
         });
     }
 

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Inertia\Tests\Testing;
+
+use Inertia\Inertia;
+use Inertia\Tests\TestCase;
+use PHPUnit\Framework\AssertionFailedError;
+
+class AssertableInertiaTest extends TestCase
+{
+    /** @test */
+    public function the_view_is_served_by_inertia(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo')
+        );
+
+        $response->assertInertia();
+    }
+
+    /** @test */
+    public function the_view_is_not_served_by_inertia(): void
+    {
+        $response = $this->makeMockRequest(view('welcome'));
+        $response->assertOk(); // Make sure we can render the built-in Orchestra 'welcome' view..
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Not a valid Inertia response.');
+
+        $response->assertInertia();
+    }
+
+    /** @test */
+    public function the_component_matches(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo')
+        );
+
+        $response->assertInertia(function ($inertia) {
+            $inertia->component('foo');
+        });
+    }
+
+    /** @test */
+    public function the_component_does_not_match(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo')
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Unexpected Inertia page component.');
+
+        $response->assertInertia(function ($inertia) {
+            $inertia->component('bar');
+        });
+    }
+
+    /** @test */
+    public function the_component_exists_on_the_filesystem(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('Stubs/ExamplePage')
+        );
+
+        config()->set('inertia.testing.ensure_pages_exist', true);
+        $response->assertInertia(function ($inertia) {
+            $inertia->component('Stubs/ExamplePage');
+        });
+    }
+
+    /** @test */
+    public function the_component_does_not_exist_on_the_filesystem(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo')
+        );
+
+        config()->set('inertia.testing.ensure_pages_exist', true);
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia page component file [foo] does not exist.');
+
+        $response->assertInertia(function ($inertia) {
+            $inertia->component('foo');
+        });
+    }
+
+    /** @test */
+    public function it_can_force_enable_the_component_file_existence(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo')
+        );
+
+        config()->set('inertia.testing.ensure_pages_exist', false);
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia page component file [foo] does not exist.');
+
+        $response->assertInertia(function ($inertia) {
+            $inertia->component('foo', true);
+        });
+    }
+
+    /** @test */
+    public function it_can_force_disable_the_component_file_existence_check(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo')
+        );
+
+        config()->set('inertia.testing.ensure_pages_exist', true);
+
+        $response->assertInertia(function ($inertia) {
+            $inertia->component('foo', false);
+        });
+    }
+
+    /** @test */
+    public function the_component_does_not_exist_on_the_filesystem_when_it_does_not_exist_relative_to_any_of_the_given_paths(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('fixtures/ExamplePage')
+        );
+
+        config()->set('inertia.testing.ensure_pages_exist', true);
+        config()->set('inertia.testing.page_paths', [realpath(__DIR__)]);
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia page component file [fixtures/ExamplePage] does not exist.');
+
+        $response->assertInertia(function ($inertia) {
+            $inertia->component('fixtures/ExamplePage');
+        });
+    }
+
+    /** @test */
+    public function the_component_does_not_exist_on_the_filesystem_when_it_does_not_have_one_of_the_configured_extensions(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('fixtures/ExamplePage')
+        );
+
+        config()->set('inertia.testing.ensure_pages_exist', true);
+        config()->set('inertia.testing.page_extensions', ['bin', 'exe', 'svg']);
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia page component file [fixtures/ExamplePage] does not exist.');
+
+        $response->assertInertia(function ($inertia) {
+            $inertia->component('fixtures/ExamplePage');
+        });
+    }
+
+    /** @test */
+    public function the_page_url_matches(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo')
+        );
+
+        $response->assertInertia(function ($inertia) {
+            $inertia->url('/example-url');
+        });
+    }
+
+    /** @test */
+    public function the_page_url_does_not_match(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo')
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Unexpected Inertia page url.');
+
+        $response->assertInertia(function ($inertia) {
+            $inertia->url('/invalid-page');
+        });
+    }
+
+    /** @test */
+    public function the_asset_version_matches(): void
+    {
+        Inertia::version('example-version');
+
+        $response = $this->makeMockRequest(
+            Inertia::render('foo')
+        );
+
+        $response->assertInertia(function ($inertia) {
+            $inertia->version('example-version');
+        });
+    }
+
+    /** @test */
+    public function the_asset_version_does_not_match(): void
+    {
+        Inertia::version('example-version');
+
+        $response = $this->makeMockRequest(
+            Inertia::render('foo')
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Unexpected Inertia asset version.');
+
+        $response->assertInertia(function ($inertia) {
+            $inertia->version('different-version');
+        });
+    }
+}

--- a/tests/Testing/TestResponseMacrosTest.php
+++ b/tests/Testing/TestResponseMacrosTest.php
@@ -2,6 +2,7 @@
 
 namespace Inertia\Tests\Testing;
 
+use Illuminate\Testing\Fluent\AssertableJson;
 use Inertia\Inertia;
 use Inertia\Testing\Assert;
 use Inertia\Tests\TestCase;
@@ -17,7 +18,12 @@ class TestResponseMacrosTest extends TestCase
 
         $success = false;
         $response->assertInertia(function ($page) use (&$success) {
-            $this->assertInstanceOf(Assert::class, $page);
+            if (class_exists(AssertableJson::class)) {
+                $this->assertInstanceOf(AssertableJson::class, $page);
+            } else {
+                // TODO: Remove once built-in Assert library is removed.
+                $this->assertInstanceOf(Assert::class, $page);
+            }
             $success = true;
         });
 


### PR DESCRIPTION
This PR deprecated the assertion library introduced in #220.

Because we added Inertia's assertions to Laravel's core in https://github.com/laravel/framework/pull/36454, it no longer makes sense to maintain two separate versions of this. While it is true that Inertia pioneerd this assertion library, it has since matured as part of the Laravel framework.

In addition to reducing the maintenance effort for the Inertia team, the Laravel variant (by now) also has more features that users might want, [it's properly documented](https://laravel.com/docs/8.x/http-tests#fluent-json-testing), and has the benefit of automatically inheriting assertion macros that are registered by installed third-party packages.

# Differences
Do not worry, **the Laravel variant is nearly identical**. Here's all the differences: 
- The parameter type is different
- The `misses` / `missesAll` methods are named `missing` and `missingAll` instead
- Inertia-specific methods (`component`, `url`, `version`) are **only available on the top-level** when using the new `AssertableInertia` class, or when using `$response->assertInertia(function ($inertia) {`
- The Laravel / new variant has additional methods: [`whereType`](https://github.com/laravel/framework/commit/9981c774a20c9542bf6ed2482a6fe5e1eddc2d30#diff-d301e5322119ba823e76aecc3b468ff94d861dd303d53e30c436c6d2a1977ffc), [`whereContains`](https://github.com/laravel/framework/commit/2d2d108a21b21a149c797cb3995c3a25ac9b4be4#diff-d301e5322119ba823e76aecc3b468ff94d861dd303d53e30c436c6d2a1977ffc), [`each`](https://github.com/laravel/framework/commit/389cd2b9a4075750661d37a1691ecb074c7cfdae#diff-d301e5322119ba823e76aecc3b468ff94d861dd303d53e30c436c6d2a1977ffc) and the ability to do [shorthand-scoping without counting](https://github.com/laravel/framework/commit/fea2e5416f8e5f7fc09b2724d7a6cf4256dbef95#diff-d301e5322119ba823e76aecc3b468ff94d861dd303d53e30c436c6d2a1977ffc)

# Deprecating `Assert`
Right now (Dec 26th, 2021) the `Assert` version is still available, and the `AssertableInertia` is only automatically used on Laravel 8.32 or newer, but a deprecation notice/error will be shown during tests. 

In addition, strict parameter type hints **will crash** in existing tests. To solve this quickly, you can alias your import:

```php
// Before
use Inertia\Testing\Assert;

// After
use Inertia\Testing\AssertableInertia as Assert; 
```