### PR TITLE
Add `inertia:start-ssr` and `inertia:stop-ssr` artisan commands

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -20,7 +20,9 @@ return [
 
         'enabled' => false,
 
-        'url' => 'http://127.0.0.1:13714/render',
+        'url' => 'http://127.0.0.1:13714',
+
+        'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
 
     ],
 

--- a/src/Console/StartSsr.php
+++ b/src/Console/StartSsr.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Inertia\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+
+class StartSsr extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'inertia:start-ssr';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Start the Inertia SSR server';
+
+    /**
+     * Start the SSR server via a Node process.
+     */
+    public function handle()
+    {
+        $ssrBundle = config('inertia.ssr.bundle', base_path('bootstrap/ssr/ssr.mjs'));
+
+        if (! file_exists($ssrBundle)) {
+            $this->error('Inertia SSR bundle not found: '.$ssrBundle);
+            $this->info('Set the correct Inertia SSR bundle path in your `inertia.ssr.bundle` config.');
+
+            return 1;
+        }
+
+        $process = new Process(['node', $ssrBundle]);
+        $process->setTimeout(null);
+        $process->start();
+
+        foreach ($process as $type => $data) {
+            if ($process::OUT === $type) {
+                $this->info(trim($data));
+            } else {
+                $this->error(trim($data));
+            }
+        }
+    }
+}

--- a/src/Console/StopSsr.php
+++ b/src/Console/StopSsr.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Inertia\Console;
+
+use Illuminate\Console\Command;
+
+class StopSsr extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'inertia:stop-ssr';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Stop the Inertia SSR server';
+
+    /**
+     * Stop the SSR server.
+     */
+    public function handle()
+    {
+        $url = str_replace('/render', '', config('inertia.ssr.url', 'http://127.0.0.1:13714')).'/shutdown';
+
+        $ch = curl_init($url);
+        curl_exec($ch);
+
+        if (curl_error($ch) === 'Empty reply from server') {
+            $this->info('Inertia SSR server stopped.');
+        } else {
+            $this->error('Unable to connect to Inertia SSR server.');
+
+            return 1;
+        }
+
+        curl_close($ch);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -65,6 +65,8 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->commands([
             Console\CreateMiddleware::class,
+            Console\StartSsr::class,
+            Console\StopSsr::class,
         ]);
     }
 

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -3,24 +3,20 @@
 namespace Inertia\Ssr;
 
 use Exception;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 
 class HttpGateway implements Gateway
 {
     /**
      * Dispatch the Inertia page to the Server Side Rendering engine.
-     *
-     * @param  array  $page
-     * @return Response|null
      */
     public function dispatch(array $page): ?Response
     {
-        if (! Config::get('inertia.ssr.enabled', false)) {
+        if (! config('inertia.ssr.enabled', false)) {
             return null;
         }
 
-        $url = Config::get('inertia.ssr.url', 'http://127.0.0.1:13714/render');
+        $url = str_replace('/render', '', config('inertia.ssr.url', 'http://127.0.0.1:13714')).'/render';
 
         try {
             $response = Http::post($url, $page)->throw()->json();


### PR DESCRIPTION
This PR adds two new Inertia artisan commands for starting and stopping the Inertia SSR server:

```bash
# start the SSR server
php artisan inertia:start-ssr

# stop the SSR server
php artisan inertia:stop-ssr
```

The goal here is to simplify the SSR setup, removing the need to add these commands to your `package.json` scripts.

```diff
  "scripts": {
    "dev": "vite",
    "build": "vite build && vite build --ssr",
-   "ssr:serve": "node bootstrap/ssr/ssr.mjs",
-   "ssr:shutdown": "[ $(curl -s 'http://localhost:13714/shutdown'; echo $?) -eq 52 ]"
  },
```

This update includes a new `inertia.ssr.bundle` config option. This is the path to your local Inertia SSR bundle. By default it's set to `base_path('bootstrap/ssr/ssr.mjs')`, which is where the Laravel Vite plugin puts it, but you can change it to another location if needed. For example, if you're using webpack it might be located at `public_path('js/ssr.js')`.

As part of this update I also changed the `inertia.ssr.url` config value to *not* require the `/render` endpoint as part of the URL, as I'm now using this URL for both rendering and shutting down. I've made this change in a backwards compatible way — meaning if your config still includes `/render` in the URL, we automatically strip it out.