### PR TITLE
Reintroduce `inertia.ssr.enabled` config option

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -21,6 +21,8 @@ return [
 
     'ssr' => [
 
+        'enabled' => true,
+
         'url' => 'http://127.0.0.1:13714',
 
         // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),

--- a/src/Commands/StartSsr.php
+++ b/src/Commands/StartSsr.php
@@ -28,6 +28,12 @@ class StartSsr extends Command
      */
     public function handle(): int
     {
+        if (! config('inertia.ssr.enabled', true)) {
+            $this->error('Inertia SSR is not enabled. Enable it via the `inertia.ssr.enabled` config option.');
+
+            return self::FAILURE;
+        }
+
         $bundle = (new BundleDetector())->detect();
         $configuredBundle = config('inertia.ssr.bundle');
 

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -12,7 +12,7 @@ class HttpGateway implements Gateway
      */
     public function dispatch(array $page): ?Response
     {
-        if (! (new BundleDetector())->detect()) {
+        if (! config('inertia.ssr.enabled', true) || ! (new BundleDetector())->detect()) {
             return null;
         }
 

--- a/tests/DirectiveTest.php
+++ b/tests/DirectiveTest.php
@@ -92,6 +92,8 @@ class DirectiveTest extends TestCase
 
     public function test_inertia_directive_renders_the_root_element(): void
     {
+        Config::set(['inertia.ssr.enabled' => false]);
+
         $html = '<div id="app" data-page="{&quot;component&quot;:&quot;Foo\/Bar&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;},&quot;url&quot;:&quot;\/test&quot;,&quot;version&quot;:&quot;&quot;}"></div>';
 
         $this->assertSame($html, $this->renderView('@inertia', ['page' => self::EXAMPLE_PAGE_OBJECT]));
@@ -112,6 +114,8 @@ class DirectiveTest extends TestCase
 
     public function test_inertia_directive_can_use_a_different_root_element_id(): void
     {
+        Config::set(['inertia.ssr.enabled' => false]);
+
         $html = '<div id="foo" data-page="{&quot;component&quot;:&quot;Foo\/Bar&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;},&quot;url&quot;:&quot;\/test&quot;,&quot;version&quot;:&quot;&quot;}"></div>';
 
         $this->assertSame($html, $this->renderView('@inertia(foo)', ['page' => self::EXAMPLE_PAGE_OBJECT]));
@@ -121,6 +125,8 @@ class DirectiveTest extends TestCase
 
     public function test_inertia_head_directive_renders_nothing(): void
     {
+        Config::set(['inertia.ssr.enabled' => false]);
+
         $this->assertEmpty($this->renderView('@inertiaHead', ['page' => self::EXAMPLE_PAGE_OBJECT]));
     }
 


### PR DESCRIPTION
Realizing that technically people might have bene using the `inertia.ssr.enabled` config option to explicitly disable SSR for certain endpoints in their apps — for example, all Nova endpoints.

This PR adds this option back, but the default is now set to `true` so that we can still auto-enable SSR based on the existence of an SSR bundle (see #487).