### PR TITLE
Add _ide_helpers.php to git export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,5 @@
 /CHANGELOG.md       export-ignore
 /CONTRIBUTING.md    export-ignore
 /README.md          export-ignore
+/.php-cs-fixer.dist export-ignore
+/_ide_helpers.php   export-ignore


### PR DESCRIPTION
This file actually interferes with application-level LSP, because LSP
picks it up and indexes it, then things break like goto definition and
results in warnings about missing methods like `Route::get()`.

