### PR TITLE
Fix redirect when PUT/PATCH/DELETE route called while unauthenticated

### DIFF
--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -33,6 +33,25 @@ class MiddlewareTest extends TestCase
         $this->assertTrue($fooCalled);
     }
 
+    public function test_inertia_delete_request_while_unauthenticated_should_redirect_using_see_other(): void
+    {
+        Route::middleware('auth', Middleware::class)->delete('/', function () {
+            // Do nothing..
+        });
+        Route::get('/login', function () {
+            // Do nothing..
+        })->name('login');
+
+        $response = $this
+            ->from('/foo')
+            ->delete('/', [], [
+                'X-Inertia' => 'true',
+            ]);
+
+        $response->assertRedirect('/login');
+        $response->assertStatus(303);
+    }
+
     public function test_no_response_value_can_be_customized_by_overriding_the_middleware_method(): void
     {
         Route::middleware(ExampleMiddleware::class)->get('/', function () {


### PR DESCRIPTION
The Laravel auth middleware is executed before the `HandleInertiaRequests` middleware, this means when an unauthenticated exception happens Inertia does not interfere. This is an issue when, for example, a DELETE request is made while the user is unauthenticated, since Inertia does not change the statuscode of the redirect from 302 to 303, resulting in a `MethodNotAllowedHttpException`. This PR fixes the issue by letting Inertia decide how the `AuthenticationException` is rendered.

Steps to reproduce:
- Login
- In devtools delete your cookies
- Click on an Inertia DELETE link, the route has to have the `auth` middleware
- The DELETE request is made, then a 302 is returned to `/login`, which is made with as a DELETE request

I found it the easiest to reproduce with a new Laravel project, installed Jetstream, logged in and went to the profile page. There I deleted the cookies and clicked on "Delete account", filled in a random password and then the exception shows

This discussion inertiajs/inertia#1130 explains it in a bit more detail. I thought Inertia would convert the redirect appropriately, but the Inertia middleware is actually never executed