### PR TITLE
Add Inertia::deepMerge Method for Handling Complex Data Merges in Responses

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Inertia\DeferProp defer(callable $callback, string $group = 'default')
  * @method static \Inertia\AlwaysProp always(mixed $value)
  * @method static \Inertia\MergeProp merge(mixed $value)
+ * @method static \Inertia\MergeProp deepMerge(mixed $value)
  * @method static \Inertia\Response render(string $component, array|\Illuminate\Contracts\Support\Arrayable $props = [])
  * @method static \Symfony\Component\HttpFoundation\Response location(string|\Symfony\Component\HttpFoundation\RedirectResponse $url)
  * @method static void macro(string $name, object|callable $macro)

--- a/src/MergesProps.php
+++ b/src/MergesProps.php
@@ -15,17 +15,16 @@ trait MergesProps
         return $this;
     }
 
-    public function shouldMerge(): bool
-    {
-        return $this->merge;
-    }
-
     public function deepMerge(): static
     {
-
         $this->deepMerge = true;
 
         return $this->merge();
+    }
+
+    public function shouldMerge(): bool
+    {
+        return $this->merge;
     }
 
     public function shouldDeepMerge(): bool

--- a/src/MergesProps.php
+++ b/src/MergesProps.php
@@ -22,9 +22,10 @@ trait MergesProps
 
     public function deepMerge(): static
     {
+
         $this->deepMerge = true;
 
-        return $this;
+        return $this->merge();
     }
 
     public function shouldDeepMerge(): bool

