### PR TITLE
Automatically update Facade docblocks

### DIFF
--- a/.github/workflows/facade.yml
+++ b/.github/workflows/facade.yml
@@ -1,0 +1,42 @@
+name: facades
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  update:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: true
+
+    name: Facade DocBlocks
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: "composer config repositories.facade-documenter vcs git@github.com:laravel/facade-documenter.git && composer require --dev laravel/facade-documenter:dev-main"
+
+      - name: Update facade docblocks
+        run: php -f vendor/bin/facade.php -- Inertia\\Inertia
+
+      - name: Commit facade docblocks
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update facade docblocks
+          file_pattern: src/

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -3,18 +3,21 @@
 namespace Inertia;
 
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Contracts\Support\Arrayable;
 
 /**
  * @method static void setRootView(string $name)
- * @method static void share($key, $value = null)
- * @method static array getShared(string $key = null, $default = null)
- * @method static array flushShared()
- * @method static void version($version)
- * @method static int|string getVersion()
- * @method static LazyProp lazy(callable $callback)
- * @method static Response render($component, array|Arrayable $props = [])
- * @method static \Symfony\Component\HttpFoundation\Response location(string $url)
+ * @method static void share(string|array|\Illuminate\Contracts\Support\Arrayable $key, mixed $value = null)
+ * @method static mixed getShared(string|null $key = null, mixed $default = null)
+ * @method static void flushShared()
+ * @method static void version(\Closure|string|null $version)
+ * @method static string getVersion()
+ * @method static \Inertia\LazyProp lazy(callable $callback)
+ * @method static \Inertia\Response render(string $component, array|\Illuminate\Contracts\Support\Arrayable $props = [])
+ * @method static \Symfony\Component\HttpFoundation\Response location(string|\Illuminate\Http\RedirectResponse $url)
+ * @method static void macro(string $name, object|callable $macro)
+ * @method static void mixin(object $mixin, bool $replace = true)
+ * @method static bool hasMacro(string $name)
+ * @method static void flushMacros()
  *
  * @see \Inertia\ResponseFactory
  */

--- a/src/Response.php
+++ b/src/Response.php
@@ -38,7 +38,7 @@ class Response implements Responsable
 
     /**
      * @param string|array $key
-     * @param mixed|null   $value
+     * @param mixed        $value
      *
      * @return $this
      */
@@ -55,7 +55,7 @@ class Response implements Responsable
 
     /**
      * @param string|array $key
-     * @param mixed|null   $value
+     * @param mixed        $value
      *
      * @return $this
      */

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -31,7 +31,7 @@ class ResponseFactory
 
     /**
      * @param string|array|Arrayable $key
-     * @param mixed|null             $value
+     * @param mixed                  $value
      */
     public function share($key, $value = null): void
     {
@@ -45,7 +45,7 @@ class ResponseFactory
     }
 
     /**
-     * @param mixed|null $default
+     * @param mixed $default
      *
      * @return mixed
      */

--- a/src/Testing/Concerns/Has.php
+++ b/src/Testing/Concerns/Has.php
@@ -36,7 +36,7 @@ trait Has
     }
 
     /**
-     * @param mixed|null $value
+     * @param mixed $value
      *
      * @return $this
      */

--- a/tests/Stubs/ExampleMiddleware.php
+++ b/tests/Stubs/ExampleMiddleware.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 class ExampleMiddleware extends Middleware
 {
     /**
-     * @var mixed|null
+     * @var mixed
      */
     protected $version;
 


### PR DESCRIPTION
This PR introduces a new workflow that will automatically keep the `Inertia\Inertia` facade's docblock up to date with the underlying implementation.

This workflow only targets the `master` branch and will **automatically commit** changes back into `master` when a PR is merged - so it won't interrupt PRs from the community.

Note that the script reads the types from the underlying implementation, so if there are mistakes in those types they should be corrected in the implementation rather than on the Facade.