### PR TITLE
[2.x] Replace md5 with xxhash

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -29,15 +29,15 @@ class Middleware
     public function version(Request $request)
     {
         if (config('app.asset_url')) {
-            return md5(config('app.asset_url'));
+            return hash('xxh128', config('app.asset_url'));
         }
 
         if (file_exists($manifest = public_path('mix-manifest.json'))) {
-            return md5_file($manifest);
+            return hash_file('xxh128', $manifest);
         }
 
         if (file_exists($manifest = public_path('build/manifest.json'))) {
-            return md5_file($manifest);
+            return hash_file('xxh128', $manifest);
         }
 
         return null;

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -109,7 +109,7 @@ class ResponseFactoryTest extends TestCase
             $this->assertSame('', Inertia::getVersion());
 
             Inertia::version(function () {
-                return md5('Inertia');
+                return hash('xxh128', 'Inertia');
             });
 
             return Inertia::render('User/Edit');

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -117,7 +117,7 @@ class ResponseFactoryTest extends TestCase
 
         $response = $this->withoutExceptionHandling()->get('/', [
             'X-Inertia' => 'true',
-            'X-Inertia-Version' => 'b19a24ee5c287f42ee1d465dab77ab37',
+            'X-Inertia-Version' => 'f445bd0a2c393a5af14fc677f59980a9',
         ]);
 
         $response->assertSuccessful();


### PR DESCRIPTION
Another attempt of  #652

I recently noticed laravel/framework#52301, where most of the md5 calls will be replaced with xxhash, which is much faster than md5. For Inertia's asset versioning we don't need it to be cryptographically correct, but a performance improvement would be nice, especially since the middleware is executed on every request.

I think it's save to change this in the Inertia adapter, since all it would do is force a reload, which would happen when updating assets anyway.

Support for xxhash was added to PHP 8.1 (https://php.watch/versions/8.1/xxHash), so we can safely use this algorithm instead of md5.