### PR TITLE
[1.x] Fix resolving shared dot props

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -139,6 +139,8 @@ class Response implements Responsable
      */
     public function resolveArrayableProperties(array $props, Request $request, bool $unpackDotProps = true): array
     {
+        $dotProps = [];
+
         foreach ($props as $key => $value) {
             if ($value instanceof Arrayable) {
                 $value = $value->toArray();
@@ -148,14 +150,16 @@ class Response implements Responsable
                 $value = $this->resolveArrayableProperties($value, $request, false);
             }
 
-            if ($unpackDotProps && str_contains($key, '.')) {
-                Arr::set($props, $key, $value);
-                unset($props[$key]);
-            } elseif ($unpackDotProps && is_array($props[$key])) {
-                $props[$key] = array_merge($props[$key], $value);
-            } else {
-                $props[$key] = $value;
+            $props[$key] = $value;
+
+            if($unpackDotProps && str_contains($key, '.')) {
+                $dotProps[] = $key;
             }
+        }
+
+        foreach ($dotProps as $key) {
+            Arr::set($props, $key, $props[$key]);
+            unset($props[$key]);
         }
 
         return $props;

--- a/src/Response.php
+++ b/src/Response.php
@@ -218,6 +218,10 @@ class Response implements Responsable
                 $value = $value->toResponse($request)->getData(true);
             }
 
+            if($value instanceof Arrayable) {
+                $value = $value->toArray();
+            }
+
             if (is_array($value)) {
                 $value = $this->resolvePropertyInstances($value, $request);
             }

--- a/src/Response.php
+++ b/src/Response.php
@@ -151,6 +151,8 @@ class Response implements Responsable
             if ($unpackDotProps && str_contains($key, '.')) {
                 Arr::set($props, $key, $value);
                 unset($props[$key]);
+            } elseif ($unpackDotProps && is_array($props[$key])) {
+                $props[$key] = array_merge($props[$key], $value);
             } else {
                 $props[$key] = $value;
             }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -285,7 +285,6 @@ class MiddlewareTest extends TestCase
         ]);
     }
 
-
     public function test_middleware_can_change_the_root_view_via_a_property(): void
     {
         $this->prepareMockEndpoint(null, [], new class() extends Middleware {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -536,4 +536,16 @@ class ResponseTest extends TestCase
 
         $this->assertSame([2022, 2023, 2024], $page['props']['years']);
     }
+
+    public function test_mixed_array_shape(): void
+    {
+        $request = Request::create('/years', 'GET');
+
+        $response = new Response('Years', ['years' => [2022, 2023, 'exclude' => [2024, 2025]]], 'app', '123');
+        $response = $response->toResponse($request);
+        $view = $response->getOriginalContent();
+        $page = $view->getData()['page'];
+
+        $this->assertSame([2022, 2023, 'exclude' => [2024, 2025]], $page['props']['years']);
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -2,8 +2,8 @@
 
 namespace Inertia\Tests;
 
-use Exception;
 use Mockery;
+use Exception;
 use Inertia\LazyProp;
 use Inertia\Response;
 use Illuminate\View\View;
@@ -395,7 +395,7 @@ class ResponseTest extends TestCase
             ],
             'shared' => function () {
                 throw new Exception();
-            }
+            },
         ];
 
         $response = new Response('User/Edit', $props);
@@ -644,6 +644,28 @@ class ResponseTest extends TestCase
             'auth.user.is_super' => true,
         ], 'app', '123');
 
+        $response = $response->toResponse($request);
+        $view = $response->getOriginalContent();
+        $page = $view->getData()['page'];
+
+        $this->assertSame([
+            'auth' => [
+                'user' => [
+                    'name' => 'Jonathan',
+                    'is_super' => true,
+                ],
+            ],
+        ], $page['props']);
+    }
+
+    public function test_dot_notation_props_are_merged_with_other_dot_notation_props(): void
+    {
+        $request = Request::create('/test', 'GET');
+
+        $response = new Response('Test', [
+            'auth.user' => ['name' => 'Jonathan'],
+            'auth.user.is_super' => true,
+        ], 'app', '123');
         $response = $response->toResponse($request);
         $view = $response->getOriginalContent();
         $page = $view->getData()['page'];

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -608,7 +608,9 @@ class ResponseTest extends TestCase
         $request = Request::create('/test', 'GET');
 
         $response = new Response('Test', [
-            'auth' => fn () => ['user' => ['name' => 'Jonathan']],
+            'auth' => function () {
+                return ['user' => ['name' => 'Jonathan']];
+            },
             'auth.user.is_super' => true,
         ], 'app', '123');
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -524,4 +524,16 @@ class ResponseTest extends TestCase
 
         $this->assertSame('/subpath/product/123', $page->url);
     }
+
+    public function test_array_doubling(): void
+    {
+        $request = Request::create('/years', 'GET');
+
+        $response = new Response('Years', ['years' => [2022, 2023, 2024]], 'app', '123');
+        $response = $response->toResponse($request);
+        $view = $response->getOriginalContent();
+        $page = $view->getData()['page'];
+
+        $this->assertSame([2022, 2023, 2024], $page['props']['years']);
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -611,6 +611,7 @@ class ResponseTest extends TestCase
             'auth' => fn () => ['user' => ['name' => 'Jonathan']],
             'auth.user.is_super' => true,
         ], 'app', '123');
+
         $response = $response->toResponse($request);
         $view = $response->getOriginalContent();
         $page = $view->getData()['page'];

--- a/tests/Stubs/AsArrayable.php
+++ b/tests/Stubs/AsArrayable.php
@@ -16,9 +16,9 @@ class AsArrayable implements Arrayable {
         $this->data = $data;
     }
 
-    public static function make(array $data): static
+    public static function make(array $data): self
     {
-        return new static($data);
+        return new self($data);
     }
 
     /**

--- a/tests/Stubs/AsArrayable.php
+++ b/tests/Stubs/AsArrayable.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Inertia\Tests\Stubs;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+/**
+ * @implements Arrayable<array-key, mixed>
+ */
+class AsArrayable implements Arrayable {
+    /** @var array */
+    protected $data = [];
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public static function make(array $data): static
+    {
+        return new static($data);
+    }
+
+    /**
+     * Get the instance as an array.
+     */
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+}


### PR DESCRIPTION
Based on https://github.com/inertiajs/inertia-laravel/pull/634

> I think https://github.com/inertiajs/inertia-laravel/pull/620 introduced a breaking change when sharing props through the middleware, as described in https://github.com/inertiajs/inertia-laravel/issues/633

This PR includes extra tests to ensure shared props can be included and excluded from partial responses.