### PR TITLE
[2.x] Feat: Add strict model serialization

### DIFF
--- a/src/Exceptions/StrictPropertiesException.php
+++ b/src/Exceptions/StrictPropertiesException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Inertia\Exceptions;
+
+class StrictPropertiesException extends \Exception
+{
+    public static function for(string $key): self
+    {
+        return new static("Prop \"{$key}\" is shared without serialization rules.");
+    }
+}

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -27,6 +27,8 @@ class ResponseFactory
     /** @var Closure|string|null */
     protected $version;
 
+    protected $strictModels = false;
+
     public function setRootView(string $name): void
     {
         $this->rootView = $name;
@@ -108,7 +110,8 @@ class ResponseFactory
             $component,
             array_merge($this->sharedProps, $props),
             $this->rootView,
-            $this->getVersion()
+            $this->getVersion(),
+            $this->strictModels,
         );
     }
 
@@ -122,5 +125,10 @@ class ResponseFactory
         }
 
         return $url instanceof SymfonyRedirect ? $url : Redirect::away($url);
+    }
+
+    public function strictModels(bool $enabled = true): void
+    {
+        $this->strictModels = $enabled;
     }
 }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -3,8 +3,10 @@
 namespace Inertia\Tests;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Foundation\Auth\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request as HttpRequest;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Response;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Session\NullSessionHandler;
@@ -12,6 +14,7 @@ use Illuminate\Session\Store;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Route;
 use Inertia\AlwaysProp;
+use Inertia\Exceptions\StrictPropertiesException;
 use Inertia\Inertia;
 use Inertia\LazyProp;
 use Inertia\ResponseFactory;
@@ -193,6 +196,84 @@ class ResponseFactoryTest extends TestCase
             'component' => 'User/Edit',
             'props' => [
                 'foo' => 'bar',
+            ],
+        ]);
+    }
+
+    public function test_strict_models_mode_checks_if_models_have_serialization_rules()
+    {
+        $this->expectException(StrictPropertiesException::class);
+        $this->expectExceptionMessage('Prop "user" is shared without serialization rules.');
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::strictModels();
+
+            return Inertia::render('User/Edit', [
+                'user' => new class(['name' => 'John']) extends User {
+                    protected $fillable = [
+                        'name',
+                    ];
+                },
+            ]);
+        });
+
+        $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+    }
+
+    public function test_strict_models_mode_checks_for_json_resources()
+    {
+        $this->expectException(StrictPropertiesException::class);
+        $this->expectExceptionMessage('Prop "user" is shared without serialization rules.');
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::strictModels();
+
+            return Inertia::render('User/Edit', [
+                'user' => new class(['name' => 'John']) extends User {
+                    protected $fillable = [
+                        'name',
+                    ];
+                },
+            ]);
+        });
+
+        $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+    }
+
+    public function test_strict_models_allows_wrapping_in_json_resources()
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::strictModels();
+
+            $user = new class(['name' => 'John', 'email' => 'john@doe.com']) extends User {
+                protected $fillable = [
+                    'name',
+                    'email',
+                ];
+            };
+
+            return Inertia::render('User/Edit', [
+                'user' => new class($user) extends JsonResource {
+                    public static $wrap = null;
+
+                    public function toArray($request)
+                    {
+                        return [
+                            'name' => $this->name,
+                        ];
+                    }
+                },
+            ]);
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+        $response->assertSuccessful();
+        $response->assertJson([
+            'component' => 'User/Edit',
+            'props' => [
+                'user' => [
+                    'name' => 'John',
+                ],
             ],
         ]);
     }


### PR DESCRIPTION
With Inertia it's rather common to make a response like the following:

```php
Inertia::render('Users/Edit', [
	'user' => $request->user(),
]);
```

However, without proper serialization guards this can be quite dangerous, since it's easy to send more data to the frontend than needed. Inertia has no safeguards against this and it would be impossible for Inertia prevent any secret data to be shared with the frontend. However, we can inspect the type of data that is sent to the frontend.

For this reason I propose a `Inertia::strictModels()` method, inspired by Laravel's `Model::shouldBeStrict()` (https://laravel.com/api/11.x/Illuminate/Database/Eloquent/Model.html#method_shouldBeStrict). This should be called in a service provider by the developer. Then when it is enabled a fairly basic check is performed;
- If the data is not a model it is allowed, this would include the usage of a JsonResource or Spatie's Laravel Data
- If it is a model a check is done to make sure either the `hidden` or `visible` property is filled

I always use Eloquent's API resources or Spatie's Laravel Data for data that's sent to the frontend, with this it would be easier to enforce this in projects.