### PR TITLE
[2.x] Introduce inertiaProps Method in TestResponseMacros for Improved Inertia.js Testing

### DIFF
--- a/src/Testing/TestResponseMacros.php
+++ b/src/Testing/TestResponseMacros.php
@@ -3,6 +3,7 @@
 namespace Inertia\Testing;
 
 use Closure;
+use Illuminate\Support\Arr;
 
 class TestResponseMacros
 {
@@ -26,5 +27,13 @@ class TestResponseMacros
         return function () {
             return AssertableInertia::fromTestResponse($this)->toArray();
         };
+    }
+
+    public function inertiaProps(?string $propName = null): mixed
+    {
+        return Arr::get(
+            $this->inertiaPage()['props'] ?? [],
+            $propName
+        );
     }
 }

--- a/src/Testing/TestResponseMacros.php
+++ b/src/Testing/TestResponseMacros.php
@@ -29,11 +29,13 @@ class TestResponseMacros
         };
     }
 
-    public function inertiaProps(?string $propName = null): mixed
+    public function inertiaProps()
     {
-        return Arr::get(
-            $this->inertiaPage()['props'] ?? [],
-            $propName
-        );
+        return function (?string $propName = null) {
+            return Arr::get(
+                $this->inertiaPage()['props'] ?? [],
+                $propName
+            );
+        };
     }
 }

--- a/src/Testing/TestResponseMacros.php
+++ b/src/Testing/TestResponseMacros.php
@@ -32,10 +32,7 @@ class TestResponseMacros
     public function inertiaProps()
     {
         return function (?string $propName = null) {
-            return Arr::get(
-                $this->inertiaPage()['props'] ?? [],
-                $propName
-            );
+            return Arr::get($this->inertiaPage()['props'], $propName);
         };
     }
 }

--- a/tests/Testing/TestResponseMacrosTest.php
+++ b/tests/Testing/TestResponseMacrosTest.php
@@ -50,4 +50,23 @@ class TestResponseMacrosTest extends TestCase
             $this->assertFalse($page['clearHistory']);
         });
     }
+
+    public function test_it_can_retrieve_the_inertia_props(): void
+    {
+        $props = ['bar' => 'baz'];
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', $props)
+        );
+
+        tap($response->inertiaProps(), fn (array $pageProps) => $this->assertSame($props, $pageProps));
+    }
+
+    public function test_it_can_retrieve_nested_inertia_prop_values_with_dot_notation(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', ['bar' => ['baz' => 'qux']])
+        );
+
+        tap($response->inertiaProps('bar.baz'), fn (mixed $value) => $this->assertSame('qux', $value));
+    }
 }

--- a/tests/Testing/TestResponseMacrosTest.php
+++ b/tests/Testing/TestResponseMacrosTest.php
@@ -58,15 +58,22 @@ class TestResponseMacrosTest extends TestCase
             Inertia::render('foo', $props)
         );
 
-        tap($response->inertiaProps(), fn (array $pageProps) => $this->assertSame($props, $pageProps));
+        $this->assertSame($props, $response->inertiaProps());
     }
 
     public function test_it_can_retrieve_nested_inertia_prop_values_with_dot_notation(): void
     {
         $response = $this->makeMockRequest(
-            Inertia::render('foo', ['bar' => ['baz' => 'qux']])
+            Inertia::render('foo', [
+                'bar' => ['baz' => 'qux'],
+                'users' => [
+                    ['name' => 'John'],
+                    ['name' => 'Jane'],
+                ],
+            ])
         );
 
-        tap($response->inertiaProps('bar.baz'), fn (mixed $value) => $this->assertSame('qux', $value));
+        $this->assertSame('qux', $response->inertiaProps('bar.baz'));
+        $this->assertSame('John', $response->inertiaProps('users.0.name'));
     }
 }


### PR DESCRIPTION
This commit introduces an enhanced **inertiaProps** method in the TestResponseMacros class, accompanied by comprehensive tests. The method streamlines the retrieval of specific properties from an Inertia.js response during testing. By leveraging Laravel's `Arr::get` utility, it supports accessing nested properties using dot notation and gracefully handles cases where the specified property is missing by returning a default value.

### Feature
- Direct Prop Extraction: Easily extract all props from the response.
- Dot Notation Support: Access nested prop values using dot notation without causing exceptions.

### Example usage:
`$response->inertiaProps(); // Get All Props`
`$response->inertiaProps('user.name'); // Get Specific Props Value`

This improvement enhances test readability and simplifies property assertions for developers working with Inertia.js.

Contribution of [#659](https://github.com/inertiajs/inertia-laravel/issues/659#issue-2511699537), [#589](https://github.com/inertiajs/inertia-laravel/issues/589#issue-2163491886)