--- a/src/MergesProps.php
+++ b/src/MergesProps.php
@@ -6,6 +6,8 @@ trait MergesProps
 {
     protected bool $merge = false;
 
+    protected bool $deepMerge = false;
+
     public function merge(): static
     {
         $this->merge = true;
@@ -16,5 +18,17 @@ trait MergesProps
     public function shouldMerge(): bool
     {
         return $this->merge;
+    }
+
+    public function deepMerge(): static
+    {
+        $this->deepMerge = true;
+
+        return $this;
+    }
+
+    public function shouldDeepMerge(): bool
+    {
+        return $this->deepMerge;
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -323,7 +323,7 @@ class Response implements Responsable
 
         $mergeProps = $mergeProps
             ->filter(function ($prop) {
-                return !$prop->shouldDeepMerge();
+                return ! $prop->shouldDeepMerge();
             })
             ->filter(function ($prop, $key) use ($resetProps) {
                 return ! $resetProps->contains($key);
@@ -331,8 +331,12 @@ class Response implements Responsable
             ->keys();
 
         $props = [];
-        if ($mergeProps->isNotEmpty()) $props['mergeProps'] = $mergeProps->toArray();
-        if ($deepMergeProps->isNotEmpty()) $props['deepMergeProps'] = $deepMergeProps->toArray();
+        if ($mergeProps->isNotEmpty()) {
+            $props['mergeProps'] = $mergeProps->toArray();
+        }
+        if ($deepMergeProps->isNotEmpty()) {
+            $props['deepMergeProps'] = $deepMergeProps->toArray();
+        }
 
         return $props;
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -306,7 +306,7 @@ class Response implements Responsable
 
         $mergeProps = $mergeProps
             ->filter(function ($prop) {
-                return $prop->shouldMerge();
+                return $prop->shouldMerge() AND !$prop->shouldDeepMerge();
             })
             ->filter(function ($prop, $key) use ($resetProps) {
                 return ! $resetProps->contains($key);

--- a/src/Response.php
+++ b/src/Response.php
@@ -293,6 +293,9 @@ class Response implements Responsable
         $mergeProps = collect($this->props)
             ->filter(function ($prop) {
                 return $prop instanceof Mergeable;
+            })
+            ->filter(function ($prop) {
+                return $prop->shouldMerge();
             });
 
         $deepMergeProps = $mergeProps
@@ -306,7 +309,7 @@ class Response implements Responsable
 
         $mergeProps = $mergeProps
             ->filter(function ($prop) {
-                return $prop->shouldMerge() AND !$prop->shouldDeepMerge();
+                return !$prop->shouldDeepMerge();
             })
             ->filter(function ($prop, $key) use ($resetProps) {
                 return ! $resetProps->contains($key);

--- a/src/Response.php
+++ b/src/Response.php
@@ -316,10 +316,11 @@ class Response implements Responsable
             })
             ->keys();
 
-        return $mergeProps->isNotEmpty() ? [
-            'mergeProps' => $mergeProps->toArray(),
-            'deepMergeProps' => $deepMergeProps->toArray()
-        ] : [];
+        $props = [];
+        if ($mergeProps->isNotEmpty()) $props['mergeProps'] = $mergeProps->toArray();
+        if ($deepMergeProps->isNotEmpty()) $props['deepMergeProps'] = $deepMergeProps->toArray();
+
+        return $props;
     }
 
     public function resolveDeferredProps(Request $request): array

--- a/src/Response.php
+++ b/src/Response.php
@@ -293,7 +293,18 @@ class Response implements Responsable
         $mergeProps = collect($this->props)
             ->filter(function ($prop) {
                 return $prop instanceof Mergeable;
+            });
+
+        $deepMergeProps = $mergeProps
+            ->filter(function ($prop) {
+                return $prop->shouldDeepMerge();
             })
+            ->filter(function ($prop, $key) use ($resetProps) {
+                return ! $resetProps->contains($key);
+            })
+            ->keys();
+
+        $mergeProps = $mergeProps
             ->filter(function ($prop) {
                 return $prop->shouldMerge();
             })
@@ -302,7 +313,10 @@ class Response implements Responsable
             })
             ->keys();
 
-        return $mergeProps->isNotEmpty() ? ['mergeProps' => $mergeProps->toArray()] : [];
+        return $mergeProps->isNotEmpty() ? [
+            'mergeProps' => $mergeProps->toArray(),
+            'deepMergeProps' => $deepMergeProps->toArray()
+        ] : [];
     }
 
     public function resolveDeferredProps(Request $request): array

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -125,6 +125,14 @@ class ResponseFactory
     /**
      * @param  mixed  $value
      */
+    public function deepMerge($value): MergeProp
+    {
+        return (new MergeProp($value))->deepMerge();
+    }
+
+    /**
+     * @param  mixed  $value
+     */
     public function always($value): AlwaysProp
     {
         return new AlwaysProp($value);

--- a/tests/DeepMergePropTest.php
+++ b/tests/DeepMergePropTest.php
@@ -9,28 +9,21 @@ class DeepMergePropTest extends TestCase
 {
     public function test_can_invoke_with_a_callback(): void
     {
-        $mergeProp = new MergeProp(function () {
-            return 'A merge prop value';
-        });
-        $mergeProp->deepMerge();
+        $mergeProp = (new MergeProp(fn () => 'A merge prop value'))->deepMerge();
 
         $this->assertSame('A merge prop value', $mergeProp());
     }
 
     public function test_can_invoke_with_a_non_callback(): void
     {
-        $mergeProp = new MergeProp(['key' => 'value']);
-        $mergeProp->deepMerge();
+        $mergeProp = (new MergeProp(['key' => 'value']))->deepMerge();
 
         $this->assertSame(['key' => 'value'], $mergeProp());
     }
 
     public function test_can_resolve_bindings_when_invoked(): void
     {
-        $mergeProp = new MergeProp(function (Request $request) {
-            return $request;
-        });
-        $mergeProp->deepMerge();
+        $mergeProp = (new MergeProp(fn (Request $request) => $request))->deepMerge();
 
         $this->assertInstanceOf(Request::class, $mergeProp());
     }

--- a/tests/DeepMergePropTest.php
+++ b/tests/DeepMergePropTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Illuminate\Http\Request;
+use Inertia\MergeProp;
+
+class DeepMergePropTest extends TestCase
+{
+    public function test_can_invoke_with_a_callback(): void
+    {
+        $mergeProp = new MergeProp(function () {
+            return 'A merge prop value';
+        });
+        $mergeProp->deepMerge();
+
+        $this->assertSame('A merge prop value', $mergeProp());
+    }
+
+    public function test_can_invoke_with_a_non_callback(): void
+    {
+        $mergeProp = new MergeProp(['key' => 'value']);
+        $mergeProp->deepMerge();
+
+        $this->assertSame(['key' => 'value'], $mergeProp());
+    }
+
+    public function test_can_resolve_bindings_when_invoked(): void
+    {
+        $mergeProp = new MergeProp(function (Request $request) {
+            return $request;
+        });
+        $mergeProp->deepMerge();
+
+        $this->assertInstanceOf(Request::class, $mergeProp());
+    }
+}

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -280,10 +280,9 @@ class ResponseFactoryTest extends TestCase
     public function test_can_create_deep_merged_prop(): void
     {
         $factory = new ResponseFactory;
-        $mergedProp = $factory->merge(function () {
+        $mergedProp = $factory->deepMerge(function () {
             return 'A merged value';
         });
-        $mergedProp->deepMerge();
 
         $this->assertInstanceOf(MergeProp::class, $mergedProp);
     }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -256,12 +256,33 @@ class ResponseFactoryTest extends TestCase
         $this->assertInstanceOf(MergeProp::class, $mergedProp);
     }
 
+    public function test_can_create_deep_merged_prop(): void
+    {
+        $factory = new ResponseFactory;
+        $mergedProp = $factory->merge(function () {
+            return 'A merged value';
+        });
+        $mergedProp->deepMerge();
+
+        $this->assertInstanceOf(MergeProp::class, $mergedProp);
+    }
+
     public function test_can_create_deferred_and_merged_prop(): void
     {
         $factory = new ResponseFactory;
         $deferredProp = $factory->defer(function () {
             return 'A deferred + merged value';
         })->merge();
+
+        $this->assertInstanceOf(DeferProp::class, $deferredProp);
+    }
+
+    public function test_can_create_deferred_and_deep_merged_prop(): void
+    {
+        $factory = new ResponseFactory;
+        $deferredProp = $factory->defer(function () {
+            return 'A deferred + merged value';
+        })->deepMerge();
 
         $this->assertInstanceOf(DeferProp::class, $deferredProp);
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -165,6 +165,41 @@ class ResponseTest extends TestCase
         $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:&quot;foo value&quot;,&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;mergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;]}"></div>', $view->render());
     }
 
+    public function test_server_response_with_deep_merge_props(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+
+        $user = ['name' => 'Jonathan'];
+        $response = new Response(
+            'User/Edit',
+            [
+                'user' => $user,
+                'foo' => (new MergeProp('foo value'))->deepMerge(),
+                'bar' => (new MergeProp('bar value'))->deepMerge(),
+            ],
+            'app',
+            '123'
+        );
+        $response = $response->toResponse($request);
+        $view = $response->getOriginalContent();
+        $page = $view->getData()['page'];
+
+        $this->assertInstanceOf(BaseResponse::class, $response);
+        $this->assertInstanceOf(View::class, $view);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertSame([
+            'foo',
+            'bar',
+        ], $page['deepMergeProps']);
+        $this->assertFalse($page['clearHistory']);
+        $this->assertFalse($page['encryptHistory']);
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:&quot;foo value&quot;,&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deepMergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;]}"></div>', $view->render());
+    }
+
     public function test_server_response_with_defer_and_merge_props(): void
     {
         $request = Request::create('/user/123', 'GET');
@@ -203,6 +238,46 @@ class ResponseTest extends TestCase
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
         $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;mergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;],&quot;deferredProps&quot;:{&quot;default&quot;:[&quot;foo&quot;]}}"></div>', $view->render());
+    }
+
+    public function test_server_response_with_defer_and_deep_merge_props(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+
+        $user = ['name' => 'Jonathan'];
+        $response = new Response(
+            'User/Edit',
+            [
+                'user' => $user,
+                'foo' => (new DeferProp(function () {
+                    return 'foo value';
+                }, 'default'))->deepMerge(),
+                'bar' => (new MergeProp('bar value'))->deepMerge(),
+            ],
+            'app',
+            '123'
+        );
+        $response = $response->toResponse($request);
+        $view = $response->getOriginalContent();
+        $page = $view->getData()['page'];
+
+        $this->assertInstanceOf(BaseResponse::class, $response);
+        $this->assertInstanceOf(View::class, $view);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertSame([
+            'default' => ['foo'],
+        ], $page['deferredProps']);
+        $this->assertSame([
+            'foo',
+            'bar',
+        ], $page['deepMergeProps']);
+        $this->assertFalse($page['clearHistory']);
+        $this->assertFalse($page['encryptHistory']);
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deepMergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;],&quot;deferredProps&quot;:{&quot;default&quot;:[&quot;foo&quot;]}}"></div>', $view->render());
     }
 
     public function test_xhr_response(): void

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -30,10 +30,13 @@ class ServiceProviderTest extends TestCase
         $routes = Route::getRoutes();
 
         $this->assertNotEmpty($routes->getRoutes());
