### PR TITLE
Pass through NODE_ENV to Node-based Inertia SSR server

### DIFF
--- a/src/Commands/StartSsr.php
+++ b/src/Commands/StartSsr.php
@@ -53,6 +53,9 @@ class StartSsr extends Command
         $this->callSilently('inertia:stop-ssr');
 
         $process = new Process(['node', $bundle]);
+        $process->setEnv([
+            'NODE_ENV' => app()->environment()
+        ]);
         $process->setTimeout(null);
         $process->start();
 


### PR DESCRIPTION
Got an error like the one below, so I have realized that `process.env.NODE_ENV === 'production'` checks always detect that the environment is not production on the SSR node server, sometimes leading to debug mode behaviour and skipping of production optimizations.

This PR solves the issue by passing through Laravel's environment to the Node-based Inertia SSR server when starting the server through the `inertia:start-ssr` command.

Error mentioned:
```
SerializableStateInvariantMiddleware took 35ms, which is more than the warning threshold of 32ms. If your state or actions are very large, you may want to disable the middleware as it might cause too much of a slowdown in development mode. See https://redux-toolkit.js.org/api/getDefaultMiddleware for instructions. It is disabled in production builds, so you don't need to worry about that.
```