### PR TITLE
[2.x] Addition of methods facilitating adding headers onto Inertia responses

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -150,11 +150,16 @@ class ResponseFactory
 
     /**
      * @param  string|SymfonyRedirect  $url
+     * @param  array<string, string>  $headers
      */
-    public function location($url): SymfonyResponse
+    public function location($url, array $headers = []): SymfonyResponse
     {
         if (Request::inertia()) {
-            return BaseResponse::make('', 409, [Header::LOCATION => $url instanceof SymfonyRedirect ? $url->getTargetUrl() : $url]);
+            return BaseResponse::make(
+                '',
+                409,
+                array_merge($headers, ['X-Inertia-Location' => $url instanceof SymfonyRedirect ? $url->getTargetUrl() : $url])
+            );
         }
 
         return $url instanceof SymfonyRedirect ? $url : Redirect::away($url);

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -106,6 +106,21 @@ class ResponseFactoryTest extends TestCase
         $this->assertSame($response, $redirect);
     }
 
+    public function test_location_accepts_additional_headers_and_returns_them_in_response(): void
+    {
+        Request::macro('inertia', function () {
+            return true;
+        });
+
+        $response = (new ResponseFactory)->location('https://inertiajs.com', [
+            'X-Robots-Tag' => 'noindex, nofollow',
+        ]);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertEquals('noindex, nofollow', $response->headers->get('X-Robots-Tag'));
+    }
+
     public function test_the_version_can_be_a_closure(): void
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -726,4 +726,30 @@ class ResponseTest extends TestCase
 
         $this->assertSame('/subpath/product/123', $page->url);
     }
+
+    public function test_headers_can_be_chained_to_response(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+
+        $user = ['name' => 'Jonathan'];
+        $response = new Response('User/Edit', ['user' => $user], 'app', '123');
+        $time = now()->timestamp;
+        $response->withHeader('X-Session-Time', $time);
+
+        $version = 'v1';
+        $limit = 100;
+
+        $response->withHeaders([
+            'X-Version' => $version,
+            'X-Rate-Limit-Limit' => $limit,
+        ]);
+
+        $response = $response->toResponse($request);
+
+        $this->assertSame((string) $time, $response->headers->get('X-Session-Time'));
+        $this->assertSame($version, $response->headers->get('X-Version'));
+        $this->assertSame((string) $limit, $response->headers->get('X-Rate-Limit-Limit'));
+    }
+
 }


### PR DESCRIPTION
This PR adds the ability to include headers in an `\Inertia\Response` via the methods `withHeader` and `withHeaders` and updates `toResponse` to include these headers with returned response.

Currently, to include headers with the Inertia response, you need to call the `toResponse` method and chain the header method calls on the response object. This changes the return type away from being an `\Inertia\Response` object.

With this update, you can add headers while still returning an `Inertia\Response` type without needing to access the underlying response object and inject the request.

**Currently**
```php
return Inertia::render('Feed/Index', compact('feed'))
    ->withViewData('description', 'This is the feed page.')
    ->with('flash.success', 'Feed loaded!')
    ->with('crumbs', ['Community', 'Feed', 'Index'])
    ->toResponse($request)
    ->withHeader('X-Feed-Fetched-Timestamp', $time);
```

**After implementation**
```php
return Inertia::render('Feed/Index', compact('feed'))
    ->withHeader('X-Feed-Fetched-Timestamp', $time)
    ->withViewData('description', 'This is the feed page.')
    ->with('flash.success', 'Feed loaded!')
    ->with('crumbs', ['Community', 'Feed', 'Index']);
```

Additionally, I included the changes, which were being considered that were submitted in #500 before it was closed due to branch deletion. This allows the `location` to have a second argument that will include headers in the redirect response.
