### PR TITLE
Upgrade GitHub Action dependencies

### DIFF
--- a/.github/workflows/facade.yml
+++ b/.github/workflows/facade.yml
@@ -3,7 +3,7 @@ name: facades
 on:
   push:
     branches:
-      - 'master'
+      - "master"
 
 jobs:
   update:
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: |
+            composer require orchestra/testbench:^9.0 --dev --${{ matrix.stability }} --no-update --no-interaction
             composer require phpunit/phpunit:^10.4 --dev --${{ matrix.stability }} --no-update --no-interaction
         if: matrix.php >= 8.2 && matrix.stability == 'prefer-lowest' && matrix.laravel >= 11
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} (w/ ${{ matrix.stability }})
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -34,7 +34,7 @@ jobs:
           coverage: none
 
       - name: Set Minimum PHP 8.1 Versions
-        uses: nick-invision/retry@v1
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -44,7 +44,7 @@ jobs:
         if: matrix.php >= 8.1 && matrix.stability == 'prefer-lowest'
 
       - name: Set Minimum PHP 8.2 Versions
-        uses: nick-invision/retry@v1
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -53,7 +53,7 @@ jobs:
         if: matrix.php >= 8.2 && matrix.stability == 'prefer-lowest'
 
       - name: Set Minimum PHP 8.2 Versions and Laravel > 11
-        uses: nick-invision/retry@v1
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -62,14 +62,14 @@ jobs:
         if: matrix.php >= 8.2 && matrix.stability == 'prefer-lowest' && matrix.laravel >= 11
 
       - name: Set Laravel version
-        uses: nick-invision/retry@v1
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5
           command: composer require "laravel/framework=^${{ matrix.laravel }}" --no-interaction --no-update
 
       - name: Install dependencies
-        uses: nick-invision/retry@v1
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: |
-            composer require orchestra/testbench:^9.0 --dev --${{ matrix.stability }} --no-update --no-interaction
+            composer require orchestra/testbench:^9.2 --dev --${{ matrix.stability }} --no-update --no-interaction
             composer require phpunit/phpunit:^10.4 --dev --${{ matrix.stability }} --no-update --no-interaction
         if: matrix.php >= 8.2 && matrix.stability == 'prefer-lowest' && matrix.laravel >= 11
 


### PR DESCRIPTION
- Upgrades dependencies to supported node version to get rid of warnings
- Fixes an issue with `orchestra/testbench` version + Laravel 11 that was causing tests to fail