### PR TITLE
[1.x] Fix shared dot props

### DIFF
--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -196,6 +196,30 @@ class MiddlewareTest extends TestCase
         ]);
     }
 
+    public function test_middleware_can_share_props_with_dot_notation(): void
+    {
+        $this->prepareMockEndpoint(null, [
+            'auth.permissions.is_admin' => true,
+            'user.verified' => true,
+        ]);
+
+        $response = $this->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertJson([
+            'props' => [
+                'user' => [
+                    'name' => 'Jonathan',
+                    'verified' => true,
+                ],
+                'auth' => [
+                    'permissions' => [
+                        'is_admin' => true,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public function test_validation_errors_are_scoped_to_error_bag_header(): void
     {
         Session::put('errors', (new ViewErrorBag())->put('default', new MessageBag([


### PR DESCRIPTION
I _think_ #620 introduced a breaking change when sharing props through the middleware, as described in #633

A use-case would be the following:

```php
class HandleInertiaRequests extends Middleware
{
	public function share(Request $request): array
	{
		return array_merge(parent::share($request), [
			'user.verified' => true,
		]);
	}
}
```

Then render the page using:
```php
Inertia::render('User/Show', [
	'user' => [
		'name' => 'John',
	],
]);
```

This would result in just `props: { user: { name: 'John' }}` being sent to the frontend instead of `props: { user: { name: 'John', verified: true }}`, with this PR the latter would happen.

I attempted to fix the issue by merging the props instead of overwriting them. However, I'm not actually sure why this feature worked before, since it seems like props were always overwritten.