### PR TITLE
Add persistent properties

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -18,6 +18,9 @@ use Illuminate\Support\Facades\Facade;
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
+ * @method static void persist(string|array|\Illuminate\Contracts\Support\Arrayable $props)
+ * @method static array getPersisted()
+ * @method static void flushPersisted()
  *
  * @see \Inertia\ResponseFactory
  */

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -20,6 +20,8 @@ class Middleware
     protected $rootView = 'app';
 
     /**
+     * The properties that should always be included on Inertia responses, regardless of "only" or "except" requests.
+     *
      * @var array
      */
     protected $persisted = [];

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -20,6 +20,11 @@ class Middleware
     protected $rootView = 'app';
 
     /**
+     * @var array
+     */
+    protected $persisted = [];
+
+    /**
      * Determines the current asset version.
      *
      * @see https://inertiajs.com/asset-versioning
@@ -83,6 +88,7 @@ class Middleware
         });
 
         Inertia::share($this->share($request));
+        Inertia::persist($this->persisted);
         Inertia::setRootView($this->rootView($request));
 
         $response = $next($request);

--- a/src/Response.php
+++ b/src/Response.php
@@ -23,6 +23,7 @@ class Response implements Responsable
 
     protected $component;
     protected $props;
+    protected $persisted;
     protected $rootView;
     protected $version;
     protected $viewData = [];
@@ -30,10 +31,11 @@ class Response implements Responsable
     /**
      * @param array|Arrayable $props
      */
-    public function __construct(string $component, $props, string $rootView = 'app', string $version = '')
+    public function __construct(string $component, array $props, string $rootView = 'app', string $version = '', array $persisted = [])
     {
         $this->component = $component;
         $this->props = $props instanceof Arrayable ? $props->toArray() : $props;
+        $this->persisted = $persisted;
         $this->rootView = $rootView;
         $this->version = $version;
     }
@@ -158,7 +160,10 @@ class Response implements Responsable
      */
     public function resolveOnly(Request $request, array $props): array
     {
-        $only = array_filter(explode(',', $request->header(Header::PARTIAL_ONLY, '')));
+        $only = array_merge(
+            array_filter(explode(',', $request->header(Header::PARTIAL_ONLY, ''))),
+            $this->persisted
+        );
 
         $value = [];
 

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -24,6 +24,9 @@ class ResponseFactory
     /** @var array */
     protected $sharedProps = [];
 
+    /** @var array */
+    protected $persisted = [];
+
     /** @var Closure|string|null */
     protected $version;
 
@@ -67,6 +70,30 @@ class ResponseFactory
     }
 
     /**
+     * @param string|array|Arrayable $props
+     */
+    public function persist($props): void
+    {
+        if (is_array($props)) {
+            $this->persisted = array_merge($this->persisted, $props);
+        } elseif ($props instanceof Arrayable) {
+            $this->persisted = array_merge($this->persisted, $props->toArray());
+        } else {
+            $this->persisted[] = $props;
+        }
+    }
+
+    public function getPersisted(): array
+    {
+        return $this->persisted;
+    }
+
+    public function flushPersisted(): void
+    {
+        $this->persisted = [];
+    }
+
+    /**
      * @param Closure|string|null $version
      */
     public function version($version): void
@@ -101,7 +128,8 @@ class ResponseFactory
             $component,
             array_merge($this->sharedProps, $props),
             $this->rootView,
-            $this->getVersion()
+            $this->getVersion(),
+            $this->persisted
         );
     }
 

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -239,10 +239,39 @@ class MiddlewareTest extends TestCase
         $response->assertViewIs('welcome');
     }
 
-    private function prepareMockEndpoint($version = null, $shared = [], $middleware = null): \Illuminate\Routing\Route
+    public function test_middleware_can_set_persisted_properties(): void
+    {
+        $shared = [
+            'shared' => [
+                'flash' => 'The user has been updated.'
+            ]
+        ];
+
+        $this->prepareMockEndpoint(null, $shared, null, ['shared']);
+
+        $response = $this->get('/', [
+            'X-Inertia' => 'true',
+            'X-Inertia-Partial-Component' => 'User/Edit',
+            'X-Inertia-Partial-Data' => 'user'
+        ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'props' => [
+                'shared' => [
+                    'flash' => 'The user has been updated.'
+                ],
+                'user' => [
+                    'name' => 'Jonathan',
+                ]
+            ]
+        ]);
+    }
+
+    private function prepareMockEndpoint($version = null, $shared = [], $middleware = null, $persisted = []): \Illuminate\Routing\Route
     {
         if (is_null($middleware)) {
-            $middleware = new ExampleMiddleware($version, $shared);
+            $middleware = new ExampleMiddleware($version, $shared, $persisted);
         }
 
         return Route::middleware(StartSession::class)->get('/', function (Request $request) use ($middleware) {

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -150,6 +150,22 @@ class ResponseFactoryTest extends TestCase
         $this->assertSame([], Inertia::getShared());
     }
 
+    public function test_can_persist_properties(): void
+    {
+        Inertia::persist('auth.user');
+        $this->assertSame(['auth.user'], Inertia::getPersisted());
+        Inertia::persist(['posts']);
+        $this->assertSame(['auth.user', 'posts'], Inertia::getPersisted());
+    }
+
+    public function test_can_flush_persisted_data(): void
+    {
+        Inertia::persist('auth.user');
+        $this->assertSame(['auth.user'], Inertia::getPersisted());
+        Inertia::flushPersisted();
+        $this->assertSame([], Inertia::getPersisted());
+    }
+
     public function test_can_create_lazy_prop(): void
     {
         $factory = new ResponseFactory();

--- a/tests/Stubs/ExampleMiddleware.php
+++ b/tests/Stubs/ExampleMiddleware.php
@@ -19,10 +19,16 @@ class ExampleMiddleware extends Middleware
      */
     protected $shared = [];
 
-    public function __construct($version = null, $shared = [])
+    /**
+     * @var array
+     */
+    protected $persisted = [];
+
+    public function __construct($version = null, $shared = [], $persisted = [])
     {
         $this->version = $version;
         $this->shared = $shared;
+        $this->persisted = $persisted;
     }
 
     /**


### PR DESCRIPTION
The PR introduces an ability to persist properties on partial requests.

When making a partial reload, Inertia will only evaluate and include on the response properties, specified in the `only` array. This adds some extra inconvenience when you need to carry some common data between pages (e.g. current user data).

```php
Inertia::persist('auth.user');
// or
inertia()->persist(['auth.user'])
```

```js
router.visit(url, {
  only: ['billing'],
})
```

```php
$props = [
    // Included on partial reload
    'auth' => [
        'user' => new LazyProp(function () {
            return [
                'name' => 'Jonathan Reinink',
                'email' => 'jonathan@example.com',
            ];
        }),
    ],

    // Included on partial reload
    'billing' => [
        //
    ],
    
    // Not included on partial reload
    'data' => [
        //
    ],
];
```

Alternatively, you can define persistent properties globally in a middleware. These will be available on any request.

```php
class HandleInertiaRequests extends Middleware
{
    protected $persisted = ['auth.user'];

    public function share(Request $request): array
    {
        return array_merge(parent::share($request), [
            'auth' => [
                'user' => new LazyProp(function () {
                    return [
                        'name' => 'Jonathan Reinink',
                        'email' => 'jonathan@example.com',
                    ];
                }),
            ],
        ]);
    }
}
```

Example use cases:
- Flash messages
- Auth data