### PR TITLE
Testing lazy props

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Inertia;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Foundation\Http\Events\RequestHandled;
 use LogicException;
 use Inertia\Ssr\Gateway;
 use ReflectionException;
@@ -13,6 +15,7 @@ use Illuminate\Testing\TestResponse;
 use Inertia\Testing\TestResponseMacros;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Illuminate\Foundation\Testing\TestResponse as LegacyTestResponse;
+use Inertia\Testing\Listeners\RequestHandledListener;
 
 class ServiceProvider extends BaseServiceProvider
 {
@@ -38,6 +41,10 @@ class ServiceProvider extends BaseServiceProvider
                 $app['config']->get('inertia.testing.page_extensions')
             );
         });
+
+        $this->app->bind('inertia.testing.request', function ($app) {
+            return null;
+        });
     }
 
     public function boot(): void
@@ -47,6 +54,11 @@ class ServiceProvider extends BaseServiceProvider
         $this->publishes([
             __DIR__.'/../config/inertia.php' => config_path('inertia.php'),
         ]);
+
+        if (app()->environment('testing') === true) {
+            $dispatcher = app(Dispatcher::class);
+            $dispatcher->listen(RequestHandled::class, RequestHandledListener::class);
+        }
     }
 
     protected function registerBladeDirectives(): void

--- a/src/Testing/Assert.php
+++ b/src/Testing/Assert.php
@@ -5,7 +5,8 @@ namespace Inertia\Testing;
 use Closure;
 use const E_USER_DEPRECATED;
 use Illuminate\Contracts\Http\Kernel;
-use Illuminate\Foundation\Testing\TestResponse;
+use Illuminate\Testing\TestResponse;
+use Illuminate\Foundation\Testing\TestResponse as LegacyTestResponse;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Illuminate\Contracts\Support\Arrayable;
@@ -110,7 +111,12 @@ class Assert implements Arrayable
 
         $kernel->terminate($request, $response);
 
-        $testResponse = TestResponse::fromBaseResponse($response);
+        $testResponseClass = TestResponse::class; 
+        if (class_exists($testResponseClass) == false) {
+            $testResponseClass = LegacyTestResponse::class;
+        }
+
+        $testResponse = $testResponseClass::fromBaseResponse($response);
         $testResponse->assertInertia(function (Assert $page) use ($prop, $assert) {
             $page->has($prop);
 

--- a/src/Testing/Listeners/RequestHandledListener.php
+++ b/src/Testing/Listeners/RequestHandledListener.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Inertia\Testing\Listeners;
+
+use Illuminate\Foundation\Http\Events\RequestHandled;
+
+class RequestHandledListener
+{
+    public function handle(RequestHandled $event): void
+    {
+        app()->bind('inertia.testing.request', function () use ($event) {
+            return $event->request;
+        });
+    }
+}

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -3,7 +3,6 @@
 namespace Inertia\Tests\Testing;
 
 use Inertia\Inertia;
-use Inertia\Testing\AssertableInertia;
 use Inertia\Tests\TestCase;
 use PHPUnit\Framework\AssertionFailedError;
 
@@ -223,8 +222,6 @@ class AssertableInertiaTest extends TestCase
             $inertia->missing('bar');
 
             $inertia->requestProp('bar', function ($subInertia) {
-                $this->assertInstanceOf(AssertableInertia::class, $subInertia);
-
                 $subInertia->where('bar', 'foobar');
             });
         });

--- a/tests/Testing/Listeners/RequestHandledListener.php
+++ b/tests/Testing/Listeners/RequestHandledListener.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Inertia\Tests\Testing\Listeners;
+
+use Illuminate\Foundation\Http\Events\RequestHandled;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Event;
+use Inertia\Tests\TestCase;
+
+class RequestHandledListener extends TestCase
+{
+    /** @test */
+    public function the_request_is_stored()
+    {
+        $request = new Request();
+        $response = new Response();
+
+        $this->assertNull(app('inertia.testing.request'));
+
+        Event::dispatch(new RequestHandled($request, $response));
+
+        $this->assertSame($request, app('inertia.testing.request'));
+    }
+}


### PR DESCRIPTION
I added the method `requestProp` (name open for discussion 😉) to the AssertableInertia class which let you easy test LazyProps.

```php
/** @test */
public function test_props(): void
{
    $this
        ->get('/')
        ->assertInertia(function (AssertableInertia $page) {
            $page->has('normalPropKey');
            $page->missing('lazyPropKey');

            $page->requestProp('lazyPropKey', function (AssertableInertia $page) {
                $page->where('lazyPropKey', '1');
            });
        });
}
```

The method uses the previous request, applies the ```X-Inertia-Partial-Component``` and ```X-Inertia-Partial-Data``` headers, which are automatically seeded and resends it. A convenient way for the tester, and they do not need to know the internal mechanics of Intertia. Which I found in [#604](https://github.com/inertiajs/inertia/discussions/604). 