### PR TITLE
Fix closure props always being called

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -141,8 +141,6 @@ class Response implements Responsable
             });
         }
 
-        $props = $this->resolveArrayableProperties($props, $request);
-
         if ($isPartial && $request->hasHeader(Header::PARTIAL_ONLY)) {
             $props = $this->resolveOnly($request, $props);
         }
@@ -154,6 +152,8 @@ class Response implements Responsable
         $props = $this->resolveAlways($props);
 
         $props = $this->resolvePropertyInstances($props, $request);
+
+        $props = $this->resolveArrayableProperties($props, $request);
 
         return $props;
     }
@@ -170,10 +170,6 @@ class Response implements Responsable
 
             if (is_array($value)) {
                 $value = $this->resolveArrayableProperties($value, $request, false);
-            }
-
-            if ($value instanceof Closure) {
-                $value = $value();
             }
 
             if ($unpackDotProps && str_contains($key, '.')) {

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -311,4 +311,18 @@ class ResponseFactoryTest extends TestCase
             ],
         ]);
     }
+
+    public function test_it_does_not_evaluate_closures_on_partial_reloads(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            return Inertia::render('User/Edit', [
+                'partial' => fn() => throw new \Exception('I should never be called!'),
+            ]);
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true', 'X-Inertia-Partial-Component' => 'User/Edit', 'X-Inertia-Partial-Except' => ['partial']]);
+
+        $response->assertSuccessful();
+        $response->assertJsonMissingPath('props.partial');
+    }
 }


### PR DESCRIPTION
This PR sets to resolve the following issues:
https://github.com/inertiajs/inertia-laravel/pull/678
https://github.com/inertiajs/inertia-laravel/issues/672

Because of the following commit: https://github.com/inertiajs/inertia-laravel/commit/141256b2ed1833158852c9d239d00abec8ff4942 all optional props are evaluated on all requests, even when they are not included in the response.