### PR TITLE
Set `Vary: Accept` header for HTML responses

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -87,6 +87,8 @@ class Middleware
 
         $response = $next($request);
 
+        $response->header('Vary', 'Accept');
+
         if (! $request->header('X-Inertia')) {
             return $response;
         }

--- a/src/Response.php
+++ b/src/Response.php
@@ -104,10 +104,7 @@ class Response implements Responsable
         ];
 
         if ($request->header('X-Inertia')) {
-            return new JsonResponse($page, 200, [
-                'Vary' => 'Accept',
-                'X-Inertia' => 'true',
-            ]);
+            return new JsonResponse($page, 200, ['X-Inertia' => 'true']);
         }
 
         return ResponseFactory::view($this->rootView, $this->viewData + ['page' => $page]);


### PR DESCRIPTION
Currently we only set the `Vary: Accept` header for Inertia (JSON) responses, however we also need to set this header for standard full page HTML responses as well, otherwise it causes issues in Safari.

These issues may include seeing JSON on a page instead of rendered HTML, or getting an Inertia modal (only meant for showing errors) for proper Inertia pages.

This mostly worked previously because we set the `Vary: Accept` header on all Inertia (JSON) responses, and I guess most browsers were able to figure it out based on that, but Safari is a little more particular and requires it to be on both the Inertia (JSON) responses as well as the standard full page HTML responses.

This PR actually updates ever single response to include this header — even those that are not Inertia endpoints at all. This feels maybe a little heavy handed, but from my testing this seems to be required, as it appears to even be required on redirect responses that end up on Inertia endpoints.