### PR TITLE
Repeat BaseUrl in navigation

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -99,7 +99,7 @@ class Response implements Responsable
         $page = [
             'component' => $this->component,
             'props' => $props,
-            'url' => $request->getBaseUrl().$request->getRequestUri(),
+            'url' => $request->getRequestUri(),
             'version' => $this->version,
         ];
 


### PR DESCRIPTION
concat $request->getBaseUrl() and $request->getRequestUri()  is unreasonable。