### PR TITLE
Provide helper for asserting redirection

### DIFF
--- a/src/Testing/TestResponseMacros.php
+++ b/src/Testing/TestResponseMacros.php
@@ -26,6 +26,23 @@ class TestResponseMacros
         };
     }
 
+    public function assertInertiaRedirect($uri = null)
+    {
+        return function () use ($uri) {
+            PHPUnit::assertSame(
+                409,
+                $this->getstatusCode(),
+                $this->statusMessageWithDetails('409', $this->getStatusCode()),
+            );
+
+            if (! is_null($uri)) {
+                $this->assertLocation($uri);
+            }
+
+            return $this;
+        };
+    }
+
     public function inertiaPage()
     {
         return function () {

--- a/src/Testing/TestResponseMacros.php
+++ b/src/Testing/TestResponseMacros.php
@@ -31,8 +31,8 @@ class TestResponseMacros
         return function () use ($uri) {
             PHPUnit::assertSame(
                 409,
-                $this->getstatusCode(),
-                $this->statusMessageWithDetails('409', $this->getStatusCode()),
+                $this->getStatusCode(),
+                $this->statusMessageWithDetails('409', $this->getStatusCode())
             );
 
             if (! is_null($uri)) {

--- a/src/Testing/TestResponseMacros.php
+++ b/src/Testing/TestResponseMacros.php
@@ -26,9 +26,9 @@ class TestResponseMacros
         };
     }
 
-    public function assertInertiaRedirect($uri = null)
+    public function assertInertiaRedirect()
     {
-        return function () use ($uri) {
+        return function ($uri = null) {
             PHPUnit::assertSame(
                 409,
                 $this->getStatusCode(),
@@ -36,7 +36,7 @@ class TestResponseMacros
             );
 
             if (! is_null($uri)) {
-                $this->assertLocation($uri);
+                $this->assertHeader('X-Inertia-Location', $uri);
             }
 
             return $this;


### PR DESCRIPTION
Inertia uses 409 as the status code for redirection. When writing tests in Laravel with 

```
$this->post('/', headers: ['X-Inertia' => true])->assertRedirect('/redirected');
```

The test will fail because Laravel relies on `$this->isRedirect()` to validate whether the request returned a redirect. The `isRedirect()` method belongs to Symfony and it doesn't consider 409 as a valid status code, which means this always fail.