### PR TITLE
[1.x] Fix resolving response arrayable properties

### DIFF
--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -217,14 +217,18 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia' => 'true']);
 
         $data = AsArrayable::make([
-            'user' => fn () => [
-                'full_name' => 'Victor Gutt',
-                'organizations' => [
-                    fn () => AsArrayable::make([
-                        'name' => 'Transl.me',
-                    ]),
-                ],
-            ],
+            'user' => function () {
+                return [
+                    'full_name' => 'Victor Gutt',
+                    'organizations' => [
+                        function () {
+                            return AsArrayable::make([
+                                'name' => 'Transl.me',
+                            ]);
+                        },
+                    ],
+                ];
+            },
         ]);
 
         $response = new Response('Auth/Index', ['data' => $data], 'app', '123');

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -213,7 +213,7 @@ class ResponseTest extends TestCase
 
     public function test_nested_arrayable_prop_response(): void
     {
-        $request = Request::create('/auth', 'GET');
+        $request = Request::create('/user/123', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
         $data = AsArrayable::make([
@@ -231,15 +231,15 @@ class ResponseTest extends TestCase
             },
         ]);
 
-        $response = new Response('Auth/Index', ['data' => $data], 'app', '123');
+        $response = new Response('User/Edit', ['data' => $data], 'app', '123');
         $response = $response->toResponse($request);
         $page = $response->getData();
 
         $this->assertInstanceOf(JsonResponse::class, $response);
-        $this->assertSame('Auth/Index', $page->component);
+        $this->assertSame('User/Edit', $page->component);
         $this->assertSame('Victor Gutt', $page->props->data->user->full_name);
         $this->assertSame('Transl.me', $page->props->data->user->organizations[0]->name);
-        $this->assertSame('/auth', $page->url);
+        $this->assertSame('/user/123', $page->url);
         $this->assertSame('123', $page->version);
     }
 

--- a/tests/Stubs/AsArrayable.php
+++ b/tests/Stubs/AsArrayable.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Inertia\Tests\Stubs;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+/**
+ * @implements Arrayable<array-key, mixed>
+ */
+class AsArrayable implements Arrayable {
+    /**
+     * @var array
+     */
+    protected $data = [];
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public static function make(array $data): self {
+        return new self($data);
+    }
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array {
+        return $this->data;
+    }
+}


### PR DESCRIPTION
Prior to https://github.com/inertiajs/inertia-laravel/pull/620, property instances were resolved [before](https://github.com/inertiajs/inertia-laravel/pull/620/files?diff=split&w=0#diff-e1ee2fcc629f38d16eaba23b95a87eb8e7466fae0954483c4b8ca8ad78242e0aL136) handling arrayable/array values when sending a response.

Consider the following Inertia response dump:

<details>

<summary>AsArrayable</summary>

```php
use Illuminate\Contracts\Support\Arrayable;

class AsArrayable implements Arrayable {
    public function __construct(private array $data) {}

    public static function make(array $data): static {
        return new static($data);
    }

    public function toArray(): array {
        return $this->data;
    }
}
```
</details>


```php
use Inertia\Inertia;
use Illuminate\Http\Request;

$request = Request::create('/auth', 'GET');

$response = Inertia::render('auth', [
    'user' => fn () => [
        'full_name' => 'Victor Gutt',
        'organizations' => AsArrayable::make([
            fn () => [
                'name' => 'Transl.me',
            ],
        ]),
    ],
]);

$response = $response->toResponse($request);

dd(
    $response->original->getData()['page']['props'],
);
```

Before this fix, the dump would be similar to:

```php
Inertia\Tests\ResponseTest
array:1 [
  "user" => array:2 [
    "full_name" => "Victor Gutt"
    "organizations" => Inertia\Tests\Stubs\AsArrayable {#1291
      #data: array:1 [
        0 => Closure() {#1277
          class: "Inertia\Tests\ResponseTest"
          this: Inertia\Tests\ResponseTest {#173 …}
        }
      ]
    }
  ]
]
```

As we can see, nested _(`user.organizations`)_ arrayable values are no longer resolved.

After this fix, the dump is similar to:

```php
Inertia\Tests\ResponseTest
array:1 [
  "user" => array:2 [
    "full_name" => "Victor Gutt"
    "organizations" => array:1 [
      0 => array:1 [
        "name" => "Transl.me"
      ]
    ]
  ]
]
```

This PR aims to bring back the behaviour prior to #620.