### PR TITLE
Ensure query string not URL encoded

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -101,13 +101,7 @@ class Response implements Responsable
         $page = [
             'component' => $this->component,
             'props' => $props,
-            'url' => Str::of($request->url())
-                ->after($request->getSchemeAndHttpHost())
-                ->start('/')
-                ->when($request->getQueryString(), fn (Stringable $url, string $queryString) => $url
-                    ->append('?')
-                    ->append(urldecode($queryString)))
-                ->toString(),
+            'url' => $this->url($request),
             'version' => $this->version,
         ];
 
@@ -157,5 +151,18 @@ class Response implements Responsable
         }
 
         return $props;
+    }
+
+    public function url(Request $request): string
+    {
+        $url = Str::after($request->url(), $request->getSchemeAndHttpHost());
+        $url = Str::start($url, '/');
+
+        $queryString = $request->getQueryString();
+        if ($queryString === null) {
+            return $url;
+        }
+
+        return $url.'?'.urldecode($queryString);
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -9,6 +9,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
@@ -100,7 +101,13 @@ class Response implements Responsable
         $page = [
             'component' => $this->component,
             'props' => $props,
-            'url' => Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/'),
+            'url' => Str::of($request->url())
+                ->after($request->getSchemeAndHttpHost())
+                ->start('/')
+                ->when($request->getQueryString(), fn (Stringable $url, string $queryString) => $url
+                    ->append('?')
+                    ->append(urldecode($queryString)))
+                ->toString(),
             'version' => $this->version,
         ];
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -153,7 +153,7 @@ class Response implements Responsable
         return $props;
     }
 
-    public function url(Request $request): string
+    protected function url(Request $request): string
     {
         $url = Str::after($request->url(), $request->getSchemeAndHttpHost());
         $url = Str::start($url, '/');

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -400,4 +400,16 @@ class ResponseTest extends TestCase
 
         $this->assertSame('/subpath/product/123', $page->url);
     }
+
+    public function test_the_query_string_of_the_page_url_is_not_urlencoded(): void
+    {
+        $request = Request::create('/product/123?q=hello/world', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+
+        $response = new Response('Product/Show', []);
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $this->assertSame('/product/123?q=hello/world', $page->url);
+    }
 }


### PR DESCRIPTION
#592 fixed the long standing double path issue but it introduces a bug where the query string is URL encoded.
This PR fixes that by manually building up the URL en decoding the query string before appending it.