-        $this->assertEquals($route, $routes->getRoutes()[0]);
-        $this->assertEquals(['GET', 'HEAD'], $route->methods);
-        $this->assertEquals('/', $route->uri);
-        $this->assertEquals(['uses' => '\Inertia\Controller@__invoke', 'controller' => '\Inertia\Controller'], $route->action);
-        $this->assertEquals(['component' => 'User/Edit', 'props' => ['user' => ['name' => 'Jonathan']]], $route->defaults);
+
+        $inertiaRoute = collect($routes->getRoutes())->first(fn($route) => $route->uri === '/');
+
+        $this->assertEquals($route, $inertiaRoute);
+        $this->assertEquals(['GET', 'HEAD'], $inertiaRoute->methods);
+        $this->assertEquals('/', $inertiaRoute->uri);
+        $this->assertEquals(['uses' => '\Inertia\Controller@__invoke', 'controller' => '\Inertia\Controller'], $inertiaRoute->action);
+        $this->assertEquals(['component' => 'User/Edit', 'props' => ['user' => ['name' => 'Jonathan']]], $inertiaRoute->defaults);
     }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -31,7 +31,7 @@ class ServiceProviderTest extends TestCase
 
         $this->assertNotEmpty($routes->getRoutes());
 
-        $inertiaRoute = collect($routes->getRoutes())->first(fn($route) => $route->uri === '/');
+        $inertiaRoute = collect($routes->getRoutes())->first(fn ($route) => $route->uri === '/');
 
         $this->assertEquals($route, $inertiaRoute);
         $this->assertEquals(['GET', 'HEAD'], $inertiaRoute->methods);


