### PR TITLE
Allow Inertia\Response rebinding in user-land

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -97,10 +97,10 @@ class ResponseFactory
         }
 
         return app()->make(Response::class, [
-            "component" => $component,
-            "props" => array_merge($this->sharedProps, $props),
-            "rootView" => $this->rootView,
-            "version" => $this->getVersion(),
+            'component' => $component,
+            'props' => array_merge($this->sharedProps, $props),
+            'rootView' => $this->rootView,
+            'version' => $this->getVersion(),
         ]);
     }
 

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -96,12 +96,12 @@ class ResponseFactory
             $props = $props->toArray();
         }
 
-        return new Response(
-            $component,
-            array_merge($this->sharedProps, $props),
-            $this->rootView,
-            $this->getVersion()
-        );
+        return app()->make(Response::class, [
+            "component" => $component,
+            "props" => array_merge($this->sharedProps, $props),
+            "rootView" => $this->rootView,
+            "version" => $this->getVersion(),
+        ]);
     }
 
     /**


### PR DESCRIPTION
For some specific use case, I would be able to override the `Inertia\Response` class to add some project-specific helpers, that can't be achievable with `Inertia::shared()`.

Switching from `new Response` to `app()->make(Response::class)` in ResponseFactory would let us (as project user) rebind the Response class in a Service provider :

```php
$this->app->bind(\Inertia\Response::class, CustomInertiaResponse::class);
```

This PR doesn't introduce breaking changes.
