### PR TITLE
[2.x] Ensure closures are resolved via App in resolveArrayableProperties

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -173,7 +173,7 @@ class Response implements Responsable
             }
 
             if ($value instanceof Closure) {
-                $value = $value();
+                $value = App::call($value);
             }
 
             if ($unpackDotProps && str_contains($key, '.')) {

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -146,7 +146,7 @@ class ResponseFactoryTest extends TestCase
         ]);
     }
 
-    public function test_shared_data_can_resolve_closures_arguments(): void
+    public function test_shared_data_can_resolve_closure_arguments(): void
     {
         Inertia::share('query', fn (HttpRequest $request) => $request->query());
 

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -148,7 +148,7 @@ class ResponseFactoryTest extends TestCase
 
     public function test_shared_data_can_resolve_closures_arguments(): void
     {
-        Inertia::share('query', fn(HttpRequest $request) => $request->query());
+        Inertia::share('query', fn (HttpRequest $request) => $request->query());
 
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
             return Inertia::render('User/Edit');
@@ -200,7 +200,7 @@ class ResponseFactoryTest extends TestCase
     public function test_dot_props_with_callbacks_are_merged_from_shared(): void
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
-            Inertia::share('auth.user', fn() => [
+            Inertia::share('auth.user', fn () => [
                 'name' => 'Jonathan',
             ]);
 

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -146,6 +146,27 @@ class ResponseFactoryTest extends TestCase
         ]);
     }
 
+    public function test_shared_data_can_resolve_closures_arguments(): void
+    {
+        Inertia::share('query', fn(HttpRequest $request) => $request->query());
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            return Inertia::render('User/Edit');
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/?foo=bar', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'component' => 'User/Edit',
+            'props' => [
+                'query' => [
+                    'foo' => 'bar',
+                ],
+            ],
+        ]);
+    }
+
     public function test_dot_props_are_merged_from_shared(): void
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
@@ -179,7 +200,7 @@ class ResponseFactoryTest extends TestCase
     public function test_dot_props_with_callbacks_are_merged_from_shared(): void
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
-            Inertia::share('auth.user', fn () => [
+            Inertia::share('auth.user', fn() => [
                 'name' => 'Jonathan',
             ]);
 


### PR DESCRIPTION
This PR resolves a regression in 2.x where shared data closures with arguments could not be resolved. This patch ensures that the closures are resolved using `App::call()`.

e.g.,
```php
Inertia::share('query', fn (Request $request) => $request->query());
```

I encountered this while trying to upgrade a project to Inertia 2.x. A supporting test has been created to demonstrate further.