### PR TITLE
add inertia_location helper

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -19,3 +19,18 @@ if (! function_exists('inertia')) {
         return $instance;
     }
 }
+
+if (! function_exists('inertia_location')) {
+    /**
+     * Inertia location helper.
+     *
+     * @param  string  url
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    function inertia_location($url)
+    {
+        $instance = \Inertia\Inertia::getFacadeRoot();
+
+        return $instance->location($url);
+    }
+}


### PR DESCRIPTION
I was working on a SaaS project and I needed to redirect to a tenant domain/subdomain. I googled around and saw [this issue](https://github.com/inertiajs/inertia/issues/99). and I saw @reinink [comment](https://github.com/inertiajs/inertia/issues/99#issuecomment-702823742) and didn't notice the word "Ruby" 😅, and that's when I discovered that this helper isn't available in the Laravel adapter. 

I thought about writing a test but ended up knowing that it won't pass since the `other-domain` isn't configured anywhere.
`HelperTests.php`
```php
    public function test_the_location_helper_function_returns_a_response_instance(): void
    {
        $this->assertInstanceOf(Response::class, inertia_location('http://other-domain.test/');
    }
```