### PR TITLE
Fix `render` method docblock on facade

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -2,6 +2,7 @@
 
 namespace Inertia;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Facade;
 
 /**
@@ -12,7 +13,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void version($version)
  * @method static int|string getVersion()
  * @method static LazyProp lazy(callable $callback)
- * @method static Response render($component, array $props = [])
+ * @method static Response render($component, array|Arrayable $props = [])
  * @method static \Illuminate\Http\Response location(string $url)
  *
  * @see \Inertia\ResponseFactory


### PR DESCRIPTION
The render method can take an array or an Arrayable.
This inconsistency was introduced when #353 was merged.

If we're unhappy with this due to union types, I would suggest we look at merging #377