### PR TITLE
[1.x] Fix encoded URL

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -93,7 +93,7 @@ class Response implements Responsable
         $page = [
             'component' => $this->component,
             'props' => $props,
-            'url' => Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/'),
+            'url' => Str::start(Str::after(rawurldecode($request->fullUrl()), $request->getSchemeAndHttpHost()), '/'),
             'version' => $this->version,
         ];
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -458,6 +458,18 @@ class ResponseTest extends TestCase
         $this->assertSame('/subpath/product/123', $page->url);
     }
 
+    public function test_the_page_url_is_not_encoded(): void
+    {
+        $request = Request::create('/product/123', 'GET', ['value' => 'te/st']);
+        $request->headers->add(['X-Inertia' => 'true']);
+
+        $response = new Response('Product/Show', []);
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $this->assertSame('/product/123?value=te/st', $page->url);
+    }
+
     public function test_prop_as_basic_array(): void
     {
         $request = Request::create('/years', 'GET');


### PR DESCRIPTION
In #592 URL generation was fixed regarding sub paths. However it did introduce encoding issues; https://github.com/inertiajs/inertia-laravel/pull/592#issuecomment-1986885548

With this PR it simply decodes the URL to an unencoded variant, which would then be used on the client to set the current location.