### PR TITLE
Addition of Inertia::response to handle both json and component 

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -104,6 +104,23 @@ class ResponseFactory
         );
     }
 
+
+    /**
+     * @param array|Arrayable $props
+     * @param array $customProps
+     * @return JsonResponse|Response
+     */
+    public function response($component, $props = [], $customProps = []) 
+    {
+        $props = array_merge($props, $customProps);
+
+        if (request()->header('Accept') === 'application/json') {
+            return response()->json($props);
+        }
+
+        return $this->render($component, $props);
+    }
+
     /**
      * @param string|SymfonyRedirect $url
      */

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -121,6 +121,7 @@ class ResponseFactory
         return $this->render($component, $props);
     }
 
+
     /**
      * @param string|SymfonyRedirect $url
      */

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -143,6 +143,24 @@ class ResponseFactoryTest extends TestCase
         ]);
     }
 
+
+    /**
+     * @test
+     */
+    public function test_can_respond_with_a_response_or_json_based_on_accept_header()
+    {
+        Route::get('/', function () {
+            return $this->response('Component', ['props' => ['foo' => 'bar']]);
+        });
+
+        $response = $this->get('/', ['Accept' => 'application/json']);
+        $response->assertJson(['props' => ['foo' => 'bar']]);
+        
+
+        $response = $this->get('/');
+        $response->assertSee('Component');
+    }
+
     public function test_can_flush_shared_data(): void
     {
         Inertia::share('foo', 'bar');

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -158,8 +158,9 @@ class ResponseFactoryTest extends TestCase
         $response->assertJson(['props' => ['foo' => 'bar']]);
 
         // Without the Accept header, it defaults to Inertia Component
-        $this->get('/')->assertInertia(fn (Assert $page) => 
-        $page->component('User/Edit'));
+        $this->get('/')->assertInertia(function (Assert $page) {
+            $page->component('User/Edit');
+        }); 
     }
 
     public function test_can_flush_shared_data(): void

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -158,8 +158,8 @@ class ResponseFactoryTest extends TestCase
         $response->assertJson(['props' => ['foo' => 'bar']]);
 
         // Without the Accept header, it defaults to Inertia Component
-        $this->get('/')->assertInertia(fn (Assert $page) => $page
-                ->component('User/Edit'));
+        $this->get('/')->assertInertia(fn (Assert $page) => 
+        $page->component('User/Edit'));
     }
 
     public function test_can_flush_shared_data(): void

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -16,6 +16,7 @@ use Inertia\Tests\Stubs\ExampleMiddleware;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Request as HttpRequest;
 use Illuminate\Session\Middleware\StartSession;
+use Inertia\Testing\AssertableInertia as Assert;
 
 class ResponseFactoryTest extends TestCase
 {
@@ -150,15 +151,15 @@ class ResponseFactoryTest extends TestCase
     public function test_can_respond_with_a_response_or_json_based_on_accept_header()
     {
         Route::get('/', function () {
-            return $this->response('Component', ['props' => ['foo' => 'bar']]);
+            return Inertia::response('User/Edit', ['props' => ['foo' => 'bar']]);
         });
 
         $response = $this->get('/', ['Accept' => 'application/json']);
         $response->assertJson(['props' => ['foo' => 'bar']]);
-        
 
-        $response = $this->get('/');
-        $response->assertSee('Component');
+        // Without the Accept header, it defaults to Inertia Component
+        $this->get('/')->assertInertia(fn (Assert $page) => $page
+                ->component('User/Edit'));
     }
 
     public function test_can_flush_shared_data(): void


### PR DESCRIPTION
Addition of Inertia::reponse  to allow the single route to behave as API that sends props as JSON response if the header is set to 'Accept:application/json' and behave exact to render function if the following header is not matched