### PR TITLE
Handle SSR URLs with trailing slashes

### DIFF
--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -4,7 +4,6 @@ namespace Inertia\Ssr;
 
 use Exception;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Str;
 
 class HttpGateway implements Gateway
 {
@@ -17,7 +16,7 @@ class HttpGateway implements Gateway
             return null;
         }
 
-        $url = str_replace('/render', '', Str::chopEnd(config('inertia.ssr.url', 'http://127.0.0.1:13714'), '/')).'/render';
+        $url = str_replace('/render', '', rtrim(config('inertia.ssr.url', 'http://127.0.0.1:13714'), '/')) . '/render';
 
         try {
             $response = Http::post($url, $page)->throw()->json();

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -4,6 +4,7 @@ namespace Inertia\Ssr;
 
 use Exception;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 
 class HttpGateway implements Gateway
 {
@@ -16,7 +17,7 @@ class HttpGateway implements Gateway
             return null;
         }
 
-        $url = str_replace('/render', '', config('inertia.ssr.url', 'http://127.0.0.1:13714')).'/render';
+        $url = str_replace('/render', '', Str::chopEnd(config('inertia.ssr.url', 'http://127.0.0.1:13714'), '/')).'/render';
 
         try {
             $response = Http::post($url, $page)->throw()->json();


### PR DESCRIPTION
If `inertia.ssr.url` ends with a `/`, then generated URL ends with `//render` which results in a 404 response from the SSR server which then causes a very confusing error message in Laravel (access to undefined index "head").

Instead, remove a trailing slash from the URL before appending `/render`.