### PR TITLE
[1.x] Put Vite check before Mix

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -32,11 +32,11 @@ class Middleware
             return md5(config('app.asset_url'));
         }
 
-        if (file_exists($manifest = public_path('mix-manifest.json'))) {
+        if (file_exists($manifest = public_path('build/manifest.json'))) {
             return md5_file($manifest);
         }
 
-        if (file_exists($manifest = public_path('build/manifest.json'))) {
+        if (file_exists($manifest = public_path('mix-manifest.json'))) {
             return md5_file($manifest);
         }
 


### PR DESCRIPTION
Now that most people use `Vite`, why don't we check `Vite` manifest file before `Mix`'s for performance?