### PR TITLE
[0.6.x] Add prop utilities

### DIFF
--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -156,9 +156,13 @@ class ResponseFactoryTest extends TestCase
     {
         Inertia::share('string', 'string-value');
         Inertia::share('array', ['array-value']);
-        Inertia::share('closure', fn () => 'closure-value');
+        Inertia::share('closure', function () {
+            return 'closure-value';
+        });
         App::instance(BoundInstance::class, new BoundInstance('lazy-value'));
-        Inertia::share('lazy', Inertia::lazy(fn (BoundInstance $instance) => $instance->value));
+        Inertia::share('lazy', Inertia::lazy(function (BoundInstance $instance) {
+            return  $instance->value;
+        }));
 
         $this->assertSame('string-value', Inertia::resolveShared('string'));
         $this->assertSame(['array-value'], Inertia::resolveShared('array'));
@@ -170,7 +174,9 @@ class ResponseFactoryTest extends TestCase
     {
         // Lazy prop closures are called by the app. Want to make sure we are
         // still able to resolve from the container.
-        App::bind(BoundInstance::class, fn () => new BoundInstance('value'));
+        App::bind(BoundInstance::class, function () {
+            return new BoundInstance('value');
+        });
 
         $merged = Inertia::mergeProps(['eager-value'], ['merged-value']);
         $this->assertIsArray($merged);
@@ -180,19 +186,27 @@ class ResponseFactoryTest extends TestCase
         $this->assertIsArray($merged);
         $this->assertSame(['eager' => 'value', 'merged' => 'value'], $merged);
 
-        $merged = Inertia::mergeProps(fn () => ['closure-value'], ['merged-value']);
+        $merged = Inertia::mergeProps(function () {
+            return ['closure-value'];
+        }, ['merged-value']);
         $this->assertInstanceOf(Closure::class, $merged);
         $this->assertSame(['closure-value', 'merged-value'], $merged());
 
-        $merged = Inertia::mergeProps(fn () => ['closure' => 'value'], ['merged' => 'value']);
+        $merged = Inertia::mergeProps(function () {
+            return ['closure' => 'value'];
+        }, ['merged' => 'value']);
         $this->assertInstanceOf(Closure::class, $merged);
         $this->assertSame(['closure' => 'value', 'merged' => 'value'], $merged());
 
-        $merged = Inertia::mergeProps(Inertia::lazy(fn (BoundInstance $instance) => ["lazy-{$instance->value}"]), ['merged-value']);
+        $merged = Inertia::mergeProps(Inertia::lazy(function (BoundInstance $instance) {
+            return ["lazy-{$instance->value}"];
+        }), ['merged-value']);
         $this->assertInstanceOf(LazyProp::class, $merged);
         $this->assertSame(['lazy-value', 'merged-value'], $merged());
 
-        $merged = Inertia::mergeProps(Inertia::lazy(fn (BoundInstance $instance) => ['lazy' => $instance->value]), ['merged' => 'value']);
+        $merged = Inertia::mergeProps(Inertia::lazy(function (BoundInstance $instance) {
+            return ['lazy' => $instance->value];
+        }), ['merged' => 'value']);
         $this->assertInstanceOf(LazyProp::class, $merged);
         $this->assertSame(['lazy' => 'value', 'merged' => 'value'], $merged());
     }
@@ -230,8 +244,12 @@ class ResponseFactoryTest extends TestCase
     {
         Inertia::share('eager-list', ['eager-value']);
         Inertia::share('eager-associative', ['eager' => 'value']);
-        Inertia::share('closure-list', fn () => ['closure-value']);
-        Inertia::share('closure-associative', fn () => ['closure' => 'value']);
+        Inertia::share('closure-list', function () {
+            return ['closure-value'];
+        });
+        Inertia::share('closure-associative', function () {
+            return ['closure' => 'value'];
+        });
         $alreadyResolved = false;
         App::bind(BoundInstance::class, function () use (&$alreadyResolved) {
             if (! $alreadyResolved) {
@@ -242,8 +260,12 @@ class ResponseFactoryTest extends TestCase
                 return new BoundInstance(['lazy' => 'value']);
             }
         });
-        Inertia::share('lazy-list', Inertia::lazy(fn (BoundInstance $instance) => $instance->value));
-        Inertia::share('lazy-associative', Inertia::lazy(fn (BoundInstance $instance) => $instance->value));
+        Inertia::share('lazy-list', Inertia::lazy(function (BoundInstance $instance) {
+            return $instance->value;
+        }));
+        Inertia::share('lazy-associative', Inertia::lazy(function (BoundInstance $instance) {
+            return $instance->value;
+        }));
 
         $merged = Inertia::getSharedAndMergeProps('eager-list', ['merged-value']);
         $this->assertIsArray($merged);
@@ -308,8 +330,10 @@ class ResponseFactoryTest extends TestCase
 
 class BoundInstance
 {
-    public function __construct(public $value)
+    public $value;
+
+    public function __construct($value)
     {
-        //
+        $this->value = $value;
     }
 }


### PR DESCRIPTION
Using nested layouts means we have a lot of "shared" data for each different level of layout.

We have:

1. A global layout that has `user` specific data.
2. A server layout that has `server` specific data.
3. A site layout that has `site` specific data.

When you are looking at a site the user and server data is also provided via "shared" data.

Say you are looking at a site, on some endpoints we want to augment the `server` prop with some addition data.

We are currently using the following pattern *a lot*.

```php
Inertia::render('MyPage', [
    'key' => fn () => array_merge(value(Inertia::getShared('key')), [
        'additional_data' => $server->additional_data,
        // ...
    ]),
]);
```

What is happening...

We are always wrapping our `getShared` call in a call to `value` as it may be a closure or an array and we need to unwrap it.

We then call `array_merge` to merge the shared with the new data.

We then wrap all of this back into a Closure to make sure it isn't sent on every future response.

The `value` helper does not support `LazyProp` shared data, so we would have to use special handling for lazy props.

We do this ~40 times throughout our application to merge in additional data.

This PR proposes adding 2 new utility functions for working with raw props and the same 2 with shared support specifically.

> **Note**
> The following examples are in isolation and not how they would appear in an application - so keep that in mind when looking at them.

## `Inertia::resolveProp`

This helper is essentially an Inertia specific version of the `value` helper with support for `LazyProp`.

```php
Inertia::resolveProp('Tim');
// 'Tim'

Inertia::resolveProp(fn () => 'Tim');
// 'Tim'

Inertia::resolveProp(Inertia::lazy(fn () => 'Tim'));
// 'Tim'
```

## `Inertia::resolveShared`

```php
Inertia::share('name', 'Tim');

Inertia::resolveShared('name');
// 'Tim'

Inertia::share('name', fn () => 'Tim');

Inertia::resolveShared('name');
// 'Tim'

Inertia::share('name', Inertia::lazy(fn () => 'Tim'));

Inertia::resolveShared('name');
// 'Tim'
```

> **Note**
> The closures for the second two examples have not been resolved by the merging process. They are still yet to be resolved.

## `Inertia::mergeProps`

```php
Inertia::mergeProps(['Tim'], ['Jaz']);
// ['Tim', 'Jaz']

Inertia::mergeProps(fn () => ['Tim'], ['Jaz']);
// fn () => ['Tim', 'Jaz']

Inertia::mergeProps(Inertia::lazy(fn () => ['Tim']), ['Jaz']);
// Inertia::lazy(fn () => ['Tim', 'Jaz'])
```

> **Note**
> The closures for the second two examples have not been resolved by the merging process. They are still yet to be resolved.

## `Inertia::getSharedAndMergeProps`

```php
Inertia::share('names', ['Tim']);

Inertia::getSharedAndMergeProps('names', ['Jaz']);
// ['Tim', 'Jaz']

Inertia::share('names', fn () => ['Tim']);

Inertia::getSharedAndMergeProps('names', ['Jaz']);
// fn () => ['Tim', 'Jaz']

Inertia::share('names', Inertia::lazy(fn () => ['Tim']));

Inertia::getSharedAndMergeProps('names', ['Jaz']);
// Inertia::lazy(fn () => ['Tim', 'Jaz']
```

With this in place, we can more easily work with props and burn `fn () => array_merge(value(Inertia::getShared(` with fire...

```diff
Inertia::render('MyPage', [
-    'key' => fn () => array_merge(value(Inertia::getShared('key')), [
+    'key' => Inertia::getSharedAndMerge('key', [
        'additional_data' => $server->additional_data,
        // ...
    ]),
]);
```

It is also possible to make shared data eager for certain endpoints...


```php
Inertia::render('MyPage', [
    'key' => Inertia::resolveShared('key'),
]);
```