### PR TITLE
Add "always" props using new `Inertia::always()` wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/inertiajs/inertia-laravel/compare/v1.2.0...1.x)
 
+- Add "always" props using new `Inertia::always()` wrapper ([#627](https://github.com/inertiajs/inertia-laravel/pull/627))
+
 ## [v1.2.0](https://github.com/inertiajs/inertia-laravel/compare/v1.1.0...v1.2.0) - 2024-05-17
 
 * [1.x] Make commands lazy by [@timacdonald](https://github.com/timacdonald) in https://github.com/inertiajs/inertia-laravel/pull/601

--- a/src/AlwaysProp.php
+++ b/src/AlwaysProp.php
@@ -2,7 +2,6 @@
 
 namespace Inertia;
 
-use Closure;
 use Illuminate\Support\Facades\App;
 
 class AlwaysProp
@@ -20,6 +19,6 @@ class AlwaysProp
 
     public function __invoke()
     {
-        return $this->value instanceof Closure ? App::call($this->value) : $this->value;
+        return is_callable($this->value) ? App::call($this->value) : $this->value;
     }
 }

--- a/src/AlwaysProp.php
+++ b/src/AlwaysProp.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Inertia;
+
+use Illuminate\Support\Facades\App;
+
+class AlwaysProp
+{
+    protected $callback;
+
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    public function __invoke()
+    {
+        return App::call($this->callback);
+    }
+}

--- a/src/AlwaysProp.php
+++ b/src/AlwaysProp.php
@@ -2,19 +2,21 @@
 
 namespace Inertia;
 
-use Illuminate\Support\Facades\App;
-
 class AlwaysProp
 {
-    protected $callback;
+    /** @var mixed */
+    protected $value;
 
-    public function __construct(callable $callback)
+    /**
+     * @param mixed $value
+     */
+    public function __construct($value)
     {
-        $this->callback = $callback;
+        $this->value = $value;
     }
 
     public function __invoke()
     {
-        return App::call($this->callback);
+        return value($this->value);
     }
 }

--- a/src/AlwaysProp.php
+++ b/src/AlwaysProp.php
@@ -2,6 +2,9 @@
 
 namespace Inertia;
 
+use Closure;
+use Illuminate\Support\Facades\App;
+
 class AlwaysProp
 {
     /** @var mixed */
@@ -17,6 +20,6 @@ class AlwaysProp
 
     public function __invoke()
     {
-        return value($this->value);
+        return $this->value instanceof Closure ? App::call($this->value) : $this->value;
     }
 }

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void version(\Closure|string|null $version)
  * @method static string getVersion()
  * @method static \Inertia\LazyProp lazy(callable $callback)
- * @method static \Inertia\AlwaysProp always(callable $callback)
+ * @method static \Inertia\AlwaysProp always(mixed $value)
  * @method static \Inertia\Response render(string $component, array|\Illuminate\Contracts\Support\Arrayable $props = [])
  * @method static \Symfony\Component\HttpFoundation\Response location(string|\Symfony\Component\HttpFoundation\RedirectResponse $url)
  * @method static void macro(string $name, object|callable $macro)

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -12,15 +12,13 @@ use Illuminate\Support\Facades\Facade;
  * @method static void version(\Closure|string|null $version)
  * @method static string getVersion()
  * @method static \Inertia\LazyProp lazy(callable $callback)
+ * @method static \Inertia\AlwaysProp always(callable $callback)
  * @method static \Inertia\Response render(string $component, array|\Illuminate\Contracts\Support\Arrayable $props = [])
  * @method static \Symfony\Component\HttpFoundation\Response location(string|\Symfony\Component\HttpFoundation\RedirectResponse $url)
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
- * @method static void persist(string|array|\Illuminate\Contracts\Support\Arrayable $props)
- * @method static array getPersisted()
- * @method static void flushPersisted()
  *
  * @see \Inertia\ResponseFactory
  */

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -53,9 +53,7 @@ class Middleware
     public function share(Request $request)
     {
         return [
-            'errors' => new AlwaysProp(function () use ($request) {
-                return $this->resolveValidationErrors($request);
-            }),
+            'errors' => Inertia::always($this->resolveValidationErrors($request)),
         ];
     }
 

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -20,13 +20,6 @@ class Middleware
     protected $rootView = 'app';
 
     /**
-     * The properties that should always be included on Inertia responses, regardless of "only" or "except" requests.
-     *
-     * @var array
-     */
-    protected $persisted = [];
-
-    /**
      * Determines the current asset version.
      *
      * @see https://inertiajs.com/asset-versioning
@@ -60,9 +53,9 @@ class Middleware
     public function share(Request $request)
     {
         return [
-            'errors' => function () use ($request) {
+            'errors' => new AlwaysProp(function () use ($request) {
                 return $this->resolveValidationErrors($request);
-            },
+            }),
         ];
     }
 
@@ -90,7 +83,6 @@ class Middleware
         });
 
         Inertia::share($this->share($request));
-        Inertia::persist($this->persisted);
         Inertia::setRootView($this->rootView($request));
 
         $response = $next($request);

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -24,9 +24,6 @@ class ResponseFactory
     /** @var array */
     protected $sharedProps = [];
 
-    /** @var array */
-    protected $persisted = [];
-
     /** @var Closure|string|null */
     protected $version;
 
@@ -70,30 +67,6 @@ class ResponseFactory
     }
 
     /**
-     * @param string|array|Arrayable $props
-     */
-    public function persist($props): void
-    {
-        if (is_array($props)) {
-            $this->persisted = array_merge($this->persisted, $props);
-        } elseif ($props instanceof Arrayable) {
-            $this->persisted = array_merge($this->persisted, $props->toArray());
-        } else {
-            $this->persisted[] = $props;
-        }
-    }
-
-    public function getPersisted(): array
-    {
-        return $this->persisted;
-    }
-
-    public function flushPersisted(): void
-    {
-        $this->persisted = [];
-    }
-
-    /**
      * @param Closure|string|null $version
      */
     public function version($version): void
@@ -115,6 +88,11 @@ class ResponseFactory
         return new LazyProp($callback);
     }
 
