### PR TITLE
Update PHPUnit configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .env
-.phpunit.result.cache
+/.phpunit.cache
 composer.lock
 phpunit.xml
 /vendor

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
          backupGlobals="false"
-         backupStaticAttributes="false"
+         backupStaticProperties="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
+         failOnNotice="true"
+         failOnWarning="true"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
@@ -14,10 +13,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>
-


### PR DESCRIPTION
This PR updates the PHPUnit configuration to fix the schema deprecation warning when running the test suite on the latest version of PHPUnit.

```
There was 1 PHPUnit test runner deprecation:

1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!
```

It introduces new warnings on the older PHPUnit versions in the CI matrix, but I'm favouring the latest ones.