### PR TITLE
Run tests on Ubuntu 24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Ubuntu 20.04 LTS runner has been removed on 2025-04-15.