+    public function always(callable $callback): AlwaysProp
+    {
+        return new AlwaysProp($callback);
+    }
+
     /**
      * @param array|Arrayable $props
      */
@@ -128,8 +106,7 @@ class ResponseFactory
             $component,
             array_merge($this->sharedProps, $props),
             $this->rootView,
-            $this->getVersion(),
-            $this->persisted
+            $this->getVersion()
         );
     }
 

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -88,9 +88,12 @@ class ResponseFactory
         return new LazyProp($callback);
     }
 
-    public function always(callable $callback): AlwaysProp
+    /**
+     * @param mixed $value
+     */
+    public function always($value): AlwaysProp
     {
-        return new AlwaysProp($callback);
+        return new AlwaysProp($value);
     }
 
     /**

--- a/tests/AlwaysPropTest.php
+++ b/tests/AlwaysPropTest.php
@@ -23,6 +23,19 @@ class AlwaysPropTest extends TestCase
         $this->assertSame('An always value', $alwaysProp());
     }
 
+    public function test_can_accept_callables(): void
+    {
+        $callable = new class {
+            public function __invoke() {
+                return 'An always value';
+            }
+        };
+
+        $alwaysProp = new AlwaysProp($callable);
+
+        $this->assertSame('An always value', $alwaysProp());
+    }
+
     public function test_can_resolve_bindings_when_invoked(): void
     {
         $alwaysProp = new AlwaysProp(function (Request $request) {

--- a/tests/AlwaysPropTest.php
+++ b/tests/AlwaysPropTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Illuminate\Http\Request;
+use Inertia\AlwaysProp;
+
+class AlwaysPropTest extends TestCase
+{
+    public function test_can_invoke(): void
+    {
+        $alwaysProp = new AlwaysProp(function () {
+            return 'An always value';
+        });
+
+        $this->assertSame('An always value', $alwaysProp());
+    }
+
+    public function test_can_accept_scalar_values(): void
+    {
+        $alwaysProp = new AlwaysProp('An always value');
+
+        $this->assertSame('An always value', $alwaysProp());
+    }
+
+    public function test_can_resolve_bindings_when_invoked(): void
+    {
+        $alwaysProp = new AlwaysProp(function (Request $request) {
+            return $request;
+        });
+
+        $this->assertInstanceOf(Request::class, $alwaysProp());
+    }
+}

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -2,7 +2,6 @@
 
 namespace Inertia\Tests;
 
-use Closure;
 use LogicException;
 use Inertia\Inertia;
 use Inertia\Middleware;
@@ -13,6 +12,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
 use Inertia\Tests\Stubs\ExampleMiddleware;
 use Illuminate\Session\Middleware\StartSession;
+use Inertia\AlwaysProp;
 
 class MiddlewareTest extends TestCase
 {
@@ -125,7 +125,7 @@ class MiddlewareTest extends TestCase
     public function test_validation_errors_are_registered_as_of_default(): void
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
-            $this->assertInstanceOf(Closure::class, Inertia::getShared('errors'));
+            $this->assertInstanceOf(AlwaysProp::class, Inertia::getShared('errors'));
         });
 
         $this->withoutExceptionHandling()->get('/');
@@ -239,39 +239,10 @@ class MiddlewareTest extends TestCase
         $response->assertViewIs('welcome');
     }
 
-    public function test_middleware_can_set_persisted_properties(): void
-    {
-        $shared = [
-            'shared' => [
-                'flash' => 'The user has been updated.'
-            ]
-        ];
-
-        $this->prepareMockEndpoint(null, $shared, null, ['shared']);
-
-        $response = $this->get('/', [
-            'X-Inertia' => 'true',
-            'X-Inertia-Partial-Component' => 'User/Edit',
-            'X-Inertia-Partial-Data' => 'user'
-        ]);
-
-        $response->assertOk();
-        $response->assertJson([
-            'props' => [
-                'shared' => [
-                    'flash' => 'The user has been updated.'
-                ],
-                'user' => [
-                    'name' => 'Jonathan',
-                ]
-            ]
-        ]);
-    }
-
-    private function prepareMockEndpoint($version = null, $shared = [], $middleware = null, $persisted = []): \Illuminate\Routing\Route
+    private function prepareMockEndpoint($version = null, $shared = [], $middleware = null): \Illuminate\Routing\Route
     {
         if (is_null($middleware)) {
-            $middleware = new ExampleMiddleware($version, $shared, $persisted);
+            $middleware = new ExampleMiddleware($version, $shared);
         }
 
         return Route::middleware(StartSession::class)->get('/', function (Request $request) use ($middleware) {

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -15,6 +15,7 @@ use Illuminate\Http\Request as HttpRequest;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Session\NullSessionHandler;
 use Illuminate\Session\Store;
+use Inertia\AlwaysProp;
 
 class ResponseFactoryTest extends TestCase
 {
@@ -150,22 +151,6 @@ class ResponseFactoryTest extends TestCase
         $this->assertSame([], Inertia::getShared());
     }
 
-    public function test_can_persist_properties(): void
-    {
-        Inertia::persist('auth.user');
-        $this->assertSame(['auth.user'], Inertia::getPersisted());
-        Inertia::persist(['posts']);
-        $this->assertSame(['auth.user', 'posts'], Inertia::getPersisted());
-    }
-
-    public function test_can_flush_persisted_data(): void
-    {
-        Inertia::persist('auth.user');
-        $this->assertSame(['auth.user'], Inertia::getPersisted());
-        Inertia::flushPersisted();
-        $this->assertSame([], Inertia::getPersisted());
-    }
-
     public function test_can_create_lazy_prop(): void
     {
         $factory = new ResponseFactory();
@@ -174,6 +159,16 @@ class ResponseFactoryTest extends TestCase
         });
 
         $this->assertInstanceOf(LazyProp::class, $lazyProp);
+    }
+
+    public function test_can_create_always_prop(): void
+    {
+        $factory = new ResponseFactory();
+        $alwaysProp = $factory->always(function () {
+            return 'An always value';
+        });
+
+        $this->assertInstanceOf(AlwaysProp::class, $alwaysProp);
     }
 
     public function test_will_accept_arrayabe_props()

--- a/tests/Stubs/ExampleMiddleware.php
+++ b/tests/Stubs/ExampleMiddleware.php
@@ -19,16 +19,10 @@ class ExampleMiddleware extends Middleware
      */
     protected $shared = [];
 
