### PR TITLE
Add ifInertiaSSR blade directive

### DIFF
--- a/src/Directive.php
+++ b/src/Directive.php
@@ -64,7 +64,7 @@ class Directive
 
             if (isset($__inertiaSsr) && $__inertiaSsr instanceof \Inertia\Ssr\Response ):
         ?>';
-        
+
         return implode(' ', array_map('trim', explode("\n", $template)));
     }
 }

--- a/src/Directive.php
+++ b/src/Directive.php
@@ -49,4 +49,22 @@ class Directive
 
         return implode(' ', array_map('trim', explode("\n", $template)));
     }
+
+    /**
+     * Compiles the "@ifInertiaSSR" directive.
+     *
+     * @return string
+     */
+    public static function compileIfInertiaSSR($expression = ''): string
+    {
+        $template = '<?php
+            if (!isset($__inertiaSsr)) {
+                $__inertiaSsr = app(\Inertia\Ssr\Gateway::class)->dispatch($page);
+            }
+
+            if (isset($__inertiaSsr) && $__inertiaSsr instanceof \Inertia\Ssr\Response ):
+        ?>';
+        
+        return implode(' ', array_map('trim', explode("\n", $template)));
+    }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -54,6 +54,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         Blade::directive('inertia', [Directive::class, 'compile']);
         Blade::directive('inertiaHead', [Directive::class, 'compileHead']);
+        Blade::directive('ifInertiaSSR', [Directive::class, 'compileIfInertiaSSR']);
     }
 
     protected function registerConsoleCommands(): void


### PR DESCRIPTION
This PR adds a `ifInertiaSSR` blade directive which provides a way to check if the app is running in SSR.
```blade
@ifInertiaSSR
   My app is running in SSR mode! 🚀
@else
   My app is not running in SSR 😥
@endif
```

This also helps new users who're trying to use SSR for the first time and struggle to figure out if they're using SSR or not.