### PR TITLE
Exclude `except` props from partial reloads

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -111,7 +111,7 @@ class Response implements Responsable
     {
         $isPartial = $request->header(Header::PARTIAL_COMPONENT) === $this->component;
 
-        if(!$isPartial) {
+        if(! $isPartial) {
             $props = array_filter($this->props, static function ($prop) {
                 return ! ($prop instanceof LazyProp);
             });
@@ -121,6 +121,10 @@ class Response implements Responsable
 
         if($isPartial && $request->hasHeader(Header::PARTIAL_ONLY)) {
             $props = $this->resolveOnly($request, $props);
+        }
+
+        if($isPartial && $request->hasHeader(Header::PARTIAL_EXCEPT)) {
+            $props = $this->resolveExcept($request, $props);
         }
 
         $props = $this->resolvePropertyInstances($props, $request);
@@ -167,6 +171,18 @@ class Response implements Responsable
         }
 
         return $value;
+    }
+
+    /**
+     * Resolve the `except` partial request props.
+     */
+    public function resolveExcept(Request $request, array $props): array
+    {
+        $except = array_filter(explode(',', $request->header(Header::PARTIAL_EXCEPT, '')));
+
+        Arr::forget($props, $except);
+
+        return $props;
     }
 
     /**

--- a/src/Support/Header.php
+++ b/src/Support/Header.php
@@ -10,4 +10,5 @@ class Header
     public const VERSION = 'X-Inertia-Version';
     public const PARTIAL_COMPONENT = 'X-Inertia-Partial-Component';
     public const PARTIAL_ONLY = 'X-Inertia-Partial-Data';
+    public const PARTIAL_EXCEPT = 'X-Inertia-Partial-Except';
 }


### PR DESCRIPTION
The PR introduces an ability to exclude properties from partial responses. The `except` option can be used together with `only` to refine nested props.

The corresponding client-side PR: https://github.com/inertiajs/inertia/pull/1876

```js
router.visit(url, {
  only: ['auth'],
  except: ['auth.user'],
})
```

```php
$props = [
    // Included on partial reload
    'auth' => [
        // Excluded from partial reload
        'user' => new LazyProp(function () {
            return [
                'name' => 'Jonathan Reinink',
                'email' => 'jonathan@example.com',
            ];
        }),
        // Included on partial reload
        'refresh_token' => 'value',
    ],
    // Excluded from partial reload
    'shared' => [
        'flash' => 'value',
    ],
];
```