### PR TITLE
Fix regression introduced in #337

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -77,7 +77,7 @@ class ServiceProvider extends BaseServiceProvider
     protected function registerRouterMacro(): void
     {
         Router::macro('inertia', function ($uri, $component, $props = []) {
-            return $this->match(['GET', 'HEAD'], $uri, Controller::class)
+            return $this->match(['GET', 'HEAD'], $uri, '\Inertia\Controller')
                 ->defaults('component', $component)
                 ->defaults('props', $props);
         });

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -5,7 +5,6 @@ namespace Inertia\Tests;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
-use Inertia\Controller;
 
 class ServiceProviderTest extends TestCase
 {
@@ -34,7 +33,7 @@ class ServiceProviderTest extends TestCase
         $this->assertEquals($route, $routes->getRoutes()[0]);
         $this->assertEquals(['GET', 'HEAD'], $route->methods);
         $this->assertEquals('/', $route->uri);
-        $this->assertEquals(['uses' => 'Inertia\Controller@__invoke', 'controller' => Controller::class], $route->action);
+        $this->assertEquals(['uses' => '\Inertia\Controller@__invoke', 'controller' => '\Inertia\Controller'], $route->action);
         $this->assertEquals(['component' => 'User/Edit', 'props' => ['user' => ['name' => 'Jonathan']]], $route->defaults);
     }
 }


### PR DESCRIPTION
We cannot upgrade Inertia from 4.5.0 to 5.x as this introduces a new issue on our software.

### Issue

![image](https://user-images.githubusercontent.com/2331052/153864854-79567bf4-da57-40c8-b785-8b376a643fc2.png)

### Scenario

This is a piece of what we've in our `app/Providers/RouteServiceProvider.php`

```php
   /**
     * These namespaces is applied to your controller routes.
     *
     * In addition, it is set as the URL generator's root namespace.
     *
     * @var array
     */
    protected $namespaces = [
        'web' => 'App\Http\Controllers',
        'api' => 'App\Http\Controllers\Api',
    ];

    /**
     * Define your route model bindings, pattern filters, etc.
     *
     * @return void
     */
    public function boot()
    {
        $this->configureRateLimiting();
        $this->configureRoutePatters();

        $this->routes(function () {
            Route::middleware('web')
                ->namespace($this->namespaces['web'])
                ->group(base_path('routes/web.php'));

            Route::prefix('api')
                ->middleware('api')
                ->namespace($this->namespaces['api'])
                ->group(base_path('routes/api.php'));
        });
    }
```

So having this namespace customised for our `web.php` routes file generates this issue of Laravel not detecting that the Inertia **route controller from the macro its actually relative and not absolute as it was before**.

This could also happen with anything that modifies the namespace like route groups, etc. So I think is better having this as a string.
