### PR TITLE
fix(config): correct path case in Inertia page_paths

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -47,7 +47,7 @@ return [
 
         'page_paths' => [
 
-            resource_path('js/Pages'),
+            resource_path('js/pages'),
 
         ],
 


### PR DESCRIPTION
- Updated `page_paths` config to use lowercase 'pages' directory.
- Ensures consistency with naming conventions and avoids errors.