### PR TITLE
Switch to using the `Vary: X-Inertia` header

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -86,8 +86,7 @@ class Middleware
         Inertia::setRootView($this->rootView($request));
 
         $response = $next($request);
-
-        $response->header('Vary', 'Accept');
+        $response->headers->set('Vary', 'X-Inertia');
 
         if (! $request->header('X-Inertia')) {
             return $response;


### PR DESCRIPTION
Fixes #400
Fixes #401

This PR fixes an issue where the `$response->header()` method wasn't available for all possible response types — in particular those that come from HTTP Foundation like `HttpFoundation\StreamedResponse` and `HttpFoundation\BinaryFileResponse`. Now we're using `$response->headers->set()`, which is available everywhere.

This PR also updates the `Vary` header to use `X-Inertia` instead of `Accept`. While `Accept` previously worked, I think this was largely by coincidence (luck), because of the difference between the browser's default accept header and Inertia's XHR accept header:

Browser:
```
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
```

Inertia (see [here](https://github.com/inertiajs/inertia/blob/055c928e84dd25434db2dca5ed4f2551cc969638/packages/inertia/src/router.ts#L291)):
```
Accept: text/html, application/xhtml+xml
```

Doing some digging into how the `Vary` header works tonight, I realized that I can technically tell it to use whatever header I want to help the browser differentiate between the HTML version of a page and the Inertia JSON version of a page. And since the thing that really matters here is whether the `X-Inertia` header is set, this feels like the more correct approach.