### PR TITLE
add dumpInertia() testing method

### DIFF
--- a/_ide_helpers.php
+++ b/_ide_helpers.php
@@ -10,6 +10,7 @@ namespace Illuminate\Testing {
      * @see \Inertia\Testing\TestResponseMacros
      *
      * @method self assertInertia(\Closure $assert = null)
+     * @method self dumpInertia(string $key = null)
      */
     class TestResponse
     {
@@ -23,6 +24,7 @@ namespace Illuminate\Foundation\Testing {
      * @see \Inertia\Testing\TestResponseMacros
      *
      * @method self assertInertia(\Closure $assert = null)
+     * @method self dumpInertia(string $key = null)
      */
     class TestResponse
     {

--- a/src/Testing/TestResponseMacros.php
+++ b/src/Testing/TestResponseMacros.php
@@ -3,6 +3,7 @@
 namespace Inertia\Testing;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Illuminate\Testing\Fluent\AssertableJson;
 
 class TestResponseMacros
@@ -34,6 +35,25 @@ class TestResponseMacros
             }
 
             return Assert::fromTestResponse($this)->toArray();
+        };
+    }
+
+    public function dumpInertia()
+    {
+        return function (string $key = null) {
+            if (class_exists(AssertableJson::class)) {
+                $data = AssertableInertia::fromTestResponse($this)->toArray();
+            } else {
+                $data = Assert::fromTestResponse($this)->toArray();
+            }
+
+            if (is_null($key)) {
+                dump($data);
+            } else {
+                dump(Arr::get($data, "props.{$key}"));
+            }
+
+            return $this;
         };
     }
 }


### PR DESCRIPTION
This pull request intent is to add a new `dumpInertia(string $key = null)` method to TestResponseMacros file. Existing testing methods like `dump()`, `dumpSession()`, `dumpHeaders()` are very convenient in Laravel testing.

If parameter is not set, then all of the Inertia data will be printed (component, props, url, version, ...).
If parameter is set, then props property content will be printed (accepting dot-notation thanks to `Arr:get()`)