### PR TITLE
[1.x] remove IDE helpers from package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 /.gitignore export-ignore
 /.github export-ignore
 /.php-cs-fixer.dist.php export-ignore
+/_ide_helpers.php export-ignore
 /phpunit.xml.dist export-ignore
 /tests export-ignore
 /CHANGELOG.md export-ignore


### PR DESCRIPTION
Since [v1.1.0](https://github.com/inertiajs/inertia-laravel/releases/tag/v1.1.0) release (with changes from #625) my IDE has a big problem with understanding where `Illuminate\Http\Request` is implemented. 

![image](https://github.com/user-attachments/assets/e2730e12-e40f-4970-82cc-6fc850c416d6)
![image](https://github.com/user-attachments/assets/df630ea1-b220-43e6-b1a3-37a1b7de5458)

It looks like `[_ide_helpers.php](https://github.com/inertiajs/inertia-laravel/blob/1.x/_ide_helpers.php)` is propagating its own classes into projects using Inertia. 

I believe that IDE helpers could be great if someone needs them, but they should be in scope of package only. They should not interfere with projects using these packages.

This should fix the problem.