### PR TITLE
Drop support for Laravel 8 and 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,44 +12,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, "8.0", 8.1, 8.2, 8.3]
-        laravel: [8, 9, 10, 11]
+        php: [8.1, 8.2, 8.3]
+        laravel: [10, 11]
         stability: ["prefer-lowest", "prefer-stable"]
         exclude:
-          - php: 7.3
-            laravel: 9
-          - php: 7.3
-            laravel: 10
-          - php: 7.3
-            laravel: 11
-          - php: 7.4
-            laravel: 9
-          - php: 7.4
-            laravel: 10
-          - php: 7.4
-            laravel: 11
-          - php: '8.0'
-            laravel: 10
-          - php: '8.0'
-            laravel: 11
-          - php: 8.1
-            laravel: 6
-          - php: 8.1
-            laravel: 7
           - php: 8.1
             laravel: 11
-          - php: 8.2
-            laravel: 6
-          - php: 8.2
-            laravel: 7
-          - php: 8.2
-            laravel: 8
-          - php: 8.3
-            laravel: 6
-          - php: 8.3
-            laravel: 7
-          - php: 8.3
-            laravel: 8
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} (w/ ${{ matrix.stability }})
     steps:

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,10 @@
     "name": "inertiajs/inertia-laravel",
     "type": "library",
     "description": "The Laravel adapter for Inertia.js.",
-    "keywords": ["laravel", "inertia"],
+    "keywords": [
+        "laravel",
+        "inertia"
+    ],
     "license": "MIT",
     "authors": [
         {
@@ -25,16 +28,16 @@
         }
     },
     "require": {
-        "php": "^7.3|~8.0.0|~8.1.0|~8.2.0|~8.3.0",
+        "php": "^8.1.0",
         "ext-json": "*",
-        "laravel/framework": "^8.74|^9.0|^10.0|^11.0",
+        "laravel/framework": "^10.0|^11.0",
         "symfony/console": "^5.3|^6.0|^7.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "orchestra/testbench": "^6.4|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^8.0|^9.0",
         "mockery/mockery": "^1.3.3",
-        "phpunit/phpunit": "^8.0|^9.5.8|^10.4",
+        "phpunit/phpunit": "^10.4|^11.0",
         "laravel/pint": "^1.16"
     },
     "suggest": {

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -8,8 +8,7 @@ use PHPUnit\Framework\AssertionFailedError;
 
 class AssertableInertiaTest extends TestCase
 {
-    /** @test */
-    public function the_view_is_served_by_inertia(): void
+    public function test_the_view_is_served_by_inertia(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo')
@@ -18,8 +17,7 @@ class AssertableInertiaTest extends TestCase
         $response->assertInertia();
     }
 
-    /** @test */
-    public function the_view_is_not_served_by_inertia(): void
+    public function test_the_view_is_not_served_by_inertia(): void
     {
         $response = $this->makeMockRequest(view('welcome'));
         $response->assertOk(); // Make sure we can render the built-in Orchestra 'welcome' view..
@@ -30,8 +28,7 @@ class AssertableInertiaTest extends TestCase
         $response->assertInertia();
     }
 
-    /** @test */
-    public function the_component_matches(): void
+    public function test_the_component_matches(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo')
@@ -42,8 +39,7 @@ class AssertableInertiaTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_component_does_not_match(): void
+    public function test_the_component_does_not_match(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo')
@@ -57,8 +53,7 @@ class AssertableInertiaTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_component_exists_on_the_filesystem(): void
+    public function test_the_component_exists_on_the_filesystem(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('Stubs/ExamplePage')
@@ -70,8 +65,7 @@ class AssertableInertiaTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_component_does_not_exist_on_the_filesystem(): void
+    public function test_the_component_does_not_exist_on_the_filesystem(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo')
@@ -86,8 +80,7 @@ class AssertableInertiaTest extends TestCase
         });
     }
 
-    /** @test */
-    public function it_can_force_enable_the_component_file_existence(): void
+    public function test_it_can_force_enable_the_component_file_existence(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo')
@@ -102,8 +95,7 @@ class AssertableInertiaTest extends TestCase
         });
     }
 
-    /** @test */
-    public function it_can_force_disable_the_component_file_existence_check(): void
+    public function test_it_can_force_disable_the_component_file_existence_check(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo')
@@ -116,8 +108,7 @@ class AssertableInertiaTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_component_does_not_exist_on_the_filesystem_when_it_does_not_exist_relative_to_any_of_the_given_paths(): void
+    public function test_the_component_does_not_exist_on_the_filesystem_when_it_does_not_exist_relative_to_any_of_the_given_paths(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('fixtures/ExamplePage')
@@ -133,8 +124,7 @@ class AssertableInertiaTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_component_does_not_exist_on_the_filesystem_when_it_does_not_have_one_of_the_configured_extensions(): void
+    public function test_the_component_does_not_exist_on_the_filesystem_when_it_does_not_have_one_of_the_configured_extensions(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('fixtures/ExamplePage')
@@ -150,8 +140,7 @@ class AssertableInertiaTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_page_url_matches(): void
+    public function test_the_page_url_matches(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo')
@@ -162,8 +151,7 @@ class AssertableInertiaTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_page_url_does_not_match(): void
+    public function test_the_page_url_does_not_match(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo')
@@ -177,8 +165,7 @@ class AssertableInertiaTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_asset_version_matches(): void
+    public function test_the_asset_version_matches(): void
     {
         Inertia::version('example-version');
 
@@ -191,8 +178,7 @@ class AssertableInertiaTest extends TestCase
         });
     }
 
-    /** @test */
-    public function the_asset_version_does_not_match(): void
+    public function test_the_asset_version_does_not_match(): void
     {
         Inertia::version('example-version');
 

--- a/tests/Testing/TestResponseMacrosTest.php
+++ b/tests/Testing/TestResponseMacrosTest.php
@@ -8,8 +8,7 @@ use Inertia\Tests\TestCase;
 
 class TestResponseMacrosTest extends TestCase
 {
-    /** @test */
-    public function it_can_make_inertia_assertions(): void
+    public function test_it_can_make_inertia_assertions(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo')
@@ -24,8 +23,7 @@ class TestResponseMacrosTest extends TestCase
         $this->assertTrue($success);
     }
 
-    /** @test */
-    public function it_preserves_the_ability_to_continue_chaining_laravel_test_response_calls(): void
+    public function test_it_preserves_the_ability_to_continue_chaining_laravel_test_response_calls(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo')
@@ -37,8 +35,7 @@ class TestResponseMacrosTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_can_retrieve_the_inertia_page(): void
+    public function test_it_can_retrieve_the_inertia_page(): void
     {
         $response = $this->makeMockRequest(
             Inertia::render('foo', ['bar' => 'baz'])


### PR DESCRIPTION
This PR drops support for Laravel 8 and 9, as well as PHP 7 and 8.