### PR TITLE
[2.x] Automatically disable wrapping for API resource props

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -226,7 +226,9 @@ class Response implements Responsable
             }
 
             if ($value instanceof ResourceResponse || $value instanceof JsonResource) {
-                $value = $value->toResponse($request)->getData(true);
+                $value = tap($value, static function ($value) {
+                    $value->withoutWrapping();
+                })->toResponse($request)->getData(true);
             }
 
             if (is_array($value)) {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -14,6 +14,7 @@ use Illuminate\View\View;
 use Inertia\AlwaysProp;
 use Inertia\LazyProp;
 use Inertia\Response;
+use Inertia\Tests\Stubs\FakeNestedResource;
 use Inertia\Tests\Stubs\FakeResource;
 use Mockery;
 
@@ -80,6 +81,24 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertSame('User/Edit', $page->component);
         $this->assertSame('Jonathan', $page->props->user->name);
+        $this->assertSame('/user/123', $page->url);
+        $this->assertSame('123', $page->version);
+    }
+
+    public function test_nested_resource_response(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+
+        $resource = new FakeNestedResource(['name' => 'Jonathan']);
+
+        $response = new Response('User/Edit', ['user' => $resource], 'app', '123');
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame('User/Edit', $page->component);
+        $this->assertSame('Jonathan', $page->props->user->nested->name);
         $this->assertSame('/user/123', $page->url);
         $this->assertSame('123', $page->version);
     }
@@ -195,7 +214,7 @@ class ResponseTest extends TestCase
         });
     }
 
-    public function test_arrayable_prop_response(): void
+    public function test_arrayable_prop_resource_response(): void
     {
         $request = Request::create('/user/123', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
@@ -209,6 +228,24 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertSame('User/Edit', $page->component);
         $this->assertSame('Jonathan', $page->props->user->name);
+        $this->assertSame('/user/123', $page->url);
+        $this->assertSame('123', $page->version);
+    }
+
+    public function test_arrayable_prop_nested_resource_response(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+
+        $resource = FakeNestedResource::make(['name' => 'Jonathan']);
+
+        $response = new Response('User/Edit', ['user' => $resource], 'app', '123');
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame('User/Edit', $page->component);
+        $this->assertSame('Jonathan', $page->props->user->nested->name);
         $this->assertSame('/user/123', $page->url);
         $this->assertSame('123', $page->version);
     }
@@ -471,7 +508,7 @@ class ResponseTest extends TestCase
         $this->assertFalse(array_key_exists('can', $auth));
     }
 
-    public function test_responsable_with_invalid_key(): void
+    public function test_responsable_resource_with_invalid_key(): void
     {
         $request = Request::create('/user/123', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
@@ -485,6 +522,23 @@ class ResponseTest extends TestCase
         $this->assertSame(
             ["\x00*\x00_invalid_key" => 'for object'],
             $page['props']['resource']
+        );
+    }
+
+    public function test_responsable_nested_resource_with_invalid_key(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+
+        $resource = new FakeNestedResource(["\x00*\x00_invalid_key" => 'for object']);
+
+        $response = new Response('User/Edit', ['resource' => $resource], 'app', '123');
+        $response = $response->toResponse($request);
+        $page = $response->getData(true);
+
+        $this->assertSame(
+            ["\x00*\x00_invalid_key" => 'for object'],
+            $page['props']['resource']['nested']
         );
     }
 

--- a/tests/Stubs/FakeNestedResource.php
+++ b/tests/Stubs/FakeNestedResource.php
@@ -4,7 +4,7 @@ namespace Inertia\Tests\Stubs;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class FakeResource extends JsonResource
+class FakeNestedResource extends JsonResource
 {
     /**
      * The data that will be used.
@@ -26,6 +26,8 @@ class FakeResource extends JsonResource
      */
     public function toArray($request): array
     {
-        return $this->data;
+        return [
+            'nested' => new FakeResource($this->data),
+        ];
     }
 }


### PR DESCRIPTION
Continuation of #432 as it remains a problem in the latest version of Inertia.

I was in the process of porting the project to Inertia and I encountered a very unexpected issue with the JSON resources serialization. Some had a different structure in comparison to the one returned from API routes - a data wrapper was present.

I tinkered with the source code and discovered that the issue lies in how resources are being serialized in the response [master/src/Response.php#L136](https://github.com/inertiajs/inertia-laravel/blob/master/src/Response.php?rgh-link-date=2022-07-19T10%3A51%3A48Z#L136).

I was surprised to find out that the FakeResource used for tests has a $wrap property set to null to mitigate this issue but that has not been documented anywhere. Without this property, the test for response with JSON resource fails.

To fix this unexpected behavior I changed the logic for resource serialization to make sure not to use the data wrapper.