### PR TITLE
Preserve props on partial reloads

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static LazyProp lazy(callable $callback)
  * @method static Response render($component, array|Arrayable $props = [])
  * @method static \Symfony\Component\HttpFoundation\Response location(string $url)
+ * @method static void preserveProps(array $props = [])
  *
  * @see \Inertia\ResponseFactory
  */

--- a/src/Response.php
+++ b/src/Response.php
@@ -24,19 +24,22 @@ class Response implements Responsable
     protected $rootView;
     protected $version;
     protected $viewData = [];
+    protected $preservedProps = [];
 
     /**
      * @param  string  $component
      * @param  array|Arrayable  $props
      * @param  string  $rootView
      * @param  string  $version
+     * @param  array  $preservedProps
      */
-    public function __construct(string $component, $props, string $rootView = 'app', string $version = '')
+    public function __construct(string $component, $props, string $rootView = 'app', string $version = '', array $preservedProps = [])
     {
         $this->component = $component;
         $this->props = $props instanceof Arrayable ? $props->toArray() : $props;
         $this->rootView = $rootView;
         $this->version = $version;
+        $this->preservedProps = $preservedProps;
     }
 
     /**
@@ -89,7 +92,7 @@ class Response implements Responsable
         $only = array_filter(explode(',', $request->header('X-Inertia-Partial-Data', '')));
 
         $props = ($only && $request->header('X-Inertia-Partial-Component') === $this->component)
-            ? Arr::only($this->props, $only)
+            ? Arr::only($this->props, array_merge($only, $this->preservedProps))
             : array_filter($this->props, static function ($prop) {
                 return ! ($prop instanceof LazyProp);
             });

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -126,7 +126,7 @@ class ResponseFactory
 
     /**
      * @param  array  $value
-     * @return void 
+     * @return void
      */
     public function preserveProps(array $props = []): void
     {

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -24,6 +24,9 @@ class ResponseFactory
     /** @var Closure|string|null */
     protected $version;
 
+    /** @var array */
+    protected $preservedProps = [];
+
     public function setRootView(string $name): void
     {
         $this->rootView = $name;
@@ -100,7 +103,8 @@ class ResponseFactory
             $component,
             array_merge($this->sharedProps, $props),
             $this->rootView,
-            $this->getVersion()
+            $this->getVersion(),
+            $this->preservedProps
         );
     }
 
@@ -118,5 +122,14 @@ class ResponseFactory
         }
 
         return new RedirectResponse($url);
+    }
+
+    /**
+     * @param  array  $value
+     * @return void 
+     */
+    public function preserveProps(array $props = []): void
+    {
+        $this->preservedProps = $props;
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -292,6 +292,22 @@ class ResponseTest extends TestCase
         $this->assertSame('A lazy value', $page->props->lazy);
     }
 
+    public function test_preserved_props_are_included_in_partial_reload(): void
+    {
+        $request = Request::create('/users', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Partial-Component' => 'Users']);
+        $request->headers->add(['X-Inertia-Partial-Data' => 'partial']);
+
+        $response = new Response('Users', ['users' => [], 'partial' => 'partial-data', 'alert' => 'alert-data'], 'app', '123', ['alert']);
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $this->assertObjectNotHasAttribute('users', $page->props);
+        $this->assertSame('alert-data', $page->props->alert);
+        $this->assertSame('partial-data', $page->props->partial);
+    }
+
     public function test_top_level_dot_props_get_unpacked(): void
     {
         $props = [


### PR DESCRIPTION
This PR introduces an ability to preserve properties on partial reloads even if they aren't specified on a request.

```php
Inertia::preserveProperties(['alert']);
```

While `only` is great within a context, there could be a global state with properties that need to present on every `get` request. So, it makes sense to control them from a backend to ensure that required props are always present on the response. 

Examples:
- Alert notifications
- Popups (onboarding)
- Auth user data

So, any global state that's independent of a current context.