### PR TITLE
fix: subdirectory project link error

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -99,7 +99,7 @@ class Response implements Responsable
         $page = [
             'component' => $this->component,
             'props' => $props,
-            'url' => $request->getBaseUrl().$request->getRequestUri(),
+            'url' => $request->fullUrl(),
             'version' => $this->version,
         ];
 


### PR DESCRIPTION
Working on a project I noticed that when I was under a sub directory the links were generated in a strange way.

Example:

http://www.example.com/project1/first-page

I try to navigate to second-page, it generates this:

http://www.example.com/project1/project1/second-page
