### PR TITLE
Add option for using the bun js runtime in SSR

### DIFF
--- a/src/Commands/StartSsr.php
+++ b/src/Commands/StartSsr.php
@@ -14,7 +14,7 @@ class StartSsr extends Command
      *
      * @var string
      */
-    protected $name = 'inertia:start-ssr';
+    protected $signature = 'inertia:start-ssr {--runtime=node}';
 
     /**
      * The console command description.
@@ -50,9 +50,16 @@ class StartSsr extends Command
             $this->warn('Using a default bundle instead: "'.$bundle.'"');
         }
 
+        $runtime = $this->option('runtime');
+
+        if (! in_array($runtime, ['node', 'bun'])) {
+            $this->error('Unsupported runtime "'.$runtime.'". Supported runtimes are node and bun.');
+            return self::INVALID;
+        }
+
         $this->callSilently('inertia:stop-ssr');
 
-        $process = new Process(['node', $bundle]);
+        $process = new Process([$runtime, $bundle]);
         $process->setTimeout(null);
         $process->start();
 

--- a/src/Commands/StartSsr.php
+++ b/src/Commands/StartSsr.php
@@ -14,7 +14,7 @@ class StartSsr extends Command
      *
      * @var string
      */
-    protected $signature = 'inertia:start-ssr {--runtime=node}';
+    protected $signature = 'inertia:start-ssr {--runtime=node : The runtime to use (`node` or `bun`)}';
 
     /**
      * The console command description.
@@ -53,7 +53,8 @@ class StartSsr extends Command
         $runtime = $this->option('runtime');
 
         if (! in_array($runtime, ['node', 'bun'])) {
-            $this->error('Unsupported runtime "'.$runtime.'". Supported runtimes are node and bun.');
+            $this->error('Unsupported runtime: "'.$runtime.'". Supported runtimes are `node` and `bun`.');
+
             return self::INVALID;
         }
 


### PR DESCRIPTION
Addresses #548.

This adds a `--runtime` option which  can either be `node` or `bun`. The default is `node`.