### PR TITLE
[2.x] Call `toArray()` on `Arrayable` props resolved from the Container

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -263,6 +263,10 @@ class Response implements Responsable
                 $value = App::call($value);
             }
 
+            if ($value instanceof Arrayable) {
+                $value = $value->toArray();
+            }
+
             if ($value instanceof PromiseInterface) {
                 $value = $value->wait();
             }


### PR DESCRIPTION
There's a bug in v2.0 in which `Arrayable` instances that are resolved from the container, for example with deferred props, are not correctly resolved because `toArray()` is never called on them. This PR fixes that and adds a test for it.

In the scenario below, both `Users` and `Departments` implement the `Arrayable` interface, but when resolving `departments` on a partial request, it currently returns an empty object.

```php
return inertia('Users', [
    'users' => Users::make(),
    'departments' => Inertia::defer(fn () => Departments::make()),
]);
```