### PR TITLE
feat(ssr): support timeout option

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -22,6 +22,8 @@ return [
 
         'url' => 'http://127.0.0.1:13714/render',
 
+        'timeout' => 1,
+
     ],
 
     /*

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -21,9 +21,13 @@ class HttpGateway implements Gateway
         }
 
         $url = Config::get('inertia.ssr.url', 'http://127.0.0.1:13714/render');
+        $timeout = Config::get('inertia.ssr.timeout', 0);
 
         try {
-            $response = Http::post($url, $page)->throw()->json();
+            $response = Http::withOptions(['connect_timeout' => $timeout])
+                ->post($url, $page)
+                ->throw()
+                ->json();
         } catch (Exception $e) {
             return null;
         }


### PR DESCRIPTION
This PR adds an `inertia.ssr.timeout` option that allows for specifying the `connect_timeout` of the `Http` gateway. 

This is useful for developing locally without the SSR server enabled, as we can set a short timeout to avoid waiting 5 seconds for the page to load.