### PR TITLE
Clean up Github Actions tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require phpunit/phpunit:^9.5.8 --dev --${{ matrix.stability }} --no-interaction --no-update
+          command: composer require phpunit/phpunit:^9.5.8 --dev --${{ matrix.stability }} --no-interaction
         if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
 
       - name: Execute tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,20 +50,20 @@ jobs:
           max_attempts: 5
           command: composer require "laravel/framework=^${{ matrix.laravel }}" --no-interaction --no-update
           
+      - name: Set Minimum PHP 8.1 Versions
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require phpunit/phpunit:^9.5.8 --${{ matrix.stability }} --dev --no-interaction --no-update
+        if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
+          
       - name: Install dependencies
         uses: nick-invision/retry@v1
         with:
           timeout_minutes: 5
           max_attempts: 5
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
-          
-      - name: Fix Minimum PHP 8.1 Versions
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require phpunit/phpunit:^9.5.8 --${{ matrix.stability }} --dev --no-interaction --no-update --with-all-dependencies
-        if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,20 +50,20 @@ jobs:
           max_attempts: 5
           command: composer require "laravel/framework=^${{ matrix.laravel }}" --no-interaction --no-update
           
-      - name: Set Minimum PHP 8.1 Versions
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require phpunit/phpunit:^9.5.8 --${{ matrix.stability }} --no-interaction --no-update
-        if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
-          
       - name: Install dependencies
         uses: nick-invision/retry@v1
         with:
           timeout_minutes: 5
           max_attempts: 5
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+          
+      - name: Fix Minimum PHP 8.1 Versions
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require phpunit/phpunit:^9.5.8 --${{ matrix.stability }} --no-interaction --no-update --with-all-dependencies
+        if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           - php: 8.1
             laravel: 7
 
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} ${{ matrix.stability }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} (w/ ${{ matrix.stability }})
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -55,7 +55,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require phpunit/phpunit:^9.5.8 --no-interaction --no-update
+          command: composer require phpunit/phpunit:^9.5.8 --dev --no-interaction --no-update
         if: matrix.php >= 8.1
           
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,24 +12,24 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 7.2, 7.3, 7.4, 8.0, 8.1 ]
-        laravel: [ ^6.0, ^7.0, ^8.74, ^9.0 ]
-        composerFlags: ['--prefer-lowest', '']
+        php: [ 7.2, 7.3, 7.4, '8.0', 8.1 ]
+        laravel: [ 6, 8.74, 9 ]
+        stability: [prefer-lowest, prefer-stable]
         exclude:
           - php: 7.2
-            laravel: ^8.74
+            laravel: 8.74
           - php: 7.2
-            laravel: ^9.0
+            laravel: 9
           - php: 7.3
-            laravel: ^9.0
+            laravel: 9
           - php: 7.4
-            laravel: ^9.0
+            laravel: 9
           - php: 8.1
-            laravel: ^6.0
+            laravel: 6
           - php: 8.1
-            laravel: ^7.0
+            laravel: 7
 
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} ${{ matrix.composerFlags }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} ${{ matrix.stability }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -39,17 +39,31 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip
+          ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
-
-      - name: Install dependencies
-        run: |
-          composer require "laravel/framework=${{ matrix.laravel }}" --no-update
-          composer update --prefer-dist --no-interaction --no-progress ${{ matrix.composerFlags }}
-
+          
+      - name: Set Laravel version
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require "laravel/framework=^${{ matrix.laravel }}" --no-interaction --no-update
+          
       - name: Set Minimum PHP 8.1 Versions
-        run: composer require phpunit/phpunit:^9.5.8 --dev --with-all-dependencies --prefer-dist --no-interaction --no-progress --prefer-lowest
-        if: matrix.php == 8.1 && matrix.composerFlags == '--prefer-lowest'
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require phpunit/phpunit:^9.5.8 --no-interaction --no-update
+        if: matrix.php >= 8.1
+          
+      - name: Install dependencies
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         stability: ['prefer-lowest', 'prefer-stable']
         exclude:
           - php: 7.2
-            laravel: 8.74
+            laravel: 8
           - php: 7.2
             laravel: 9
           - php: 7.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,8 +48,8 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require league/commonmark:^2.0.2 phpunit/phpunit:^9.5.8 ramsey/collection:^1.2 brick/math:^0.9.3 --no-interaction --no-update
-        if: matrix.php >= 8.1
+          command: composer require phpunit/phpunit:^9.5.8 --${{ matrix.stability }} --no-interaction --no-update --with-all-dependencies
+        if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
           
       - name: Set Laravel version
         uses: nick-invision/retry@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           - php: 8.1
             laravel: 7
 
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} (w/ ${{ matrix.stability }})
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -49,14 +49,6 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer require "laravel/framework=^${{ matrix.laravel }}" --no-interaction --no-update
-          
-      - name: Set Minimum PHP 8.1 Versions
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require phpunit/phpunit:^9.5.8 --dev --no-interaction --no-update
-        if: matrix.php >= 8.1
           
       - name: Install dependencies
         uses: nick-invision/retry@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [ 7.2, 7.3, 7.4, '8.0', 8.1 ]
