### PR TITLE
Add pcntl to composer suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "require": {
         "php": "^7.2|~8.0.0|~8.1.0|~8.2.0",
         "ext-json": "*",
+        "ext-pcntl": "*",
         "laravel/framework": "^6.0|^7.0|^8.74|^9.0|^10.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "phpunit/phpunit": "^8.0|^9.5.8"
     },
     "suggest": {
-        "ext-pcntl": "Required to run Inertia SSR through the inertia:start-ssr artisan command"
+        "ext-pcntl": "Recommended when running the Inertia SSR server via the `inertia:start-ssr` artisan command."
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "require": {
         "php": "^7.2|~8.0.0|~8.1.0|~8.2.0",
         "ext-json": "*",
-        "ext-pcntl": "*",
         "laravel/framework": "^6.0|^7.0|^8.74|^9.0|^10.0"
     },
     "require-dev": {
@@ -35,6 +34,9 @@
         "orchestra/testbench": "^4.0|^5.0|^6.4|^7.0|^8.0",
         "mockery/mockery": "^1.3.3",
         "phpunit/phpunit": "^8.0|^9.5.8"
+    },
+    "suggest": {
+        "ext-pcntl": "Required to run Inertia SSR through the inertia:start-ssr artisan command"
     },
     "extra": {
         "laravel": {

--- a/src/Commands/StartSsr.php
+++ b/src/Commands/StartSsr.php
@@ -28,12 +28,6 @@ class StartSsr extends Command
      */
     public function handle(): int
     {
-        if (! extension_loaded('pcntl')) {
-            $this->error('The pcntl PHP extension (ext-pcntl) is required to run Inertia SSR.');
-
-            return self::FAILURE;
-        }
-
         if (! config('inertia.ssr.enabled', true)) {
             $this->error('Inertia SSR is not enabled. Enable it via the `inertia.ssr.enabled` config option.');
 
@@ -62,13 +56,15 @@ class StartSsr extends Command
         $process->setTimeout(null);
         $process->start();
 
-        $stop = function () use ($process) {
-            $process->stop();
-        };
-        pcntl_async_signals(true);
-        pcntl_signal(SIGINT, $stop);
-        pcntl_signal(SIGQUIT, $stop);
-        pcntl_signal(SIGTERM, $stop);
+        if (extension_loaded('pcntl')) {
+            $stop = function () use ($process) {
+                $process->stop();
+            };
+            pcntl_async_signals(true);
+            pcntl_signal(SIGINT, $stop);
+            pcntl_signal(SIGQUIT, $stop);
+            pcntl_signal(SIGTERM, $stop);
+        }
 
         foreach ($process as $type => $data) {
             if ($process::OUT === $type) {

--- a/src/Commands/StartSsr.php
+++ b/src/Commands/StartSsr.php
@@ -28,6 +28,12 @@ class StartSsr extends Command
      */
     public function handle(): int
     {
+        if (! extension_loaded('pcntl')) {
+            $this->error('The pcntl PHP extension (ext-pcntl) is required to run Inertia SSR.');
+
+            return self::FAILURE;
+        }
+
         if (! config('inertia.ssr.enabled', true)) {
             $this->error('Inertia SSR is not enabled. Enable it via the `inertia.ssr.enabled` config option.');
 


### PR DESCRIPTION
v0.6.6 introduced artisan commands to start the SSR server. Later this was updated (#487), but the code introduced there uses pcntl, which isn't currently part of the requirements. This adds `ext-pcntl` to the requirements. Since the docs now only provide information to start the SSR server through this command I feel like this requirement should be added to Inertia.

One side-effect of this is that's it's impossible to use this feature on systems where the extension isn't available, like Windows. 