### PR TITLE
Change the rootView from configuration

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Server Side Rendering
+    | Default Root View
     |--------------------------------------------------------------------------
     |
     | This options configures which view should be set as default root view.

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -7,6 +7,19 @@ return [
     | Server Side Rendering
     |--------------------------------------------------------------------------
     |
+    | This options configures which view should be set as default root view.
+    | By default is program is set to look for `resources/views/app.blade.php`.
+    | Can be changed on using `Inertia::setRootView()` method anytime.
+    |
+    */
+
+    'root_view' => 'app',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Server Side Rendering
+    |--------------------------------------------------------------------------
+    |
     | These options configures if and how Inertia uses Server Side Rendering
     | to pre-render the initial visits made to your application's pages.
     |

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -5,6 +5,7 @@ namespace Inertia;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
@@ -29,6 +30,13 @@ class ResponseFactory
 
     /** @var Closure|string|null */
     protected $version;
+
+    public function __construct()
+    {
+        $configuredRootView = Config::get('inertia.root_view', 'app');
+
+        $this->setRootView($configuredRootView);
+    }
 
     public function setRootView(string $name): void
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -19,13 +19,13 @@ class ServiceProvider extends BaseServiceProvider
 {
     public function register(): void
     {
-        $this->app->singleton(ResponseFactory::class);
-        $this->app->bind(Gateway::class, HttpGateway::class);
-
         $this->mergeConfigFrom(
             __DIR__.'/../config/inertia.php',
             'inertia'
         );
+
+        $this->app->singleton(ResponseFactory::class);
+        $this->app->bind(Gateway::class, HttpGateway::class);
 
         $this->registerBladeDirectives();
         $this->registerRequestMacro();


### PR DESCRIPTION
`ResponseFactory.php` class defines the *$rootView* point to `app.blade.php`. I thought it would be easy to configure it. Anyone who publishes the config file can easily change it. `ServiceProvider` boot method workaround also has the same output. IMHO This way, it feels more neat.

![image](https://github.com/inertiajs/inertia-laravel/assets/24684511/734ff3ff-653f-4da6-89f8-7da8316ed946)