-        laravel: [ 6, 8.74, 9 ]
+        laravel: [ 6, 8, 9 ]
         stability: ['prefer-lowest', 'prefer-stable']
         exclude:
           - php: 7.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,14 @@ jobs:
           tools: composer:v2
           coverage: none
           
+      - name: Set Minimum PHP 8.1 Versions
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require league/commonmark:^2.0.2 phpunit/phpunit:^9.5.8 ramsey/collection:^1.2 brick/math:^0.9.3 --no-interaction --no-update
+        if: matrix.php >= 8.1
+          
       - name: Set Laravel version
         uses: nick-invision/retry@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,14 @@ jobs:
           tools: composer:v2
           coverage: none
           
+      - name: Set Minimum PHP 8.1 Versions
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require phpunit/phpunit:^9.5.8 --dev --${{ matrix.stability }} --no-update --no-interaction
+        if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
+          
       - name: Set Laravel version
         uses: nick-invision/retry@v1
         with:
@@ -55,15 +63,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ matrix.stability }} --no-interaction --no-progress
-          
-      - name: Set Minimum PHP 8.1 Versions
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require phpunit/phpunit:^9.5.8 --dev --${{ matrix.stability }} --no-interaction
-        if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
+          command: composer update --${{ matrix.stability }} --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,20 +43,20 @@ jobs:
           tools: composer:v2
           coverage: none
           
-      - name: Set Minimum PHP 8.1 Versions
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require phpunit/phpunit:^9.5.8 --${{ matrix.stability }} --no-interaction --no-update --with-all-dependencies
-        if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
-          
       - name: Set Laravel version
         uses: nick-invision/retry@v1
         with:
           timeout_minutes: 5
           max_attempts: 5
           command: composer require "laravel/framework=^${{ matrix.laravel }}" --no-interaction --no-update
+          
+      - name: Set Minimum PHP 8.1 Versions
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require phpunit/phpunit:^9.5.8 --${{ matrix.stability }} --no-interaction --no-update
+        if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
           
       - name: Install dependencies
         uses: nick-invision/retry@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           - php: 8.1
             laravel: 7
 
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} (w/ ${{ matrix.stability }})
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         php: [ 7.2, 7.3, 7.4, '8.0', 8.1 ]
         laravel: [ 6, 8.74, 9 ]
-        stability: [prefer-lowest, prefer-stable]
+        stability: ['prefer-lowest', 'prefer-stable']
         exclude:
           - php: 7.2
             laravel: 8.74
@@ -50,20 +50,20 @@ jobs:
           max_attempts: 5
           command: composer require "laravel/framework=^${{ matrix.laravel }}" --no-interaction --no-update
           
-      - name: Set Minimum PHP 8.1 Versions
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require phpunit/phpunit:^9.5.8 --${{ matrix.stability }} --dev --no-interaction --no-update
-        if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
-          
       - name: Install dependencies
         uses: nick-invision/retry@v1
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+          command: composer update --${{ matrix.stability }} --no-interaction --no-progress
+          
+      - name: Set Minimum PHP 8.1 Versions
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require phpunit/phpunit:^9.5.8 --dev --${{ matrix.stability }} --no-interaction --no-update
+        if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,9 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require phpunit/phpunit:^9.5.8 --dev --${{ matrix.stability }} --no-update --no-interaction
+          command: |
+            composer require phpunit/phpunit:^9.5.8 --dev --${{ matrix.stability }} --no-update --no-interaction
+            composer require vlucas/phpdotenv:^5.3.1 --${{ matrix.stability }} --no-update --no-interaction
         if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
           
       - name: Set Laravel version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require phpunit/phpunit:^9.5.8 --${{ matrix.stability }} --no-interaction --no-update --with-all-dependencies
+          command: composer require phpunit/phpunit:^9.5.8 --${{ matrix.stability }} --dev --no-interaction --no-update --with-all-dependencies
         if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
 
       - name: Execute tests


### PR DESCRIPTION
This PR cleans up the Github Actions stack, and pins the dependencies to the very, very lowest possible.

On PHP 8.1:
- `phpunit/phpunit:^9.5.8` was required due to their minimum version constraint on PHP `>=7.3`, which essentially translates to them promising that _every_ PHPUnit 9.5 release (9.5.0, 9.5.1, 9.5.2 etc..) are essentially just PHPUnit changes, but are 1000000% compatible with _every PHP version after 7.2 going forward_ and are guaranteed to not break, even on PHP versions that don't exist yet. Because this promise obviously can't be kept, things broke in PHP 8.1, preventing you from doing `--prefer-lowest` and ending up with a working install.
- `vlucas/phpdotenv:^5.3.1` was required due to their dependency `graham-campbell/result-type:^1.0.1` having a dependency on `phpoption/phpoption:^1.7.3` that wasn't compatible with PHP 8.1. This was fixed in `graham-campbell/result-type:^1.0.2` by updating to `phpoption/phpoption:^1.8`, which was then used in `vlucas/phpdotenv:^5.3.1`

By manually specifying that we only want these specific versions or newer, we get versions where compatibility is actually fixed, making things work as far as necessary.