### PR TITLE
Add asset versioning for default build location using vite

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -36,6 +36,10 @@ class Middleware
             return md5_file($manifest);
         }
 
+        if (file_exists($manifest = public_path('build/manifest.json'))) {
+            return md5_file($manifest);
+        }
+
         return null;
     }
 


### PR DESCRIPTION
When mix is not used for asset compilation, chances are high that vite is used instead.
That's why I think it makes sense to add the default location that vite builds to as a
fallback for when now mix-manifest is available.

https://laravel-vite.dev/guide/essentials/building-for-production.html#build-path contains
some information about the default production build using laravel-vite.