### PR TITLE
Auto enable SSR based on existence of SSR bundle

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -10,6 +10,9 @@ return [
     | These options configures if and how Inertia uses Server Side Rendering
     | to pre-render the initial visits made to your application's pages.
     |
+    | You can specify a custom SSR bundle path, or omit it to let Inertia
+    | try and automatically detect it for you.
+    |
     | Do note that enabling these options will NOT automatically make SSR work,
     | as a separate rendering service needs to be available. To learn more,
     | please visit https://inertiajs.com/server-side-rendering
@@ -18,11 +21,9 @@ return [
 
     'ssr' => [
 
-        'enabled' => false,
-
         'url' => 'http://127.0.0.1:13714',
 
-        'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
+        // 'bundle' => base_path('bootstrap/ssr/ssr.mjs')
 
     ],
 

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -23,7 +23,7 @@ return [
 
         'url' => 'http://127.0.0.1:13714',
 
-        // 'bundle' => base_path('bootstrap/ssr/ssr.mjs')
+        // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
 
     ],
 

--- a/src/Commands/StartSsr.php
+++ b/src/Commands/StartSsr.php
@@ -2,7 +2,9 @@
 
 namespace Inertia\Commands;
 
+use Inertia\Ssr\SsrException;
 use Illuminate\Console\Command;
+use Inertia\Ssr\BundleDetector;
 use Symfony\Component\Process\Process;
 
 class StartSsr extends Command
@@ -26,16 +28,23 @@ class StartSsr extends Command
      */
     public function handle(): int
     {
-        $ssrBundle = config('inertia.ssr.bundle', base_path('bootstrap/ssr/ssr.mjs'));
+        $bundle = (new BundleDetector())->detect();
+        $configuredBundle = config('inertia.ssr.bundle');
 
-        if (! file_exists($ssrBundle)) {
-            $this->error('Inertia SSR bundle not found: '.$ssrBundle);
-            $this->info('Set the correct Inertia SSR bundle path in your `inertia.ssr.bundle` config.');
+        if ($bundle === null) {
+            $this->error(
+                $configuredBundle
+                    ? 'Inertia SSR bundle not found at the configured path: "'.$configuredBundle.'"'
+                    : 'Inertia SSR bundle not found. Set the correct Inertia SSR bundle path in your `inertia.ssr.bundle` config.'
+            );
 
             return self::FAILURE;
+        } elseif ($configuredBundle && $bundle !== $configuredBundle) {
+            $this->warn('Inertia SSR bundle not found at the configured path: "'.$configuredBundle.'"');
+            $this->warn('Using a default bundle instead: "'.$bundle.'"');
         }
 
-        $process = new Process(['node', $ssrBundle]);
+        $process = new Process(['node', $bundle]);
         $process->setTimeout(null);
         $process->start();
 

--- a/src/Commands/StartSsr.php
+++ b/src/Commands/StartSsr.php
@@ -44,9 +44,19 @@ class StartSsr extends Command
             $this->warn('Using a default bundle instead: "'.$bundle.'"');
         }
 
+        $this->callSilently('inertia:stop-ssr');
+
         $process = new Process(['node', $bundle]);
         $process->setTimeout(null);
         $process->start();
+
+        $stop = function () use ($process) {
+            $process->stop();
+        };
+        pcntl_async_signals(true);
+        pcntl_signal(SIGINT, $stop);
+        pcntl_signal(SIGQUIT, $stop);
+        pcntl_signal(SIGTERM, $stop);
 
         foreach ($process as $type => $data) {
             if ($process::OUT === $type) {

--- a/src/Ssr/BundleDetector.php
+++ b/src/Ssr/BundleDetector.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Inertia\Ssr;
+
+class BundleDetector
+{
+    public function detect()
+    {
+        return collect([
+            config('inertia.ssr.bundle'),
+            base_path('bootstrap/ssr/ssr.mjs'),
+            base_path('bootstrap/ssr/ssr.js'),
+            public_path('js/ssr.js'),
+        ])->filter()->first(function ($path) {
+            return file_exists($path);
+        });
+    }
+}

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -12,7 +12,7 @@ class HttpGateway implements Gateway
      */
     public function dispatch(array $page): ?Response
     {
-        if (! config('inertia.ssr.enabled', false)) {
+        if (! (new BundleDetector())->detect()) {
             return null;
         }
 


### PR DESCRIPTION
This PR removes the `inertia.ssr.enabled` config value in favor of automatically enabling SSR based on the existence of an SSR JavaScript bundle file.

By default it looks for the SSR bundle in a few common places, so quite often you won't even need to publish an Inertia config as long as you're using a pretty standard setup, such as `bootstrap/ssr/ssr.mjs` — the default location used by the Laravel Vite plugin.

You can, of course, still set a custom SSR bundle path using the `inertia.ssr.bundle` config option:

```php
'ssr' => [

    'url' => 'http://127.0.0.1:13714',

    'bundle' => base_path('bootstrap/ssr/ssr.mjs'), // <!-- here

],
```

This PR also updates the `inertia:start-ssr` command to automatically terminate the node process should the PHP process die, as well as when the command is run, just in case there is a lingering node process hanging around still.