### PR TITLE
Update versioning in middleware

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -6,6 +6,7 @@ use Closure;
 use Inertia\Support\Header;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
+use Inertia\Support\LaravelVapor;
 use Symfony\Component\HttpFoundation\Response;
 
 class Middleware
@@ -28,7 +29,7 @@ class Middleware
      */
     public function version(Request $request)
     {
-        if (config('app.asset_url')) {
+        if (LaravelVapor::detect()) {
             return md5(config('app.asset_url'));
         }
 

--- a/src/Support/LaravelVapor.php
+++ b/src/Support/LaravelVapor.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Inertia\Support;
+
+use Laravel\Vapor\Vapor;
+
+class LaravelVapor
+{
+    public static function detect(): bool
+    {
+        if (class_exists(Vapor::class)) {
+            return Vapor::active();
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
The first check that's done in the default `version` method of the middleware is to check if `app.asset_url` exists. This was added to support Laravel Vapor, see the comment in the original commit by @claudiodekker: https://github.com/inertiajs/inertia-laravel/commit/b1a4af2094bee755a154ed233f48b3fe825b1e39

This can however introduce unintended behaviour. For example if you have your assets located on a CDN it would just be a static URL. This causes the version hash to not update, so deploying a new version of your app would cause issues as clients would try to fetch non-existing assets and Inertia not forcing a refresh on the client.

A simple fix is instead of just checking if the config value exists we'd check if the app is running within Vapor (see https://github.com/laravel/vapor-core/pull/164)