### PR TITLE
Add environment variables for SSR enabled and url options

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -21,9 +21,9 @@ return [
 
     'ssr' => [
 
-        'enabled' => true,
+        'enabled' => (bool) env('INERTIA_SSR_ENABLED', true),
 
-        'url' => 'http://127.0.0.1:13714',
+        'url' => env('INERTIA_SSR_URL', 'http://127.0.0.1:13714'),
 
         // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
 


### PR DESCRIPTION
### Summary

- Wrap the config values for `inertia.ssr.enabled` and `inertia.ssr.url` with environment variables:
  - `INERTIA_SSR_ENABLED`, with default value of `true`
  - `INERTIA_SSR_URL`, with default value of `http://127.0.0.1:13714`

### Why?

As it would be nice to be able to configure these values out of the box based on environment variables (for example when running in Docker or Kubernetes), this makes it so people don't have to publish the configuration to edit these values. Nor does it require file system changes, cause ideally all external dependencies of an app should be able to be configured through environment.
