### PR TITLE
[1.x] Ensure Inertia Response generate also compatible with Inertia.js 2

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -95,6 +95,7 @@ class Response implements Responsable
             'props' => $props,
             'url' => Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/'),
             'version' => $this->version,
+            'encodeHistory' => false,
         ];
 
         if ($request->header(Header::INERTIA)) {

--- a/src/Response.php
+++ b/src/Response.php
@@ -95,7 +95,7 @@ class Response implements Responsable
             'props' => $props,
             'url' => Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/'),
             'version' => $this->version,
-            'encodeHistory' => false,
+            'encryptHistory' => false,
         ];
 
         if ($request->header(Header::INERTIA)) {

--- a/src/Response.php
+++ b/src/Response.php
@@ -96,6 +96,7 @@ class Response implements Responsable
             'url' => Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/'),
             'version' => $this->version,
             'encryptHistory' => false,
+            'clearHistory' => false,
         ];
 
         if ($request->header(Header::INERTIA)) {

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -28,7 +28,7 @@ class ControllerTest extends TestCase
             ],
             'url' => '/',
             'version' => '',
-            'encodeHistory' => false,
+            'encryptHistory' => false,
         ]);
     }
 }

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -28,6 +28,7 @@ class ControllerTest extends TestCase
             ],
             'url' => '/',
             'version' => '',
+            'encodeHistory' => false,
         ]);
     }
 }

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -29,6 +29,7 @@ class ControllerTest extends TestCase
             'url' => '/',
             'version' => '',
             'encryptHistory' => false,
+            'clearHistory' => false,
         ]);
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -46,7 +46,7 @@ class ResponseTest extends TestCase
         $this->assertSame('Jonathan', $page['props']['user']['name']);
         $this->assertSame('/user/123', $page['url']);
         $this->assertSame('123', $page['version']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;encodeHistory&quot;:false}"></div>', $view->render());
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;encryptHistory&quot;:false}"></div>', $view->render());
     }
 
     public function test_xhr_response(): void
@@ -98,8 +98,7 @@ class ResponseTest extends TestCase
         $callable = static function () use ($users) {
             $page = new LengthAwarePaginator($users->take(2), $users->count(), 2);
 
-            return new class($page, JsonResource::class) extends ResourceCollection {
-            };
+            return new class($page, JsonResource::class) extends ResourceCollection {};
         };
 
         $response = new Response('User/Index', ['users' => $callable], 'app', '123');

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -46,7 +46,7 @@ class ResponseTest extends TestCase
         $this->assertSame('Jonathan', $page['props']['user']['name']);
         $this->assertSame('/user/123', $page['url']);
         $this->assertSame('123', $page['version']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;}"></div>', $view->render());
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;encodeHistory&quot;:false}"></div>', $view->render());
     }
 
     public function test_xhr_response(): void

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -46,7 +46,7 @@ class ResponseTest extends TestCase
         $this->assertSame('Jonathan', $page['props']['user']['name']);
         $this->assertSame('/user/123', $page['url']);
         $this->assertSame('123', $page['version']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;encryptHistory&quot;:false}"></div>', $view->render());
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;encryptHistory&quot;:false,&quot;clearHistory&quot;:false}"></div>', $view->render());
     }
 
     public function test_xhr_response(): void


### PR DESCRIPTION
This would allow the application to use multiple packages that use both Inertia.js 1 and 2, relying on `inertia/inertia-laravel` v1 before fully migrating to v2.

## Proposal

With these changes, developers can now update their packages to use Inertia.js v2 without including any new specific v2 features, including Defer props, Polling, etc., and set the packages composer.json to `"inertia/inertia-laravel": "^1.4|^2.0"`. This way, applications that still run on Inertia.js v1 can get the latest package releases without being locked into running older package versions or having to upgrade the application to v2 straight away.

Package developers can choose to ignore this options and enforce `"inertia/inertia-laravel": "^2.0"` to utilise v2 features.

### Pros

* Package developers can safely update npm dependencies to v2.
* Application developers can get updated packages with the latest v2 without changing their code instead locked to older release due to `"inertia/inertia-laravel"` version conflict.

### Cons

* Package developers cannot utilize new Inertia 2 features. 
* Encode histories are ignored until `inertiajs/inertia-laravel` has been updated to v2.
