### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -46,7 +46,7 @@ class ResponseFactory
         }
     }
 
-    public function getShared(string $key = null, $default = null)
+    public function getShared(?string $key = null, $default = null)
     {
         if ($key) {
             return Arr::get($this->sharedProps, $key, $default);

--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -42,7 +42,7 @@ class AssertableInertia extends AssertableJson
         return $instance;
     }
 
-    public function component(string $value = null, $shouldExist = null): self
+    public function component(?string $value = null, $shouldExist = null): self
     {
         PHPUnit::assertSame($value, $this->component, 'Unexpected Inertia page component.');
 

--- a/src/Testing/Concerns/Debugging.php
+++ b/src/Testing/Concerns/Debugging.php
@@ -4,17 +4,17 @@ namespace Inertia\Testing\Concerns;
 
 trait Debugging
 {
-    public function dump(string $prop = null): self
+    public function dump(?string $prop = null): self
     {
         dump($this->prop($prop));
 
         return $this;
     }
 
-    public function dd(string $prop = null): void
+    public function dd(?string $prop = null): void
     {
         dd($this->prop($prop));
     }
 
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 }

--- a/src/Testing/Concerns/Has.php
+++ b/src/Testing/Concerns/Has.php
@@ -38,7 +38,7 @@ trait Has
     /**
      * @return $this
      */
-    public function has(string $key, $value = null, Closure $scope = null): self
+    public function has(string $key, $value = null, ?Closure $scope = null): self
     {
         PHPUnit::assertTrue(
             Arr::has($this->prop(), $key),
@@ -106,7 +106,7 @@ trait Has
         return $this->missing($key);
     }
 
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 
     abstract protected function dotPath(string $key): string;
 

--- a/src/Testing/Concerns/Interaction.php
+++ b/src/Testing/Concerns/Interaction.php
@@ -37,5 +37,5 @@ trait Interaction
         return $this;
     }
 
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 }

--- a/src/Testing/Concerns/Matching.php
+++ b/src/Testing/Concerns/Matching.php
@@ -68,7 +68,7 @@ trait Matching
 
     abstract protected function dotPath(string $key): string;
 
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 
-    abstract public function has(string $key, $value = null, Closure $scope = null);
+    abstract public function has(string $key, $value = null, ?Closure $scope = null);
 }

--- a/src/Testing/Concerns/PageObject.php
+++ b/src/Testing/Concerns/PageObject.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
 
 trait PageObject
 {
-    public function component(string $value = null, $shouldExist = null): self
+    public function component(?string $value = null, $shouldExist = null): self
     {
         PHPUnit::assertSame($value, $this->component, 'Unexpected Inertia page component.');
 
@@ -23,7 +23,7 @@ trait PageObject
         return $this;
     }
 
-    protected function prop(string $key = null)
+    protected function prop(?string $key = null)
     {
         return Arr::get($this->props, $key);
     }

--- a/src/Testing/TestResponseMacros.php
+++ b/src/Testing/TestResponseMacros.php
@@ -8,7 +8,7 @@ class TestResponseMacros
 {
     public function assertInertia()
     {
-        return function (Closure $callback = null) {
+        return function (?Closure $callback = null) {
             $assert = AssertableInertia::fromTestResponse($this);
 
             if (is_null($callback)) {


### PR DESCRIPTION
This PR removes implicitly nullable parameters because these result in deprecation warnings for PHP 8.4.

https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter