### PR TITLE
[2.x] Allow environment config for `ssr.enabled`, `ssr.url`, and `history.encrypt`

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -21,9 +21,9 @@ return [
 
     'ssr' => [
 
-        'enabled' => true,
+        'enabled' => (bool) env('INERTIA_SSR_ENABLED', true),
 
-        'url' => 'http://127.0.0.1:13714',
+        'url' => env('INERTIA_SSR_URL', 'http://127.0.0.1:13714'),
 
         // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
 

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -66,7 +66,7 @@ return [
 
     'history' => [
 
-        'encrypt' => false,
+        'encrypt' => (bool) env('INERTIA_ENCRYPT_HISTORY', false),
 
     ],
 


### PR DESCRIPTION
It is great to be able to configure commonly changed settings through environment variables, as recommended by the 12 factor app guidelines: <https://12factor.net/config>.

In recent times the amount of Laravel config values exposed through environment variables has also increased by a lot.

It only makes sense to also allow for this same practice with Inertia.