### PR TITLE
[2.x] Fix clearing history when redirecting

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -41,13 +41,13 @@ class Response implements Responsable
     /**
      * @param  array|Arrayable  $props
      */
-    public function __construct(string $component, array $props, string $rootView = 'app', string $version = '', bool $clearHistory = false, bool $encryptHistory = false)
+    public function __construct(string $component, array $props, string $rootView = 'app', string $version = '', bool $encryptHistory = false)
     {
         $this->component = $component;
         $this->props = $props instanceof Arrayable ? $props->toArray() : $props;
         $this->rootView = $rootView;
         $this->version = $version;
-        $this->clearHistory = $clearHistory;
+        $this->clearHistory = session()->pull('inertia.clear_history', false);
         $this->encryptHistory = $encryptHistory;
     }
 

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -88,7 +88,7 @@ class ResponseFactory
 
     public function clearHistory(): void
     {
-        $this->clearHistory = true;
+        session(['inertia.clear_history' => true]);
     }
 
     public function encryptHistory($encrypt = true): void
@@ -144,7 +144,6 @@ class ResponseFactory
             array_merge($this->sharedProps, $props),
             $this->rootView,
             $this->getVersion(),
-            $this->clearHistory,
             $this->encryptHistory ?? config('inertia.history.encrypt', false),
         );
     }

--- a/tests/HistoryTest.php
+++ b/tests/HistoryTest.php
@@ -140,4 +140,26 @@ class HistoryTest extends TestCase
             'clearHistory' => true,
         ]);
     }
+
+    public function test_the_history_can_be_cleared_when_redirecting(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::clearHistory();
+
+            return redirect('/users');
+        });
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/users', function () {
+            return Inertia::render('User/Edit');
+        });
+
+        $this->followingRedirects();
+
+        $response = $this->withoutExceptionHandling()->get('/', [
+            'X-Inertia' => 'true',
+        ]);
+
+        $response->assertSuccessful();
+        $response->assertContent('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;errors&quot;:{}},&quot;url&quot;:&quot;\/users&quot;,&quot;version&quot;:&quot;&quot;,&quot;clearHistory&quot;:true,&quot;encryptHistory&quot;:false}"></div>');
+    }
 }


### PR DESCRIPTION
This now stores the flag to clear the history in the session so that the _next_ request will clear the history, even if the next request is the result of a redirect.