### PR TITLE
Don't evaluate lazy properties when not specified by partial reload

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -133,27 +133,41 @@ class Response implements Responsable
      */
     public function resolveProperties(Request $request, array $props): array
     {
-        $isPartial = $this->isPartial($request);
+        $props = $this->resolvePartialProperties($props, $request);
+        $props = $this->resolveArrayableProperties($props, $request);
+        $props = $this->resolveAlways($props);
+        $props = $this->resolvePropertyInstances($props, $request);
 
-        if (! $isPartial) {
-            $props = array_filter($this->props, static function ($prop) {
+        return $props;
+    }
+
+    /**
+     * Resolve the `only` and `except` partial request props.
+     */
+    public function resolvePartialProperties(array $props, Request $request): array
+    {
+        if (! $this->isPartial($request)) {
+            return array_filter($this->props, static function ($prop) {
                 return ! ($prop instanceof IgnoreFirstLoad);
             });
         }
 
-        $props = $this->resolveArrayableProperties($props, $request);
+        $only = array_filter(explode(',', $request->header(Header::PARTIAL_ONLY, '')));
+        $except = array_filter(explode(',', $request->header(Header::PARTIAL_EXCEPT, '')));
 
-        if ($isPartial && $request->hasHeader(Header::PARTIAL_ONLY)) {
-            $props = $this->resolveOnly($request, $props);
+        if (count($only)) {
+            $newProps = [];
+
+            foreach ($only as $key) {
+                Arr::set($newProps, $key, Arr::get($props, $key));
+            }
+
+            $props = $newProps;
         }
 
-        if ($isPartial && $request->hasHeader(Header::PARTIAL_EXCEPT)) {
-            $props = $this->resolveExcept($request, $props);
+        if ($except) {
+            Arr::forget($props, $except);
         }
-
-        $props = $this->resolveAlways($props);
-
-        $props = $this->resolvePropertyInstances($props, $request);
 
         return $props;
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -187,7 +187,7 @@ class Response implements Responsable
             }
 
             if ($value instanceof Closure) {
-                $value = $value();
+                $value = App::call($value);
             }
 
             if ($unpackDotProps && str_contains($key, '.')) {

--- a/tests/DirectiveTest.php
+++ b/tests/DirectiveTest.php
@@ -32,7 +32,7 @@ class DirectiveTest extends TestCase
      */
     protected const EXAMPLE_PAGE_OBJECT = ['component' => 'Foo/Bar', 'props' => ['foo' => 'bar'], 'url' => '/test', 'version' => '', 'encryptHistory' => false, 'clearHistory' => false];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -176,6 +176,27 @@ class ResponseFactoryTest extends TestCase
         ]);
     }
 
+    public function test_shared_data_can_resolve_closure_arguments(): void
+    {
+        Inertia::share('query', fn (HttpRequest $request) => $request->query());
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            return Inertia::render('User/Edit');
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/?foo=bar', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'component' => 'User/Edit',
+            'props' => [
+                'query' => [
+                    'foo' => 'bar',
+                ],
+            ],
+        ]);
+    }
+
     public function test_dot_props_with_callbacks_are_merged_from_shared(): void
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,7 @@ abstract class TestCase extends Orchestra
         ];
     }
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This PR fixes a situation where properties such as this:

```php
inertia('Users/Index', [
    'users' => fn() => Users::all(),
]);
```

were being evaluated on partial reloads even when `users` was not specified by `X-Inertia-Partial-Data`.