### PR DESCRIPTION
This PR adds the `Inertia::deepMerge` method to the Laravel package, complementing the new `deepMerge` feature introduced in Inertia.js (see the corresponding PR in the Inertia.js repository). This provides developers with the ability to merge deeply nested data structures in their props, such as arrays and objects within objects, without completely replacing the existing properties.

### **New Method:**
- **`Inertia::deepMerge()`**: This method will mark specific props for deep merging when used with the `Inertia` response. Unlike the existing `merge` method, `deepMerge` performs recursive merging to handle arrays and nested properties effectively.

### **Usage Example:**
```php
return Inertia::render('Dashboard', [
    'items' => Inertia::deepMerge(Item::paginate())
]);
```

### **Why This Is Useful:**
When dealing with complex data, such as a paginated dataset, it’s often necessary to update only parts of the data rather than replacing the entire object. For example, suppose we want to append items to the `data` array in a pagination object but leave `meta` and `links` intact or only partially updated:
```php
'items' => [
    'data' => [...],   // Appending new data
    'meta' => [...],   // Meta data remains consistent
    'links' => [...],  // Links updated if needed
]
```
The `Inertia::deepMerge()` method ensures that nested properties are correctly merged instead of overwritten, offering a more granular approach to updating props in dynamic, real-time applications.

### **Related PR**:
This PR works in conjunction with the newly added deep merging logic in the Inertia.js repository. Please see [Inertia.js PR #2069](https://github.com/inertiajs/inertia/pull/2069) for details on the client-side implementation.

### **Related Issue**:
- [Inertia.js issue #2068](https://github.com/inertiajs/inertia/issues/2068)