### PR TITLE
Output json when TestResponse contains an exception

### DIFF
--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -31,6 +31,9 @@ class AssertableInertia extends AssertableJson
             PHPUnit::assertArrayHasKey('url', $page);
             PHPUnit::assertArrayHasKey('version', $page);
         } catch (AssertionFailedError $e) {
+            if ($response->exception) {
+                $response->json();
+            }
             PHPUnit::fail('Not a valid Inertia response.');
         }
 


### PR DESCRIPTION
This pull request outputs a console friendly json response when AssertableInertia is passed an Illuminate\Testing\TestResponse containing an exception.

#### Current Behavior
Tests utilizing the AssertableInertia class return all unhandled exceptions with the same 'Not a valid Inertia response' message. This limited information makes troubleshooting a failing test cumbersome. 

To identify the actual problem I typically need to rerun the test with `->dump()` chained on before the call to assertInertia. This workaround is not ideal as 1) it dumps the Ignition response as raw html/css and 2) is not possible to do in a CI pipeline.

For example:
```php
    $this->get(route('posts.index'))->dump()
        ->assertInertia(fn(AssertableInertia $page) => $page
            ->component('Posts/Index')
        );
```