### PR TITLE
Register directives only when Blade is actually needed

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,7 +5,6 @@ namespace Inertia;
 use Illuminate\Foundation\Testing\TestResponse as LegacyTestResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
-use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Illuminate\Testing\TestResponse;
 use Illuminate\View\FileViewFinder;
@@ -27,6 +26,7 @@ class ServiceProvider extends BaseServiceProvider
             'inertia'
         );
 
+        $this->registerBladeDirectives();
         $this->registerRequestMacro();
         $this->registerRouterMacro();
         $this->registerTestingMacros();
@@ -42,7 +42,6 @@ class ServiceProvider extends BaseServiceProvider
 
     public function boot(): void
     {
-        $this->registerBladeDirectives();
         $this->registerConsoleCommands();
 
         $this->publishes([
@@ -52,8 +51,10 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function registerBladeDirectives(): void
     {
-        Blade::directive('inertia', [Directive::class, 'compile']);
-        Blade::directive('inertiaHead', [Directive::class, 'compileHead']);
+        $this->callAfterResolving('blade.compiler', function ($blade) {
+            $blade->directive('inertia', [Directive::class, 'compile']);
+            $blade->directive('inertiaHead', [Directive::class, 'compileHead']);
+        });
     }
 
     protected function registerConsoleCommands(): void


### PR DESCRIPTION
Hey 👋

Thanks so much for creating Inertia. Today, I finally got the chance to try it out.
Everything went smoothly, but something caught my eye in the `ServiceProvider`.

According to [this line in Response](https://github.com/inertiajs/inertia-laravel/blob/master/src/Response.php#L113), Inertia is only making use of `BladeCompiler` for its very first render. After that, Blade is never touched.

However, due to the way things are handled in the `ServiceProvider`, `BladeCompiler` is instantiated for **every request** even when it's not needed. This PR fixes that by leveraging the events provided by the IoC Container. `callAfterResolving` is available since Laravel 6, so it's fully backwards compatible.

Thanks!