### PR TITLE
[1.x] Run tests on Ubuntu 24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: true
       matrix:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "symfony/console": "^5.3|^6.0|^7.0"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-master",
         "orchestra/testbench": "^6.45|^7.44|^8.25|^9.3|^10.0",
         "mockery/mockery": "^1.3.3",
         "phpunit/phpunit": "^8.0|^9.5.8|^10.4|^11.5"

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -30,10 +30,13 @@ class ServiceProviderTest extends TestCase
         $routes = Route::getRoutes();
 
         $this->assertNotEmpty($routes->getRoutes());
-        $this->assertEquals($route, $routes->getRoutes()[0]);
-        $this->assertEquals(['GET', 'HEAD'], $route->methods);
-        $this->assertEquals('/', $route->uri);
-        $this->assertEquals(['uses' => '\Inertia\Controller@__invoke', 'controller' => '\Inertia\Controller'], $route->action);
-        $this->assertEquals(['component' => 'User/Edit', 'props' => ['user' => ['name' => 'Jonathan']]], $route->defaults);
+
+        $inertiaRoute = collect($routes->getRoutes())->first(fn ($route) => $route->uri === '/');
+
+        $this->assertEquals($route, $inertiaRoute);
+        $this->assertEquals(['GET', 'HEAD'], $inertiaRoute->methods);
+        $this->assertEquals('/', $inertiaRoute->uri);
+        $this->assertEquals(['uses' => '\Inertia\Controller@__invoke', 'controller' => '\Inertia\Controller'], $inertiaRoute->action);
+        $this->assertEquals(['component' => 'User/Edit', 'props' => ['user' => ['name' => 'Jonathan']]], $inertiaRoute->defaults);
     }
 }


### PR DESCRIPTION
Ubuntu 20.04 LTS runner has been removed on 2025-04-15.

Also drops `roave/security-advisories` dev dependency.