### PR TITLE
Report SSR errors

### DIFF
--- a/src/Commands/StartSsr.php
+++ b/src/Commands/StartSsr.php
@@ -44,6 +44,7 @@ class StartSsr extends Command
                 $this->info(trim($data));
             } else {
                 $this->error(trim($data));
+                report(new SsrException($data));
             }
         }
 


### PR DESCRIPTION
Right now when an JavaScript related error occurs we display it on the console, but it would be really helpful to have these exceptions reported in PHP as well, so that they can get surfaced in error tracking software.

This PR updates the `inertia:start-ssr` command to automatically report all of these errors. However, it doesn't throw an exception, as that would kill the SSR process, which isn't desirable.