### PR TITLE
[2.x] Support for a custom URL resolver

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void flushShared()
  * @method static void version(\Closure|string|null $version)
  * @method static string getVersion()
+ * @method static void resolveUrlUsing(\Closure|null $urlResolver = null)
  * @method static \Inertia\OptionalProp optional(callable $callback)
  * @method static \Inertia\LazyProp lazy(callable $callback)
  * @method static \Inertia\DeferProp defer(callable $callback, string $group = 'default')

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -70,6 +70,16 @@ class Middleware
     }
 
     /**
+     * Defines a callback that returns the relative URL.
+     *
+     * @return Closure|null
+     */
+    public function urlResolver()
+    {
+        return null;
+    }
+
+    /**
      * Handle the incoming request.
      *
      * @return Response
@@ -82,6 +92,10 @@ class Middleware
 
         Inertia::share($this->share($request));
         Inertia::setRootView($this->rootView($request));
+
+        if ($urlResolver = $this->urlResolver()) {
+            Inertia::resolveUrlUsing($urlResolver);
+        }
 
         $response = $next($request);
         $response->headers->set('Vary', Header::INERTIA);

--- a/src/Response.php
+++ b/src/Response.php
@@ -36,17 +36,26 @@ class Response implements Responsable
 
     protected $cacheFor = [];
 
+    protected ?Closure $urlResolver = null;
+
     /**
      * @param  array|Arrayable  $props
      */
-    public function __construct(string $component, array $props, string $rootView = 'app', string $version = '', bool $encryptHistory = false)
-    {
+    public function __construct(
+        string $component,
+        array $props,
+        string $rootView = 'app',
+        string $version = '',
+        bool $encryptHistory = false,
+        ?Closure $urlResolver = null
+    ) {
         $this->component = $component;
         $this->props = $props instanceof Arrayable ? $props->toArray() : $props;
         $this->rootView = $rootView;
         $this->version = $version;
         $this->clearHistory = session()->pull('inertia.clear_history', false);
         $this->encryptHistory = $encryptHistory;
+        $this->urlResolver = $urlResolver;
     }
 
     /**
@@ -365,6 +374,10 @@ class Response implements Responsable
      */
     protected function getUrl(Request $request): string
     {
+        if ($this->urlResolver) {
+            return App::call($this->urlResolver, ['request' => $request]);
+        }
+
         $url = Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/');
 
         $rawUri = Str::before($request->getRequestUri(), '?');

--- a/src/Response.php
+++ b/src/Response.php
@@ -374,15 +374,15 @@ class Response implements Responsable
      */
     protected function getUrl(Request $request): string
     {
-        if ($this->urlResolver) {
-            return App::call($this->urlResolver, ['request' => $request]);
-        }
+        $urlResolver = $this->urlResolver ?? function (Request $request) {
+            $url = Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/');
 
-        $url = Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/');
+            $rawUri = Str::before($request->getRequestUri(), '?');
 
-        $rawUri = Str::before($request->getRequestUri(), '?');
+            return Str::endsWith($rawUri, '/') ? $this->finishUrlWithTrailingSlash($url) : $url;
+        };
 
-        return Str::endsWith($rawUri, '/') ? $this->finishUrlWithTrailingSlash($url) : $url;
+        return App::call($urlResolver, ['request' => $request]);
     }
 
     /**

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -96,7 +96,7 @@ class ResponseFactory
         return (string) $version;
     }
 
-    public function resolveUrlUsing(?Closure $urlResolver): void
+    public function resolveUrlUsing(?Closure $urlResolver = null): void
     {
         $this->urlResolver = $urlResolver;
     }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -31,6 +31,9 @@ class ResponseFactory
 
     protected $encryptHistory;
 
+    /** @var Closure|null */
+    protected $urlResolver;
+
     /***
      * @param string $name The name of the root view
      * @return void
@@ -91,6 +94,11 @@ class ResponseFactory
             : $this->version;
 
         return (string) $version;
+    }
+
+    public function resolveUrlUsing(?Closure $urlResolver): void
+    {
+        $this->urlResolver = $urlResolver;
     }
 
     public function clearHistory(): void
@@ -163,6 +171,7 @@ class ResponseFactory
             $this->rootView,
             $this->getVersion(),
             $this->encryptHistory ?? config('inertia.history.encrypt', false),
+            $this->urlResolver,
         );
     }
 

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\ViewErrorBag;
 use Inertia\AlwaysProp;
 use Inertia\Inertia;
 use Inertia\Middleware;
+use Inertia\Tests\Stubs\CustomUrlResolverMiddleware;
 use Inertia\Tests\Stubs\ExampleMiddleware;
 use LogicException;
 
@@ -120,6 +121,21 @@ class MiddlewareTest extends TestCase
         $response->assertStatus(409);
         $response->assertHeader('X-Inertia-Location', $this->baseUrl);
         self::assertEmpty($response->getContent());
+    }
+
+    public function test_the_url_can_be_resolved_with_a_custom_resolver()
+    {
+        $this->prepareMockEndpoint(middleware: new CustomUrlResolverMiddleware);
+
+        $response = $this->withoutExceptionHandling()->get('/', [
+            'X-Inertia' => 'true',
+        ]);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'component' => 'User/Edit',
+            'url' => '/my-custom-url',
+        ]);
     }
 
     public function test_validation_errors_are_registered_as_of_default(): void

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -127,6 +127,30 @@ class ResponseFactoryTest extends TestCase
         $response->assertJson(['component' => 'User/Edit']);
     }
 
+    public function test_the_url_can_be_resolved_with_a_custom_resolver()
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::resolveUrlUsing(function ($request, ResponseFactory $otherDependency) {
+                $this->assertInstanceOf(HttpRequest::class, $request);
+                $this->assertInstanceOf(ResponseFactory::class, $otherDependency);
+
+                return '/my-custom-url';
+            });
+
+            return Inertia::render('User/Edit');
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', [
+            'X-Inertia' => 'true',
+        ]);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'component' => 'User/Edit',
+            'url' => '/my-custom-url',
+        ]);
+    }
+
     public function test_shared_data_can_be_shared_from_anywhere(): void
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {

--- a/tests/Stubs/CustomUrlResolverMiddleware.php
+++ b/tests/Stubs/CustomUrlResolverMiddleware.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Inertia\Tests\Stubs;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\ResponseFactory;
+use Inertia\Middleware;
+use PHPUnit\Framework\Assert;
+
+class CustomUrlResolverMiddleware extends Middleware
+{
+    public function urlResolver()
+    {
+        return function ($request, ResponseFactory $otherDependency) {
+            Assert::assertInstanceOf(Request::class, $request);
+            Assert::assertInstanceOf(ResponseFactory::class, $otherDependency);
+
+            return '/my-custom-url';
+        };
+    }
+}


### PR DESCRIPTION
Credit goes to @RobertBoes for bringing [this idea](https://github.com/inertiajs/inertia-laravel/pull/663#issuecomment-2391372314) to the table. I'll add you as an author when this is merged.

With this callback, you can customize the URL that gets sent to the frontend. There are many edge cases and preferences to have one unified way to do this (trailing slashes, encoded query params, etc.). This way, developers can customize the URL to their needs and setup.

```php
Inertia::resolveUrlUsing(function (Request $request) {
    // Return a custom relative URL based on the current request.
    return Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/');
});
```

Here are some of the issues/PRs about it:
- #236
- #333
- #359
- #360
- #421
- #422
- #437
- #446
- #499
- #503
- #592
- #663
- #707
- #731