-    /**
-     * @var array
-     */
-    protected $persisted = [];
-
-    public function __construct($version = null, $shared = [], $persisted = [])
+    public function __construct($version = null, $shared = [])
     {
         $this->version = $version;
         $this->shared = $shared;
-        $this->persisted = $persisted;
     }
 
     /**


### PR DESCRIPTION
Introduce `Inertia::always()` wrapper to replace the current [persistent props](https://github.com/inertiajs/inertia-laravel/pull/621) implementation.

```php
return [
    'flash' => Inertia::always(session('flash')),
];
```

Lazy data evaluation behavior:

```php
return Inertia::render('Users/Index', [
    // ALWAYS included on first visit...
    // OPTIONALLY included on partial reloads...
    // ALWAYS evaluated...
    'users' => User::get(),

    // ALWAYS included on first visit...
    // OPTIONALLY included on partial reloads...
    // ONLY evaluated when needed...
    'users' => fn () => User::get(),

    // NEVER included on first visit...
    // OPTIONALLY included on partial reloads...
    // ONLY evaluated when needed...
    'users' => Inertia::lazy(fn () => User::get()),
    
    // ALWAYS included on first visit...
    // ALWAYS included on partial reloads...
    // ALWAYS evaluated...
    'users' => Inertia::always(User::get()),
]);
```