### PR TITLE
Fix Github Actions test matrix (Laravel 9)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,9 @@ jobs:
         composerFlags: ['--prefer-lowest', '']
         exclude:
           - php: 7.2
-            laravel: [ ^8.74, ^9.0 ]
+            laravel: ^8.74
+          - php: 7.2
+            laravel: ^9.0
           - php: 7.3
             laravel: ^9.0
           - php: 7.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,11 @@ jobs:
         composerFlags: ['--prefer-lowest', '']
         exclude:
           - php: 7.2
-            laravel: ^8.74
+            laravel: [ ^8.74, ^9.0 ]
+          - php: 7.3
+            laravel: ^9.0
+          - php: 7.4
+            laravel: ^9.0
           - php: 8.1
             laravel: ^6.0
           - php: 8.1


### PR DESCRIPTION
While we've verified Laravel 9 support to be working already, we forgot to update the test matrix on Github, causing the tests to fail. This PR updates the matrix to allow the tests to properly execute again.