### PR TITLE
[2.x] Allow deepMerge on custom properties

### DIFF
--- a/src/MergeProp.php
+++ b/src/MergeProp.php
@@ -13,11 +13,13 @@ class MergeProp implements Mergeable
 
     /**
      * @param  mixed  $value
+     * @param  string[]  $mergeStrategies
      */
-    public function __construct($value)
+    public function __construct($value, array $mergeStrategies = [])
     {
         $this->value = $value;
         $this->merge = true;
+        $this->mergeStrategies = $mergeStrategies;
     }
 
     public function __invoke()

--- a/src/MergesProps.php
+++ b/src/MergesProps.php
@@ -8,6 +8,8 @@ trait MergesProps
 
     protected bool $deepMerge = false;
 
+    protected array $mergeStrategies = [];
+
     public function merge(): static
     {
         $this->merge = true;
@@ -30,5 +32,10 @@ trait MergesProps
     public function shouldDeepMerge(): bool
     {
         return $this->deepMerge;
+    }
+
+    public function mergeStrategies(): array
+    {
+        return $this->mergeStrategies;
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -319,6 +319,15 @@ class Response implements Responsable
             ->filter(fn ($prop) => $prop->shouldDeepMerge())
             ->keys();
 
+        $mergeStrategies = $mergeProps
+            ->map(function ($prop, $key) {
+                return collect($prop->mergeStrategies())
+                    ->map(fn ($strategy) => $key.".".$strategy)
+                    ->toArray();
+            })
+            ->flatten()
+            ->values();
+
         $mergeProps = $mergeProps
             ->filter(fn ($prop) => ! $prop->shouldDeepMerge())
             ->keys();
@@ -326,6 +335,7 @@ class Response implements Responsable
         return array_filter([
             'mergeProps' => $mergeProps->toArray(),
             'deepMergeProps' => $deepMergeProps->toArray(),
+            'mergeStrategies' => $mergeStrategies->toArray(),
         ], fn ($prop) => count($prop) > 0);
     }
 

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -134,10 +134,11 @@ class ResponseFactory
 
     /**
      * @param  mixed  $value
+     * @parram null|string|string[]  $mergeStrategies
      */
-    public function deepMerge($value): MergeProp
+    public function deepMerge($value, $mergeStrategies = null): MergeProp
     {
-        return (new MergeProp($value))->deepMerge();
+        return (new MergeProp($value, Arr::wrap($mergeStrategies)))->deepMerge();
     }
 
     /**

--- a/tests/DeepMergePropTest.php
+++ b/tests/DeepMergePropTest.php
@@ -27,4 +27,11 @@ class DeepMergePropTest extends TestCase
 
         $this->assertInstanceOf(Request::class, $mergeProp());
     }
+
+    public function test_can_use_single_string_as_merge_strategy(): void
+    {
+        $mergeProp = (new MergeProp(['key' => 'value'], ['key']))->deepMerge();
+
+        $this->assertEquals(['key'], $mergeProp->mergeStrategies());
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -201,6 +201,45 @@ class ResponseTest extends TestCase
         $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:&quot;foo value&quot;,&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deepMergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;]}"></div>', $view->render());
     }
 
+    public function test_server_response_with_merge_strategies(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+
+        $user = ['name' => 'Jonathan'];
+        $response = new Response(
+            'User/Edit',
+            [
+                'user' => $user,
+                'foo' => (new MergeProp('foo value', ['foo-key']))->deepMerge(),
+                'bar' => (new MergeProp('bar value', ['bar-key']))->deepMerge(),
+            ],
+            'app',
+            '123'
+        );
+        $response = $response->toResponse($request);
+        $view = $response->getOriginalContent();
+        $page = $view->getData()['page'];
+
+        $this->assertInstanceOf(BaseResponse::class, $response);
+        $this->assertInstanceOf(View::class, $view);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('Jonathan', $page['props']['user']['name']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertSame([
+            'foo',
+            'bar',
+        ], $page['deepMergeProps']);
+        $this->assertSame([
+            'foo.foo-key',
+            'bar.bar-key',
+        ], $page['mergeStrategies']);
+        $this->assertFalse($page['clearHistory']);
+        $this->assertFalse($page['encryptHistory']);
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:&quot;foo value&quot;,&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deepMergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;],&quot;mergeStrategies&quot;:[&quot;foo.foo-key&quot;,&quot;bar.bar-key&quot;]}"></div>', $view->render());
+    }
+
     public function test_server_response_with_defer_and_merge_props(): void
     {
         $request = Request::create('/user/123', 'GET');


### PR DESCRIPTION
This PR adds the ability to specify custom dot notated keys to use when deep merging data with Inertia.

For example, let's say you have a component that renders a user pagination via infinite loading using the `WhenVisible` component:

```php
Route::get('/users', function () {
    return Inertia::render('Users/Index', [
        'results' => Inertia::deepMerge(User::paginate()),
    ]);
});
```

This works great while scrolling through the site as new users get appended, however when you perform any additional request that results in a redirect to the `/users` route, the current `deepMerge` strategy will append the users to the state.

This PR aims to fix this by allowing you to specify on which key(s) the data should be merged. In the case of a pagination, you would return:

```php
Route::get('/users', function () {
    return Inertia::render('Users/Index', [
        'results' => Inertia::deepMerge(User::paginate(), 'data.id'), // <--
    ]);
});
```

This tells Inertia to try and merge the `results.data` array by looking at the `id` property of the underlying objects (if it exists).
If the property is the same, the target object will be replaced with the new one from the response - otherwise it will be appended.

The JS implementation can be found here: https://github.com/inertiajs/inertia/pull/2344