### PR TITLE
Merge shared data recursively for arrays as well

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -36,9 +36,9 @@ class ResponseFactory
     public function share($key, $value = null): void
     {
         if (is_array($key)) {
-            $this->sharedProps = array_merge($this->sharedProps, $key);
+            $this->sharedProps = array_merge_recursive($this->sharedProps, $key);
         } elseif ($key instanceof Arrayable) {
-            $this->sharedProps = array_merge($this->sharedProps, $key->toArray());
+            $this->sharedProps = array_merge_recursive($this->sharedProps, $key->toArray());
         } else {
             Arr::set($this->sharedProps, $key, $value);
         }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -158,4 +158,44 @@ class ResponseFactoryTest extends TestCase
             ],
         ]);
     }
+
+    public function test_shared_key_value_data_is_merged_recursively(): void
+    {
+        Inertia::share([
+            'foo' => [
+                'bar' => 'baz'
+            ],
+        ]);
+
+        Inertia::share('foo.qux', 'quux');
+
+        $this->assertSame([
+            'foo' => [
+                'bar' => 'baz',
+                'qux' => 'quux',
+            ]
+        ], Inertia::getShared());
+    }
+
+    public function test_shared_array_data_is_merged_recursively(): void
+    {
+        Inertia::share([
+            'foo' => [
+                'bar' => 'baz'
+            ],
+        ]);
+
+        Inertia::share([
+            'foo' => [
+                'qux' => 'quux',
+            ],
+        ]);
+
+        $this->assertSame([
+            'foo' => [
+                'bar' => 'baz',
+                'qux' => 'quux',
+            ]
+        ], Inertia::getShared());
+    }
 }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -163,7 +163,7 @@ class ResponseFactoryTest extends TestCase
     {
         Inertia::share([
             'foo' => [
-                'bar' => 'baz'
+                'bar' => 'baz',
             ],
         ]);
 
@@ -173,7 +173,7 @@ class ResponseFactoryTest extends TestCase
             'foo' => [
                 'bar' => 'baz',
                 'qux' => 'quux',
-            ]
+            ],
         ], Inertia::getShared());
     }
 
@@ -181,7 +181,7 @@ class ResponseFactoryTest extends TestCase
     {
         Inertia::share([
             'foo' => [
-                'bar' => 'baz'
+                'bar' => 'baz',
             ],
         ]);
 
@@ -195,7 +195,7 @@ class ResponseFactoryTest extends TestCase
             'foo' => [
                 'bar' => 'baz',
                 'qux' => 'quux',
-            ]
+            ],
         ], Inertia::getShared());
     }
 }


### PR DESCRIPTION
`Inertia::share()` accepts an array, an Arrayable or `($key, $value)` arguments.

In the latter, `Arr::set()` is being used, resulting in the key-value being _added_ to existing shared props.
In the first two invocations the entire argument _replaces_ existing props.

Let's treat all scenarios equally. I'd go for always adding (and hence merging recursively) to the existing props because it'll allow calling `Inertia::share()` anywhere multiple times (e.g. multiple middleware sharing each their own piece of shareable data).