### PR TITLE
Restore request and session on redirects

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -109,14 +109,10 @@ class ResponseFactory
      */
     public function location($url): SymfonyResponse
     {
-        [$url, $redirect] = $url instanceof SymfonyRedirect
-            ? [$url->getTargetUrl(), $url]
-            : [$url, Redirect::away($url)];
-
         if (Request::inertia()) {
-            return BaseResponse::make('', 409, ['X-Inertia-Location' => $url]);
+            return BaseResponse::make('', 409, ['X-Inertia-Location' => $url instanceof SymfonyRedirect ? $url->getTargetUrl() : $url]);
         }
 
-        return $redirect;
+        return $url instanceof SymfonyRedirect ? $url : Redirect::away($url);
     }
 }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -107,7 +107,13 @@ class ResponseFactory
      */
     public function location($url): \Symfony\Component\HttpFoundation\Response
     {
+        $request = $session = null;
+
         if ($url instanceof RedirectResponse) {
+            $request = $url->getRequest();
+
+            $session = $url->getSession();
+
             $url = $url->getTargetUrl();
         }
 
@@ -115,6 +121,14 @@ class ResponseFactory
             return BaseResponse::make('', 409, ['X-Inertia-Location' => $url]);
         }
 
-        return new RedirectResponse($url);
+        return tap(new RedirectResponse($url), function ($redirect) use ($request, $session) {
+            if ($request) {
+                $redirect->setRequest($request);
+            }
+
+            if ($session) {
+                $redirect->setSession($session);
+            }
+        });
     }
 }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -5,7 +5,6 @@ namespace Inertia;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -11,7 +11,10 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Request;
 use Inertia\Tests\Stubs\ExampleMiddleware;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Http\Request as HttpRequest;
 use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Session\NullSessionHandler;
+use Illuminate\Session\Store;
 
 class ResponseFactoryTest extends TestCase
 {
@@ -73,6 +76,20 @@ class ResponseFactoryTest extends TestCase
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
         $this->assertEquals('https://inertiajs.com', $response->headers->get('location'));
+    }
+
+    public function test_location_response_for_non_inertia_requests_using_redirect_response_with_existing_session_and_request_properties(): void
+    {
+        $redirect = new RedirectResponse('https://inertiajs.com');
+        $redirect->setSession($session = new Store('test', new NullSessionHandler));
+        $redirect->setRequest($request = new HttpRequest);
+        $response = (new ResponseFactory())->location($redirect);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
+        $this->assertEquals('https://inertiajs.com', $response->headers->get('location'));
+        $this->assertSame($session, $response->getSession());
+        $this->assertSame($request, $response->getRequest());
     }
 
     public function test_the_version_can_be_a_closure(): void

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -78,6 +78,15 @@ class ResponseFactoryTest extends TestCase
         $this->assertEquals('https://inertiajs.com', $response->headers->get('location'));
     }
 
+    public function test_location_redirects_are_not_modified(): void
+    {
+        $response = (new ResponseFactory())->location('/foo');
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
+        $this->assertEquals('/foo', $response->headers->get('location'));
+    }
+
     public function test_location_response_for_non_inertia_requests_using_redirect_response_with_existing_session_and_request_properties(): void
     {
         $redirect = new RedirectResponse('https://inertiajs.com');
@@ -90,6 +99,7 @@ class ResponseFactoryTest extends TestCase
         $this->assertEquals('https://inertiajs.com', $response->headers->get('location'));
         $this->assertSame($session, $response->getSession());
         $this->assertSame($request, $response->getRequest());
+        $this->assertSame($response, $redirect);
     }
 
     public function test_the_version_can_be_a_closure(): void


### PR DESCRIPTION
If there is an existing session on the redirect, it would be nice to restore it.

```php
Inertia::location(
    redirect()->to('/login')
)->with('foo', 'bar');
```

Also restoring the request while I'm in there.