### PR TITLE
Fix incorrect type hint in render method

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -85,7 +85,7 @@ class ResponseFactory
         return new LazyProp($callback);
     }
 
-    /** 
+    /**
      * @param  string  $component
      * @param  array|Arrayable  $props
      */

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -85,7 +85,7 @@ class ResponseFactory
         return new LazyProp($callback);
     }
 
-    public function render($component, array|Arrayable $props = []): Response
+    public function render($component, $props = []): Response
     {
         if ($props instanceof Arrayable) {
             $props = $props->toArray();

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -85,7 +85,7 @@ class ResponseFactory
         return new LazyProp($callback);
     }
 
-    public function render($component, array $props = []): Response
+    public function render($component, array|Arrayable $props = []): Response
     {
         if ($props instanceof Arrayable) {
             $props = $props->toArray();

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -86,8 +86,8 @@ class ResponseFactory
     }
 
     /** 
-     * @param string          $component
-     * @param array|Arrayable $props
+     * @param  string  $component
+     * @param  array|Arrayable  $props
      */
     public function render($component, $props = []): Response
     {

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -85,6 +85,10 @@ class ResponseFactory
         return new LazyProp($callback);
     }
 
+    /** 
+     * @param string          $component
+     * @param array|Arrayable $props
+     */
     public function render($component, $props = []): Response
     {
         if ($props instanceof Arrayable) {

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -138,7 +138,8 @@ class ResponseFactoryTest extends TestCase
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
             Inertia::share('foo', 'bar');
 
-            return Inertia::render('User/Edit', new class implements Arrayable {
+            return Inertia::render('User/Edit', new class implements Arrayable 
+            {
                 public function toArray()
                 {
                     return [

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -142,7 +142,7 @@ class ResponseFactoryTest extends TestCase
                 public function toArray()
                 {
                     return [
-                        'user' => 'rhys'
+                        'foo' => 'bar'
                     ];
                 }
             });
@@ -153,7 +153,7 @@ class ResponseFactoryTest extends TestCase
         $response->assertJson([
             'component' => 'User/Edit',
             'props' => [
-                'user' => 'rhys'
+                'foo' => 'bar'
             ],
         ]);
     }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -138,7 +138,7 @@ class ResponseFactoryTest extends TestCase
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
             Inertia::share('foo', 'bar');
 
-            return Inertia::render('User/Edit', new class implements Arrayable 
+            return Inertia::render('User/Edit', new class implements Arrayable
             {
                 public function toArray()
                 {

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -2,8 +2,8 @@
 
 namespace Inertia\Tests;
 
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Request;
@@ -138,11 +138,11 @@ class ResponseFactoryTest extends TestCase
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
             Inertia::share('foo', 'bar');
 
-            return Inertia::render('User/Edit',  new class implements Arrayable {
+            return Inertia::render('User/Edit', new class implements Arrayable {
                 public function toArray()
                 {
                     return [
-                        'foo' => 'bar'
+                        'foo' => 'bar',
                     ];
                 }
             });
@@ -153,7 +153,7 @@ class ResponseFactoryTest extends TestCase
         $response->assertJson([
             'component' => 'User/Edit',
             'props' => [
-                'foo' => 'bar'
+                'foo' => 'bar',
             ],
         ]);
     }


### PR DESCRIPTION
Fixes #352 

Inertia has always supported passing `Arrayable` objects for props. The type hint added recently broke this feature. ~~This PR adds `Arrayable` to the typehint.~~ I've removed the type hint because older php versions don't support union types