### PR TITLE
Support dot-notation in partial reloads

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -5,6 +5,7 @@ namespace Inertia;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
+use Inertia\Support\Header;
 use Symfony\Component\HttpFoundation\Response;
 
 class Middleware
@@ -85,13 +86,13 @@ class Middleware
         Inertia::setRootView($this->rootView($request));
 
         $response = $next($request);
-        $response->headers->set('Vary', 'X-Inertia');
+        $response->headers->set('Vary', Header::INERTIA);
 
-        if (! $request->header('X-Inertia')) {
+        if (! $request->header(Header::INERTIA)) {
             return $response;
         }
 
-        if ($request->method() === 'GET' && $request->header('X-Inertia-Version', '') !== Inertia::getVersion()) {
+        if ($request->method() === 'GET' && $request->header(Header::VERSION, '') !== Inertia::getVersion()) {
             $response = $this->onVersionChange($request, $response);
         }
 
@@ -145,8 +146,8 @@ class Middleware
                 return $errors[0];
             })->toArray();
         })->pipe(function ($bags) use ($request) {
-            if ($bags->has('default') && $request->header('x-inertia-error-bag')) {
-                return [$request->header('x-inertia-error-bag') => $bags->get('default')];
+            if ($bags->has('default') && $request->header(Header::ERROR_BAG)) {
+                return [$request->header(Header::ERROR_BAG) => $bags->get('default')];
             }
 
             if ($bags->has('default')) {

--- a/src/Response.php
+++ b/src/Response.php
@@ -105,7 +105,7 @@ class Response implements Responsable
     }
 
     /**
-     * Resolve properties.
+     * Resolve the properites for the response.
      */
     public function resolveProperties(Request $request, array $props): array
     {
@@ -129,7 +129,7 @@ class Response implements Responsable
     }
 
     /**
-     * Resolve `only` partial request.
+     * Resolve the `only` partial request props.
      */
     public function resolveOnly(Request $request, array $props): array
     {

--- a/src/Response.php
+++ b/src/Response.php
@@ -129,22 +129,6 @@ class Response implements Responsable
     }
 
     /**
-     * Resolve the `only` partial request props.
-     */
-    public function resolveOnly(Request $request, array $props): array
-    {
-        $only = array_filter(explode(',', $request->header(Header::PARTIAL_ONLY, '')));
-
-        $value = [];
-
-        foreach($only as $key) {
-            Arr::set($value, $key, data_get($props, $key));
-        }
-
-        return $value;
-    }
-
-    /**
      * Resolve all arrayables properties into an array.
      */
     public function resolveArrayableProperties(array $props, Request $request, bool $unpackDotProps = true): array
@@ -167,6 +151,22 @@ class Response implements Responsable
         }
 
         return $props;
+    }
+
+    /**
+     * Resolve the `only` partial request props.
+     */
+    public function resolveOnly(Request $request, array $props): array
+    {
+        $only = array_filter(explode(',', $request->header(Header::PARTIAL_ONLY, '')));
+
+        $value = [];
+
+        foreach($only as $key) {
+            Arr::set($value, $key, data_get($props, $key));
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -90,7 +90,6 @@ class Response implements Responsable
     {
         $props = $this->resolveProperties($request, $this->props);
 
-
         $page = [
             'component' => $this->component,
             'props' => $props,
@@ -105,6 +104,9 @@ class Response implements Responsable
         return ResponseFactory::view($this->rootView, $this->viewData + ['page' => $page]);
     }
 
+    /**
+     * Resolve properties.
+     */
     public function resolveProperties(Request $request, array $props): array
     {
         $isPartial = $request->header(Header::PARTIAL_COMPONENT) === $this->component;
@@ -126,6 +128,9 @@ class Response implements Responsable
         return $props;
     }
 
+    /**
+     * Resolve `only` partial request.
+     */
     public function resolveOnly(Request $request, array $props): array
     {
         $only = array_filter(explode(',', $request->header(Header::PARTIAL_ONLY, '')));
@@ -139,6 +144,9 @@ class Response implements Responsable
         return $value;
     }
 
+    /**
+     * Resolve all arrayables properties into an array.
+     */
     public function resolveArrayableProperties(array $props, Request $request, bool $unpackDotProps = true): array
     {
         foreach ($props as $key => $value) {

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Response as BaseResponse;
+use Inertia\Support\Header;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirect;
 
@@ -110,7 +111,7 @@ class ResponseFactory
     public function location($url): SymfonyResponse
     {
         if (Request::inertia()) {
-            return BaseResponse::make('', 409, ['X-Inertia-Location' => $url instanceof SymfonyRedirect ? $url->getTargetUrl() : $url]);
+            return BaseResponse::make('', 409, [Header::LOCATION => $url instanceof SymfonyRedirect ? $url->getTargetUrl() : $url]);
         }
 
         return $url instanceof SymfonyRedirect ? $url : Redirect::away($url);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Testing\TestResponse;
 use Inertia\Testing\TestResponseMacros;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Illuminate\Foundation\Testing\TestResponse as LegacyTestResponse;
+use Inertia\Support\Header;
 
 class ServiceProvider extends BaseServiceProvider
 {
@@ -73,7 +74,7 @@ class ServiceProvider extends BaseServiceProvider
     protected function registerRequestMacro(): void
     {
         Request::macro('inertia', function () {
-            return (bool) $this->header('X-Inertia');
+            return (bool) $this->header(Header::INERTIA);
         });
     }
 

--- a/src/Support/Header.php
+++ b/src/Support/Header.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Inertia\Support;
+
+class Header
+{
+    public const INERTIA = 'X-Inertia';
+    public const ERROR_BAG = 'X-Inertia-Error-Bag';
+    public const LOCATION = 'X-Inertia-Location';
+    public const VERSION = 'X-Inertia-Version';
+    public const PARTIAL_COMPONENT = 'X-Inertia-Partial-Component';
+    public const PARTIAL_ONLY = 'X-Inertia-Partial-Data';
+}

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -261,101 +261,29 @@ class ResponseTest extends TestCase
         $request = Request::create('/user/123', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
         $request->headers->add(['X-Inertia-Partial-Component' => 'User/Edit']);
-        $request->headers->add(['X-Inertia-Partial-Data' => 'partial.nested']);
-
-        $user = (object) ['name' => 'Jonathan'];
-        $partialProp = ['nested' => 'partial-data'];
-
-        $response = new Response('User/Edit', ['user' => $user, 'partial' => $partialProp], 'app', '123');
-        $response = $response->toResponse($request);
-        $page = $response->getData();
-
-        $props = get_object_vars($page->props);
-
-        $this->assertFalse(isset($props['user']));
-        $this->assertCount(1, $props);
-        $this->assertSame('partial-data', $page->props->partial->nested);
-    }
-
-    public function test_nested_lazy_props_are_included_in_partial_reload(): void
-    {
-        $request = Request::create('/user/123', 'GET');
-        $request->headers->add(['X-Inertia' => 'true']);
-        $request->headers->add(['X-Inertia-Partial-Component' => 'User/Edit']);
-        $request->headers->add(['X-Inertia-Partial-Data' => 'auth.user.name,auth.user.email']);
+        $request->headers->add(['X-Inertia-Partial-Data' => 'auth.user']);
 
         $props = [
-            'auth' => new LazyProp(function () {
-                return [
-                    'user' => [
-                        'id' => 1,
+            'auth' => [
+                'user' => new LazyProp(function () {
+                    return [
                         'name' => 'Jonathan Reinink',
-                        'email' => 'jonathan@example.com'
-                    ],
-                ];
-            }),
+                        'email' => 'jonathan@example.com',
+                    ];
+                }),
+            ],
             'shared' => [
                 'flash' => 'Value',
             ]
         ];
 
-        $response = new Response('User/Edit', $props, 'app', '123');
+        $response = new Response('User/Edit', $props);
         $response = $response->toResponse($request);
         $page = $response->getData();
 
         $this->assertFalse(isset($page->props->shared));
         $this->assertSame('Jonathan Reinink', $page->props->auth->user->name);
         $this->assertSame('jonathan@example.com', $page->props->auth->user->email);
-        $this->assertFalse(isset($page->props->auth->user->id));
-    }
-
-    public function test_missing_props_are_null_on_nested_partial_reload(): void
-    {
-        $request = Request::create('/user/123', 'GET');
-        $request->headers->add(['X-Inertia' => 'true']);
-        $request->headers->add(['X-Inertia-Partial-Component' => 'User/Edit']);
-        $request->headers->add(['X-Inertia-Partial-Data' => 'auth.user.email']);
-
-        $props = [
-            'auth' => [
-                'user' => [
-                    'name' => 'Jonathan Reinink',
-                ],
-            ],
-        ];
-
-        $response = new Response('User/Edit', $props, 'app', '123');
-        $response = $response->toResponse($request);
-        $page = $response->getData();
-
-        $this->assertNull($page->props->auth->user->email);
-    }
-
-    public function test_nested_lazy_props_not_included_in_partial_reload_should_not_be_unpacked(): void
-    {
-        $request = Request::create('/users', 'GET');
-        $request->headers->add(['X-Inertia' => 'true']);
-        $request->headers->add(['X-Inertia-Partial-Component' => 'Users']);
-        $request->headers->add(['X-Inertia-Partial-Data' => 'lazy.valid']);
-
-        $validProp = new LazyProp(function () {
-            return 'A lazy value';
-        });
-
-        $invalidProp = new LazyProp(function () {
-            throw new Exception;
-        });
-
-        $lazyProp = new LazyProp(function () use ($validProp, $invalidProp) {
-            return ['valid' => $validProp, 'invalid' => $invalidProp];
-        });
-
-        $response = new Response('Users', ['lazy' => $lazyProp], 'app', '123');
-        $response = $response->toResponse($request);
-        $page = $response->getData();
-
-        $this->assertFalse(isset($page->props->lazy->invalid));
-        $this->assertSame('A lazy value', $page->props->lazy->valid);
     }
 
     public function test_lazy_props_are_not_included_by_default(): void

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -261,7 +261,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/user/123', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
         $request->headers->add(['X-Inertia-Partial-Component' => 'User/Edit']);
-        $request->headers->add(['X-Inertia-Partial-Data' => 'auth.user']);
+        $request->headers->add(['X-Inertia-Partial-Data' => 'auth.user,auth.refresh_token']);
 
         $props = [
             'auth' => [
@@ -271,6 +271,8 @@ class ResponseTest extends TestCase
                         'email' => 'jonathan@example.com',
                     ];
                 }),
+                'refresh_token' => 'value',
+                'token' => 'value',
             ],
             'shared' => [
                 'flash' => 'Value',
@@ -282,8 +284,10 @@ class ResponseTest extends TestCase
         $page = $response->getData();
 
         $this->assertFalse(isset($page->props->shared));
+        $this->assertFalse(isset($page->props->auth->token));
         $this->assertSame('Jonathan Reinink', $page->props->auth->user->name);
         $this->assertSame('jonathan@example.com', $page->props->auth->user->email);
+        $this->assertSame('value', $page->props->auth->refresh_token);
     }
 
     public function test_lazy_props_are_not_included_by_default(): void


### PR DESCRIPTION
This PR introduces support for nested props in partial requests.

```js
router.visit(url, {
  only: ['auth.user', 'auth.refresh_token'],
})
```

```php
$props = [
    'auth' => [
        // Included on partial reload
        'user' => new LazyProp(function () {
            return [
                'name' => 'Jonathan Reinink',
                'email' => 'jonathan@example.com',
            ];
        }),

        // Included on partial reload
        'refresh_token' => 'value',

        // Not included on partial reload
        'token' => 'value',
    ],
    
    // Not included on partial reload
    'shared' => [
        'flash' => 'value',
    ]
];
```

Additionally, some insignificant internal changes were made:
- Extract methods:
  - `resolveProperties`
  - `resolveArrayableProperties`
  - `resolveOnly`
- Introduce `Header` enum

This would help simplify development of future improvements, including:
- Partial `except` visits
- Deferred properties
- Persistent properties