### PR TITLE
skip validating errors if session isn't loaded

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -145,7 +145,7 @@ class Middleware
      */
     public function resolveValidationErrors(Request $request)
     {
-        if (! $request->session()->has('errors')) {
+        if (! $request->hasSession() || ! $request->session()->has('errors')) {
             return (object) [];
         }
 


### PR DESCRIPTION
This change prevents an error occurring when the middleware is used in a group that doesn't load run `StartSession`