### PR TITLE
feat: validation errors can return all error messages

### DIFF
--- a/tests/Stubs/ExampleMiddleware.php
+++ b/tests/Stubs/ExampleMiddleware.php
@@ -25,6 +25,13 @@ class ExampleMiddleware extends Middleware
         $this->shared = $shared;
     }
 
+    public static $returnOnlyFirstValidationErrorMessage = true;
+
+    public function returnOnlyFirstValidationErrorMessage(): bool
+    {
+        return static::$returnOnlyFirstValidationErrorMessage;
+    }
+
     /**
      * Determines the current asset version.
      *


### PR DESCRIPTION
Right now, when you have errors with multiple messages, only the first is returned as string.

I added a function `returnOnlyFirstErrorMessage` in middleware in order to be able to overide on our app if we want to display all the messages in an array