### PR TITLE
Fix bug where SSR is dispatched twice when errors exist

### DIFF
--- a/src/Directive.php
+++ b/src/Directive.php
@@ -14,12 +14,13 @@ class Directive
         $id = trim(trim($expression), "\'\"") ?: 'app';
 
         $template = '<?php
-            if (!isset($__inertiaSsr)) {
-                $__inertiaSsr = app(\Inertia\Ssr\Gateway::class)->dispatch($page);
+            if (!isset($__inertiaSsrDispatched)) {
+                $__inertiaSsrDispatched = true;
+                $__inertiaSsrResponse = app(\Inertia\Ssr\Gateway::class)->dispatch($page);
             }
 
-            if ($__inertiaSsr instanceof \Inertia\Ssr\Response) {
-                echo $__inertiaSsr->body;
+            if ($__inertiaSsrResponse) {
+                echo $__inertiaSsrResponse->body;
             } else {
                 ?><div id="'.$id.'" data-page="{{ json_encode($page) }}"></div><?php
             }
@@ -36,12 +37,13 @@ class Directive
     public static function compileHead($expression = ''): string
     {
         $template = '<?php
-            if (!isset($__inertiaSsr)) {
-                $__inertiaSsr = app(\Inertia\Ssr\Gateway::class)->dispatch($page);
+            if (!isset($__inertiaSsrDispatched)) {
+                $__inertiaSsrDispatched = true;
+                $__inertiaSsrResponse = app(\Inertia\Ssr\Gateway::class)->dispatch($page);
             }
 
-            if ($__inertiaSsr instanceof \Inertia\Ssr\Response) {
-                echo $__inertiaSsr->head;
+            if ($__inertiaSsrResponse) {
+                echo $__inertiaSsrResponse->head;
             }
         ?>';
 


### PR DESCRIPTION
This PR fixes a bug with the Inertia Blade directives that cause the SSR node server to be called twice in the event of a JavaScript related failure.

<img width="1224" alt="image" src="https://user-images.githubusercontent.com/882133/212474697-694e8fd5-7171-44f4-b5ee-7d47d05a2af0.png">

This happens because the `\Inertia\Ssr\Gateway` returns either an `\Inertia\Ssr\Response` (on success), or `null` on failure (a JavaScript error), which is saved in the `$__inertiaSsr` variable, and then we check to see if that variable `isset` to prevent calling the SSR server twice. Problem is, in PHP calling `isset()` on a variable that's `null` returns `false`, even if that variable has been set.

This PR fixes this by introducing a new `$__inertiaSsrDispatched` variable to keep track of whether the SSR server has been dispatched, regardless of the response.