### PR TITLE
Add Realtime Validation feature

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -149,9 +149,8 @@ class ResponseFactory
                 );
                 $validator->validate();
             }
-            // We throw this exception to stop the controller from continuing
-            // Since at this point, we know the request has a 'X-Inertia-Validate' header
-            // And because we're doing real-time validation, we don't want the controller to continue
+            // We throw this exception because at this point, we know the request has a 'X-Inertia-Validate' header
+            // And since we're doing a real-time validation, we don't want the controller to continue
             throw \Illuminate\Validation\ValidationException::withMessages([]);
         }
     }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -133,9 +133,9 @@ class ResponseFactory
                     $attributes[] = $key;
                 }
             }
-            if (Request::has(['_realtimeValidation', $attributes])) {
-                $realtimeValidator = \Illuminate\Support\Facades\Validator::make(
-                    Request::except('_realtimeValidation'),
+            if (Request::has($attributes) && Request::hasHeader('X-Inertia-Real-Time-Validation')) {
+                $realtimeValidator = validator(
+                    Request::only($attributes),
                     collect($rules)->map(function ($rule, $attribute) {
                         if (is_string($rule)) {
                             $rule = explode('|', $rule);

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -9,8 +9,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response as BaseResponse;
-use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Traits\Macroable;
 
 class ResponseFactory
 {
@@ -127,17 +127,22 @@ class ResponseFactory
      */
     public function realtimeValidation($rules = []): bool
     {
-        if(Request::has('_realtimeValidation')){
+        if (Request::has('_realtimeValidation')) {
             $realtimeValidator = Validator::make(
                 Request::except('_realtimeValidation'),
-                collect($rules)->map(function ($rule, $attribute) use ($rules) {
-                    if (is_string($rule)) $rule = explode('|', $rule);
-                    if (! in_array('sometimes', $rule)) array_unshift($rule, 'sometimes');
+                collect($rules)->map(function ($rule, $attribute) {
+                    if (is_string($rule)) {
+                        $rule = explode('|', $rule);
+                    }
+                    if (! in_array('sometimes', $rule)) {
+                        array_unshift($rule, 'sometimes');
+                    }
+
                     return $rule;
                 })->toArray()
             );
             $realtimeValidator->validate();
-            if(!$realtimeValidator->fails()) {
+            if (! $realtimeValidator->fails()) {
                 return true;
             }
         }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -127,7 +127,13 @@ class ResponseFactory
      */
     public function realtimeValidation($rules = []): bool
     {
-        if (Request::has('_realtimeValidation')) {
+        $attributes = [];
+        foreach ($rules as $key => $value) {
+            if (is_string($key)) {
+                $attributes[] = $key;
+            }
+        }
+        if (Request::has(['_realtimeValidation', $attributes])) {
             $realtimeValidator = Validator::make(
                 Request::except('_realtimeValidation'),
                 collect($rules)->map(function ($rule, $attribute) {

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -136,16 +136,8 @@ class ResponseFactory
             if (! empty($inertia_validate) && ! empty($rules)) {
                 $validator = validator(
                     Request::only($inertia_validate),
-                    collect($rules)->map(function ($rule, $attribute) {
-                        if (is_string($rule)) {
-                            $rule = explode('|', $rule);
-                        }
-                        if (! in_array('sometimes', $rule)) {
-                            array_unshift($rule, 'sometimes');
-                        }
-
-                        return $rule;
-                    })->toArray()
+                    // Only pass the rules that are present in the 'X-Inertia-Validate' header
+                    array_intersect_key($rules, array_flip($inertia_validate))
                 );
                 $validator->validate();
             }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -146,6 +146,7 @@ class ResponseFactory
                 return true;
             }
         }
+
         return false;
     }
 }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -126,7 +126,7 @@ class ResponseFactory
      */
     public function realtimeValidation($rules = []): void
     {
-        if (!empty($rules)) {
+        if (! empty($rules)) {
             $attributes = [];
             foreach ($rules as $key => $value) {
                 if (is_string($key)) {
@@ -143,12 +143,12 @@ class ResponseFactory
                         if (! in_array('sometimes', $rule)) {
                             array_unshift($rule, 'sometimes');
                         }
-    
+
                         return $rule;
                     })->toArray()
                 );
                 $realtimeValidator->validate();
-    
+
                 if (! $realtimeValidator->fails()) {
                     throw new \Illuminate\Validation\ValidationException($realtimeValidator);
                 }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response as BaseResponse;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Facades\Validator;
 
 class ResponseFactory
 {
@@ -118,5 +119,28 @@ class ResponseFactory
         }
 
         return new RedirectResponse($url);
+    }
+
+    /**
+     * @param  array|Arrayable  $rules
+     * @return bool
+     */
+    public function realtimeValidation($rules = []): bool
+    {
+        if(Request::has('_realtimeValidation')){
+            $realtimeValidator = Validator::make(
+                Request::except('_realtimeValidation'),
+                collect($rules)->map(function ($rule, $attribute) use ($rules) {
+                    if (is_string($rule)) $rule = explode('|', $rule);
+                    if (! in_array('sometimes', $rule)) array_unshift($rule, 'sometimes');
+                    return $rule;
+                })->toArray()
+            );
+            $realtimeValidator->validate();
+            if(!$realtimeValidator->fails()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -124,7 +124,7 @@ class ResponseFactory
      * @param  array|Arrayable  $rules
      * @return void
      */
-    public function realtimeValidation($rules = []): void
+    public function validate($rules = []): void
     {
         if (! empty($rules)) {
             $attributes = [];
@@ -133,8 +133,8 @@ class ResponseFactory
                     $attributes[] = $key;
                 }
             }
-            if (Request::has($attributes) && Request::hasHeader('X-Inertia-Real-Time-Validation')) {
-                $realtimeValidator = validator(
+            if (Request::has($attributes) && Request::hasHeader('X-Inertia-Validate')) {
+                $validator = validator(
                     Request::only($attributes),
                     collect($rules)->map(function ($rule, $attribute) {
                         if (is_string($rule)) {
@@ -147,10 +147,10 @@ class ResponseFactory
                         return $rule;
                     })->toArray()
                 );
-                $realtimeValidator->validate();
+                $validator->validate();
 
-                if (! $realtimeValidator->fails()) {
-                    throw new \Illuminate\Validation\ValidationException($realtimeValidator);
+                if (! $validator->fails()) {
+                    throw new \Illuminate\Validation\ValidationException($validator);
                 }
             }
         }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -124,7 +124,7 @@ class ResponseFactory
      * @param  array|Arrayable  $rules
      * @return void
      */
-    public function validate($rules = []): void
+    public function validate($rules = [], $messages = []): void
     {
         if (Request::hasHeader('X-Inertia-Validate')) {
             // We extract the attribute names from the $rules
@@ -137,7 +137,8 @@ class ResponseFactory
                 $validator = validator(
                     Request::only($inertia_validate),
                     // Only pass the rules that are present in the 'X-Inertia-Validate' header
-                    array_intersect_key($rules, array_flip($inertia_validate))
+                    array_intersect_key($rules, array_flip($inertia_validate)),
+                    $messages
                 );
                 $validator->validate();
             }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -126,30 +126,32 @@ class ResponseFactory
      */
     public function realtimeValidation($rules = []): void
     {
-        $attributes = [];
-        foreach ($rules as $key => $value) {
-            if (is_string($key)) {
-                $attributes[] = $key;
+        if (!empty($rules)) {
+            $attributes = [];
+            foreach ($rules as $key => $value) {
+                if (is_string($key)) {
+                    $attributes[] = $key;
+                }
             }
-        }
-        if (Request::has(['_realtimeValidation', $attributes])) {
-            $realtimeValidator = \Illuminate\Support\Facades\Validator::make(
-                Request::except('_realtimeValidation'),
-                collect($rules)->map(function ($rule, $attribute) {
-                    if (is_string($rule)) {
-                        $rule = explode('|', $rule);
-                    }
-                    if (! in_array('sometimes', $rule)) {
-                        array_unshift($rule, 'sometimes');
-                    }
-
-                    return $rule;
-                })->toArray()
-            );
-            $realtimeValidator->validate();
-
-            if (! $realtimeValidator->fails()) {
-                throw new \Illuminate\Validation\ValidationException($realtimeValidator);
+            if (Request::has(['_realtimeValidation', $attributes])) {
+                $realtimeValidator = \Illuminate\Support\Facades\Validator::make(
+                    Request::except('_realtimeValidation'),
+                    collect($rules)->map(function ($rule, $attribute) {
+                        if (is_string($rule)) {
+                            $rule = explode('|', $rule);
+                        }
+                        if (! in_array('sometimes', $rule)) {
+                            array_unshift($rule, 'sometimes');
+                        }
+    
+                        return $rule;
+                    })->toArray()
+                );
+                $realtimeValidator->validate();
+    
+                if (! $realtimeValidator->fails()) {
+                    throw new \Illuminate\Validation\ValidationException($realtimeValidator);
+                }
             }
         }
     }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response as BaseResponse;
-use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Traits\Macroable;
 
 class ResponseFactory
@@ -123,9 +122,9 @@ class ResponseFactory
 
     /**
      * @param  array|Arrayable  $rules
-     * @return bool
+     * @return void
      */
-    public function realtimeValidation($rules = []): bool
+    public function realtimeValidation($rules = []): void
     {
         $attributes = [];
         foreach ($rules as $key => $value) {
@@ -134,7 +133,7 @@ class ResponseFactory
             }
         }
         if (Request::has(['_realtimeValidation', $attributes])) {
-            $realtimeValidator = Validator::make(
+            $realtimeValidator = \Illuminate\Support\Facades\Validator::make(
                 Request::except('_realtimeValidation'),
                 collect($rules)->map(function ($rule, $attribute) {
                     if (is_string($rule)) {
@@ -148,11 +147,10 @@ class ResponseFactory
                 })->toArray()
             );
             $realtimeValidator->validate();
+
             if (! $realtimeValidator->fails()) {
-                return true;
+                throw new \Illuminate\Validation\ValidationException($realtimeValidator);
             }
         }
-
-        return false;
     }
 }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -143,6 +143,7 @@ class ResponseFactory
                         if (! in_array('sometimes', $rule)) {
                             array_unshift($rule, 'sometimes');
                         }
+
                         return $rule;
                     })->toArray()
                 );


### PR DESCRIPTION
Based on this [PR](https://github.com/inertiajs/inertia/pull/1061). This PR introduces the backend support for the client-side feature.

You simply pass your validation rules to the `Inertia::validate()` function like so:
```php
// Your controller
public function store()
{
   Inertia::validate([
      'first_name' => ['required', 'min:3'],
      'last_name' => ['required', 'max:3'],
   ], [
     'required' => 'The :attribute field is required.', // You can pass custom validation message
   ]);

   // Execution doesn't reach here if validation fails.
   // Also if you pass call `validate` method with no arguments, nothing will happen

   // Further controller logic
}
```

- [x] Re-write the current implementation with a more optimal solution ( Thanks to @innocenzi )
- [x] Improve support/check for validation rules
- [x] Remove the usage of `sometimes` rule and use a different approach
- [x] Add support for custom validation messages
- [ ] Add support for input values that depend on other fields such as `{field}_confirmation`, `required_if`
- [ ] Add support for FormRequests

The current implementation may not be very optimal and will probably be tuned in future commits, so if you have any ideas on how to improve this, don't hesitate to share them!