### PR TITLE
feat: add `toHtml` to `Inertia\Response`

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -77,6 +77,17 @@ class Response implements Responsable
 
         return $this;
     }
+    
+    /**
+     * Returns the HTML for this view.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     */
+    public function toHtml($request)
+    {
+        return $this->toResponse($request ?? app('request'))->getContent();
+    }
 
     /**
      * Create an HTTP response that represents the object.

--- a/src/Response.php
+++ b/src/Response.php
@@ -77,7 +77,7 @@ class Response implements Responsable
 
         return $this;
     }
-    
+
     /**
      * Returns the HTML for this view.
      *


### PR DESCRIPTION
This PR adds a new `toHtml` method to `Inertia\Response`. The use case is to get the HTML for an Inertia response, just like you would do with Blade:

```php
// With Blade
view('path.to.view')->render();

// With Inertia 
inertia('path.to.view')->toHtml();
```

Currently, you would need to do the following:

```php
// Directly
inertia('path.to.view')
    ->toResponse(request())
    ->getContent();

// With a macro
Response::macro('toHtml', function (Request $request = null): string {
    return $this->toResponse($request ?? app('request'))->getContent();
});

inertia('path.to.view')->toHtml();
```

The use case that I frequently meet is to generate PDF files with Browsershot using Inertia. This method is a more convenient way to get the HTML for a specific Inertia view.

Note: I would have called it `render` like the Blade one, but it would conflict with `Inertia\ResponseFactory#render` when using the `inertia` helper.