### PR TITLE
Redirect back when an Inertia response is empty (customizable)

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -83,77 +83,57 @@ class Middleware
         });
 
         Inertia::share($this->share($request));
-
         Inertia::setRootView($this->rootView($request));
 
         $response = $next($request);
-        $response = $this->changeEmptyToRedirect($request, $response);
-        $response = $this->checkVersion($request, $response);
 
-        return $this->changeRedirectCode($request, $response);
-    }
-
-    /**
-     * Changes empty/no-response Inertia requests to redirects back.
-     *
-     * @param  Request  $request
-     * @param  Response  $response
-     * @return Response
-     */
-    public function changeEmptyToRedirect(Request $request, Response $response)
-    {
-        if ($request->header('X-Inertia') &&
-            $response->getStatusCode() === 200 &&
-            empty($response->getContent())
-        ) {
-            return Redirect::back(303);
+        if (! $request->header('X-Inertia')) {
+            return $response;
         }
 
-        return $response;
-    }
-
-    /**
-     * In the event that the assets change, initiate a
-     * client-side location visit to force an update.
-     *
-     * @param  Request  $request
-     * @param  Response  $response
-     * @return Response
-     */
-    public function checkVersion(Request $request, Response $response)
-    {
-        if ($request->header('X-Inertia') &&
-            $request->method() === 'GET' &&
-            $request->header('X-Inertia-Version', '') !== Inertia::getVersion()
-        ) {
-            if ($request->hasSession()) {
-                $request->session()->reflash();
-            }
-
-            return Inertia::location($request->fullUrl());
+        if ($request->method() === 'GET' && $request->header('X-Inertia-Version', '') !== Inertia::getVersion()) {
+            $response = $this->onVersionChange($request, $response);
         }
 
-        return $response;
-    }
+        if ($response->isOk() && empty($response->getContent())) {
+            $response = $this->onEmptyResponse($request, $response);
+        }
 
-    /**
-     * Changes the status code during redirects, ensuring they are made as
-     * GET requests, preventing "MethodNotAllowedHttpException" errors.
-     *
-     * @param  Request  $request
-     * @param  Response  $response
-     * @return Response
-     */
-    public function changeRedirectCode(Request $request, Response $response)
-    {
-        if ($request->header('X-Inertia') &&
-            $response->getStatusCode() === 302 &&
-            in_array($request->method(), ['PUT', 'PATCH', 'DELETE'])
-        ) {
+        if ($response->getStatusCode() === 302 && in_array($request->method(), ['PUT', 'PATCH', 'DELETE'])) {
             $response->setStatusCode(303);
         }
 
         return $response;
+    }
+
+    /**
+     * Determines what to do when an Inertia action returned with no response.
+     * By default, we'll redirect the user back to where they came from.
+     *
+     * @param  Request  $request
+     * @param  Response  $response
+     * @return Response
+     */
+    public function onEmptyResponse(Request $request, Response $response): Response
+    {
+        return Redirect::back();
+    }
+
+    /**
+     * Determines what to do when the Inertia asset version has changed.
+     * By default, we'll initiate a client-side location visit to force an update.
+     *
+     * @param  Request  $request
+     * @param  Response  $response
+     * @return Response
+     */
+    public function onVersionChange(Request $request, Response $response): Response
+    {
+        if ($request->hasSession()) {
+            $request->session()->reflash();
+        }
+
+        return Inertia::location($request->fullUrl());
     }
 
     /**
@@ -163,7 +143,7 @@ class Middleware
      * @param  Request  $request
      * @return object
      */
-    public function resolveValidationErrors(Request $request)
+    protected function resolveValidationErrors(Request $request)
     {
         if (! $request->session()->has('errors')) {
             return (object) [];

--- a/stubs/middleware.stub
+++ b/stubs/middleware.stub
@@ -40,4 +40,17 @@ class {{ class }} extends Middleware
             //
         ]);
     }
+
+    /**
+     * Determines what to do when an Inertia action returned with no response.
+     * By default, we'll redirect the user back to where they came from.
+     *
+     * @param  Request  $request
+     * @param  Response  $response
+     * @return Response
+     */
+    public function onEmptyResponse(Request $request, Response $response): Response
+    {
+        return parent::onEmptyResponse($request, $response);
+    }
 }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -14,16 +14,16 @@ use Inertia\Tests\Stubs\ExampleMiddleware;
 
 class MiddlewareTest extends TestCase
 {
-    public function test_no_response_value_means_redirect_back_for_inertia_requests(): void
+    public function test_no_response_value_by_default_means_automatically_redirecting_back_for_inertia_requests(): void
     {
         $fooCalled = false;
-        Route::middleware(Middleware::class)->get('/', function () use (&$fooCalled) {
+        Route::middleware(Middleware::class)->put('/', function () use (&$fooCalled) {
             $fooCalled = true;
         });
 
         $response = $this
             ->from('/foo')
-            ->get('/', [
+            ->put('/', [], [
                 'X-Inertia' => 'true',
                 'Content-Type' => 'application/json',
             ]);
@@ -33,16 +33,34 @@ class MiddlewareTest extends TestCase
         $this->assertTrue($fooCalled);
     }
 
+    public function test_no_response_value_can_be_customized_by_overriding_the_middleware_method(): void
+    {
+        Route::middleware(ExampleMiddleware::class)->get('/', function () {
+            // Do nothing..
+        });
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('An empty Inertia response was returned.');
+
+        $this
+            ->withoutExceptionHandling()
+            ->from('/foo')
+            ->get('/', [
+                'X-Inertia' => 'true',
+                'Content-Type' => 'application/json',
+            ]);
+    }
+
     public function test_no_response_means_no_response_for_non_inertia_requests(): void
     {
         $fooCalled = false;
-        Route::middleware(Middleware::class)->get('/', function () use (&$fooCalled) {
+        Route::middleware(Middleware::class)->put('/', function () use (&$fooCalled) {
             $fooCalled = true;
         });
 
         $response = $this
             ->from('/foo')
-            ->get('/', [
+            ->put('/', [], [
                 'Content-Type' => 'application/json',
             ]);
 

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -14,6 +14,42 @@ use Inertia\Tests\Stubs\ExampleMiddleware;
 
 class MiddlewareTest extends TestCase
 {
+    public function test_no_response_value_means_redirect_back_for_inertia_requests(): void
+    {
+        $fooCalled = false;
+        Route::middleware(Middleware::class)->get('/', function () use (&$fooCalled) {
+            $fooCalled = true;
+        });
+
+        $response = $this
+            ->from('/foo')
+            ->get('/', [
+                'X-Inertia' => 'true',
+                'Content-Type' => 'application/json',
+            ]);
+
+        $response->assertRedirect('/foo');
+        $response->assertStatus(303);
+        $this->assertTrue($fooCalled);
+    }
+
+    public function test_no_response_means_no_response_for_non_inertia_requests(): void
+    {
+        $fooCalled = false;
+        Route::middleware(Middleware::class)->get('/', function () use (&$fooCalled) {
+            $fooCalled = true;
+        });
+
+        $response = $this
+            ->from('/foo')
+            ->get('/', [
+                'Content-Type' => 'application/json',
+            ]);
+
+        $response->assertNoContent(200);
+        $this->assertTrue($fooCalled);
+    }
+
     public function test_the_version_is_optional(): void
     {
         $this->prepareMockEndpoint();

--- a/tests/Stubs/ExampleMiddleware.php
+++ b/tests/Stubs/ExampleMiddleware.php
@@ -4,6 +4,7 @@ namespace Inertia\Tests\Stubs;
 
 use Illuminate\Http\Request;
 use Inertia\Middleware;
+use Symfony\Component\HttpFoundation\Response;
 
 class ExampleMiddleware extends Middleware
 {
@@ -47,5 +48,18 @@ class ExampleMiddleware extends Middleware
     public function share(Request $request): array
     {
         return array_merge(parent::share($request), $this->shared);
+    }
+
+    /**
+     * Determines what to do when an Inertia action returned with no response.
+     * By default, we'll redirect the user back to where they came from.
+     *
+     * @param  Request  $request
+     * @param  Response  $response
+     * @return Response
+     */
+    public function onEmptyResponse(Request $request, Response $response): Response
+    {
+        throw new \LogicException('An empty Inertia response was returned.');
     }
 }


### PR DESCRIPTION
This PR automatically converts empty Inertia controller/action responses to Inertia redirects back. 

This prevents the need to manually specify the `redirect()->back();` at the bottom of all of your actions, keeping your code a little bit simpler. Do note that this doesn't mean you _have to_ stop redirecting back manually if you prefer to have a consistent return value, but it does provide the option to omit it for those who'd rather not do it everywhere.

This behavior is customizable by customizing the `onEmptyResponse` method that's now part of the Middleware.
You can, for example, render an error page of your own using `Inertia::render()`, or throw an exception.