### PR TITLE
Improve URL handling with support for trailing slashes

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -109,7 +109,7 @@ class Response implements Responsable
             [
                 'component' => $this->component,
                 'props' => $props,
-                'url' => $this->getRequestUrl($request),
+                'url' => $this->getUrl($request),
                 'version' => $this->version,
                 'clearHistory' => $this->clearHistory,
                 'encryptHistory' => $this->encryptHistory,
@@ -361,28 +361,27 @@ class Response implements Responsable
     }
 
     /**
-     * Get the request URL with proper handling of proxy prefixes and trailing slashes.
+     * Get the URL from the request (without the scheme and host) while preserving the trailing slash if it exists.
      */
-    protected function getRequestUrl(Request $request): string
+    protected function getUrl(Request $request): string
     {
-        // Get the original request URI which should already contain any base path
-        $originalUri = $request->getRequestUri();
-        
-        // Handle X-Forwarded-Prefix header for proxy setups
-        if ($prefix = $request->header('X_FORWARDED_PREFIX')) {
-            // Only add the prefix if it's not already at the start of the URI
-            if (!str_starts_with($originalUri, $prefix)) {
-                $originalUri = $prefix . $originalUri;
-            }
-        }
-        
-        // Decode the query string portion for better readability
-        if (str_contains($originalUri, '?')) {
-            list($path, $query) = explode('?', $originalUri, 2);
-            $query = urldecode($query);
-            return $path . '?' . $query;
-        }
-        
-        return $originalUri;
+        $url = Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/');
+
+        $rawUri = Str::before($request->getRequestUri(), '?');
+
+        return Str::endsWith($rawUri, '/') ? $this->finishUrlWithTrailingSlash($url) : $url;
+    }
+
+    /**
+     * Ensure the URL has a trailing slash before the query string (if it exists).
+     */
+    protected function finishUrlWithTrailingSlash(string $url): string
+    {
+        // Make sure the relative URL ends with a trailing slash and re-append the query string if it exists.
+        $urlWithoutQueryWithTrailingSlash = Str::finish(Str::before($url, '?'), '/');
+
+        return str_contains($url, '?')
+            ? $urlWithoutQueryWithTrailingSlash.'?'.Str::after($url, '?')
+            : $urlWithoutQueryWithTrailingSlash;
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -109,7 +109,7 @@ class Response implements Responsable
             [
                 'component' => $this->component,
                 'props' => $props,
-                'url' => Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/'),
+                'url' => $this->getRequestUrl($request),
                 'version' => $this->version,
                 'clearHistory' => $this->clearHistory,
                 'encryptHistory' => $this->encryptHistory,
@@ -358,5 +358,22 @@ class Response implements Responsable
     public function isPartial(Request $request): bool
     {
         return $request->header(Header::PARTIAL_COMPONENT) === $this->component;
+    }
+
+    /**
+     * Get the request URL with proper handling of proxy prefixes and trailing slashes.
+     */
+    protected function getRequestUrl(Request $request): string
+    {
+        $uri = $request->getRequestUri();
+        
+        // Handle X-Forwarded-Prefix header for proxy setups
+        if ($prefix = $request->header('X_FORWARDED_PREFIX')) {
+            if (!str_starts_with($uri, $prefix)) {
+                $uri = $prefix . $uri;
+            }
+        }
+        
+        return $uri;
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -365,15 +365,24 @@ class Response implements Responsable
      */
     protected function getRequestUrl(Request $request): string
     {
-        $uri = $request->getRequestUri();
+        // Get the original request URI which should already contain any base path
+        $originalUri = $request->getRequestUri();
         
         // Handle X-Forwarded-Prefix header for proxy setups
         if ($prefix = $request->header('X_FORWARDED_PREFIX')) {
-            if (!str_starts_with($uri, $prefix)) {
-                $uri = $prefix . $uri;
+            // Only add the prefix if it's not already at the start of the URI
+            if (!str_starts_with($originalUri, $prefix)) {
+                $originalUri = $prefix . $originalUri;
             }
         }
         
-        return $uri;
+        // Decode the query string portion for better readability
+        if (str_contains($originalUri, '?')) {
+            list($path, $query) = explode('?', $originalUri, 2);
+            $query = urldecode($query);
+            return $path . '?' . $query;
+        }
+        
+        return $originalUri;
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -32,18 +32,6 @@ class ResponseTest extends TestCase
         $this->assertEquals('bar', $response->foo());
     }
 
-public function test_the_page_url_is_not_encoded(): void
-    {
-        $request = Request::create('/product/123', 'GET', ['value' => 'te/st']);
-        $request->headers->add(['X-Inertia' => 'true']);
-
-        $response = new Response('Product/Show', []);
-        $response = $response->toResponse($request);
-        $page = $response->getData();
-
-        $this->assertSame('/product/123?value=te/st', $page->url);
-    }
-
     public function test_server_response(): void
     {
         $request = Request::create('/user/123', 'GET');
@@ -839,112 +827,52 @@ public function test_the_page_url_is_not_encoded(): void
 
         $this->assertSame('/subpath/product/123', $page->url);
     }
-    
-    public function test_trailing_slashes_in_url_are_preserved(): void
+
+    public function test_trailing_slashes_in_a_url_are_preserved(): void
     {
-        // Test with trailing slash in the URL
-        $request = Request::create('/categories/', 'GET');
+        $request = Request::create('/users/', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
-        
-        $response = new Response('Category/Index', []);
+
+        $response = new Response('User/Index', []);
         $response = $response->toResponse($request);
         $page = $response->getData();
-        
-        $this->assertSame('/categories/', $page->url);
-        
-        // Test with trailing slash and query parameters
-        $request = Request::create('/categories/?page=1&sort=name', 'GET');
-        $request->headers->add(['X-Inertia' => 'true']);
-        
-        $response = new Response('Category/Index', []);
-        $response = $response->toResponse($request);
-        $page = $response->getData();
-        
-        $this->assertSame('/categories/?page=1&sort=name', $page->url);
-        
-        // Test with trailing slash and proxy prefix
-        $request = Request::create('/categories/', 'GET');
-        $request->headers->set('X_FORWARDED_PREFIX', '/admin');
-        $request->headers->add(['X-Inertia' => 'true']);
-        
-        $response = new Response('Category/Index', []);
-        $response = $response->toResponse($request);
-        $page = $response->getData();
-        
-        $this->assertSame('/admin/categories/', $page->url);
+
+        $this->assertSame('/users/', $page->url);
     }
-    
-    public function test_non_trailing_slashes_in_url_work_correctly(): void
+
+    public function test_trailing_slashes_in_a_url_with_query_parameters_are_preserved(): void
     {
-        // Test with non-trailing slash in the URL
-        $request = Request::create('/categories', 'GET');
+        $request = Request::create('/users/?page=1&sort=name', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
-        
-        $response = new Response('Category/Index', []);
+
+        $response = new Response('User/Index', []);
         $response = $response->toResponse($request);
         $page = $response->getData();
-        
-        $this->assertSame('/categories', $page->url);
-        
-        // Test with non-trailing slash and query parameters
-        $request = Request::create('/categories?page=1&sort=name', 'GET');
-        $request->headers->add(['X-Inertia' => 'true']);
-        
-        $response = new Response('Category/Index', []);
-        $response = $response->toResponse($request);
-        $page = $response->getData();
-        
-        $this->assertSame('/categories?page=1&sort=name', $page->url);
-        
-        // Test with non-trailing slash and proxy prefix
-        $request = Request::create('/categories', 'GET');
-        $request->headers->set('X_FORWARDED_PREFIX', '/admin');
-        $request->headers->add(['X-Inertia' => 'true']);
-        
-        $response = new Response('Category/Index', []);
-        $response = $response->toResponse($request);
-        $page = $response->getData();
-        
-        $this->assertSame('/admin/categories', $page->url);
+
+        $this->assertSame('/users/?page=1&sort=name', $page->url);
     }
-    
-    public function test_url_with_slashes_in_query_params(): void
+
+    public function test_a_url_without_trailing_slash_is_resolved_correctly(): void
     {
-        // Test with forward slashes in query parameters
-        $request = Request::create('/product/123?value=te/st', 'GET');
+        $request = Request::create('/users', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
-        
-        $response = new Response('Product/Show', []);
+
+        $response = new Response('User/Index', []);
         $response = $response->toResponse($request);
         $page = $response->getData();
-        
-        // Forward slashes should be preserved, not encoded as %2F
-        $this->assertSame('/product/123?value=te/st', $page->url);
+
+        $this->assertSame('/users', $page->url);
     }
-    
-    public function test_url_with_ampersands_in_query_params(): void
+
+    public function test_a_url_without_trailing_slash_and_query_parameters_is_resolved_correctly(): void
     {
-        // Test normal query parameters with & as separator
-        $request = Request::create('/families?search=jonathan&amy=test', 'GET');
+        $request = Request::create('/users?page=1&sort=name', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
-        
-        $response = new Response('Family/Index', []);
+
+        $response = new Response('User/Index', []);
         $response = $response->toResponse($request);
         $page = $response->getData();
-        
-        // Check that the URL contains both parameters properly separated by &
-        $this->assertStringContainsString('search=jonathan', $page->url);
-        $this->assertStringContainsString('amy=test', $page->url);
-        
-        // Test encoded ampersand within a parameter value
-        $request = Request::create('/families?search=jonathan%26amy', 'GET');
-        $request->headers->add(['X-Inertia' => 'true']);
-        
-        $response = new Response('Family/Index', []);
-        $response = $response->toResponse($request);
-        $page = $response->getData();
-        
-        // The & should be decoded in the parameter value
-        $this->assertSame('/families?search=jonathan&amy', $page->url);
+
+        $this->assertSame('/users?page=1&sort=name', $page->url);
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -827,4 +827,72 @@ class ResponseTest extends TestCase
 
         $this->assertSame('/subpath/product/123', $page->url);
     }
+    
+    public function test_trailing_slashes_in_url_are_preserved(): void
+    {
+        // Test with trailing slash in the URL
+        $request = Request::create('/categories/', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        
+        $response = new Response('Category/Index', []);
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+        
+        $this->assertSame('/categories/', $page->url);
+        
+        // Test with trailing slash and query parameters
+        $request = Request::create('/categories/?page=1&sort=name', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        
+        $response = new Response('Category/Index', []);
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+        
+        $this->assertSame('/categories/?page=1&sort=name', $page->url);
+        
+        // Test with trailing slash and proxy prefix
+        $request = Request::create('/categories/', 'GET');
+        $request->headers->set('X_FORWARDED_PREFIX', '/admin');
+        $request->headers->add(['X-Inertia' => 'true']);
+        
+        $response = new Response('Category/Index', []);
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+        
+        $this->assertSame('/admin/categories/', $page->url);
+    }
+    
+    public function test_non_trailing_slashes_in_url_work_correctly(): void
+    {
+        // Test with non-trailing slash in the URL
+        $request = Request::create('/categories', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        
+        $response = new Response('Category/Index', []);
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+        
+        $this->assertSame('/categories', $page->url);
+        
+        // Test with non-trailing slash and query parameters
+        $request = Request::create('/categories?page=1&sort=name', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        
+        $response = new Response('Category/Index', []);
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+        
+        $this->assertSame('/categories?page=1&sort=name', $page->url);
+        
+        // Test with non-trailing slash and proxy prefix
+        $request = Request::create('/categories', 'GET');
+        $request->headers->set('X_FORWARDED_PREFIX', '/admin');
+        $request->headers->add(['X-Inertia' => 'true']);
+        
+        $response = new Response('Category/Index', []);
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+        
+        $this->assertSame('/admin/categories', $page->url);
+    }
 }


### PR DESCRIPTION
Trailing slashes in URL are legit: https://developers.google.com/search/blog/2010/04/to-slash-or-not-to-slash

However the workaround for this package is pretty ugly: https://medium.com/@elbijay/trailing-slashes-for-inertia-and-laravel-74718fae51e2

Not only that, but the above solution calling setContent will double the request rendering.  Without this code, only one view and one http client is created for each request.
![image](https://github.com/user-attachments/assets/c9e4b54b-8258-49b8-847e-9c03d0b37de7)


This PR improves URL handling to properly preserve trailing slashes in URLs, which is important for SEO and compatibility with certain routing configurations. It also ensures proper handling of proxy prefixes with trailing slashes (which is how [this bug](https://github.com/inertiajs/inertia-laravel/commit/f2cd16b5f31488eb7cb6dfa278b614ceb9acc27c) was introduced originally)

EDIT:  Hopefully this doesn't decrease the chances that this will get merged, but I added a second commit to solve this [PR](https://github.com/inertiajs/inertia-laravel/pull/663).  Since the logic for determining the URL is now in it's own function, it is much easier to write clean code for each of these situations.