### PR TITLE
[2.x] Keep only partial data in mergeProps

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -309,16 +309,16 @@ class Response implements Responsable
 
     public function resolveMergeProps(Request $request): array
     {
-        $resetProps = collect(explode(',', $request->header(Header::RESET, '')));
-        $onlyProps = collect(explode(',', $request->header(Header::PARTIAL_ONLY, '')))->filter();
-        $exceptProps = collect(explode(',', $request->header(Header::PARTIAL_EXCEPT, '')));
+        $resetProps = array_filter(explode(',', $request->header(Header::RESET, '')));
+        $onlyProps = array_filter(explode(',', $request->header(Header::PARTIAL_ONLY, '')));
+        $exceptProps = array_filter(explode(',', $request->header(Header::PARTIAL_EXCEPT, '')));
 
         $mergeProps = collect($this->props)
             ->filter(fn ($prop) => $prop instanceof Mergeable)
             ->filter(fn ($prop) => $prop->shouldMerge())
-            ->filter(fn ($_, $key) => ! $resetProps->contains($key))
-            ->filter(fn ($_, $key) => $onlyProps->isEmpty() || $onlyProps->contains($key))
-            ->filter(fn ($_, $key) => ! $exceptProps->contains($key));
+            ->reject(fn ($_, $key) => in_array($key, $resetProps))
+            ->filter(fn ($_, $key) => count($onlyProps) === 0 || in_array($key, $onlyProps))
+            ->reject(fn ($_, $key) => in_array($key, $exceptProps));
 
         $deepMergeProps = $mergeProps
             ->filter(fn ($prop) => $prop->shouldDeepMerge())

--- a/src/Response.php
+++ b/src/Response.php
@@ -310,10 +310,15 @@ class Response implements Responsable
     public function resolveMergeProps(Request $request): array
     {
         $resetProps = collect(explode(',', $request->header(Header::RESET, '')));
+        $onlyProps = collect(explode(',', $request->header(Header::PARTIAL_ONLY, '')))->filter();
+        $exceptProps = collect(explode(',', $request->header(Header::PARTIAL_EXCEPT, '')));
+
         $mergeProps = collect($this->props)
             ->filter(fn ($prop) => $prop instanceof Mergeable)
             ->filter(fn ($prop) => $prop->shouldMerge())
-            ->filter(fn ($_, $key) => ! $resetProps->contains($key));
+            ->filter(fn ($_, $key) => ! $resetProps->contains($key))
+            ->filter(fn ($_, $key) => $onlyProps->isEmpty() || $onlyProps->contains($key))
+            ->filter(fn ($_, $key) => ! $exceptProps->contains($key));
 
         $deepMergeProps = $mergeProps
             ->filter(fn ($prop) => $prop->shouldDeepMerge())

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -320,6 +320,64 @@ class ResponseTest extends TestCase
         $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deepMergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;],&quot;deferredProps&quot;:{&quot;default&quot;:[&quot;foo&quot;]}}"></div>', $view->render());
     }
 
+    public function test_exclude_merge_props_from_partial_only_response(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Partial-Component' => 'User/Edit']);
+        $request->headers->add(['X-Inertia-Partial-Data' => 'user']);
+
+        $user = ['name' => 'Jonathan'];
+        $response = new Response(
+            'User/Edit',
+            [
+                'user' => $user,
+                'foo' => new MergeProp('foo value'),
+                'bar' => new MergeProp('bar value'),
+            ],
+            'app',
+            '123'
+        );
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $props = get_object_vars($page->props);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+
+        $this->assertSame('Jonathan', $props['user']->name);
+        $this->assertFalse(isset($page->mergeProps));
+    }
+
+    public function test_exclude_merge_props_from_partial_except_response(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Partial-Component' => 'User/Edit']);
+        $request->headers->add(['X-Inertia-Partial-Except' => 'foo']);
+
+        $user = ['name' => 'Jonathan'];
+        $response = new Response(
+            'User/Edit',
+            [
+                'user' => $user,
+                'foo' => new MergeProp('foo value'),
+                'bar' => new MergeProp('bar value'),
+            ],
+            'app',
+            '123'
+        );
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $props = get_object_vars($page->props);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+
+        $this->assertSame('Jonathan', $props['user']->name);
+        $this->assertSame(['bar'], $page->mergeProps);
+    }
+
     public function test_xhr_response(): void
     {
         $request = Request::create('/user/123', 'GET');

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -346,6 +346,8 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
 
         $this->assertSame('Jonathan', $props['user']->name);
+        $this->assertArrayNotHasKey('foo', $props);
+        $this->assertArrayNotHasKey('bar', $props);
         $this->assertFalse(isset($page->mergeProps));
     }
 
@@ -375,6 +377,8 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
 
         $this->assertSame('Jonathan', $props['user']->name);
+        $this->assertArrayNotHasKey('foo', $props);
+        $this->assertArrayHasKey('bar', $props);
         $this->assertSame(['bar'], $page->mergeProps);
     }
 


### PR DESCRIPTION
This PR resolve this issue https://github.com/inertiajs/inertia/issues/2371

When you reload with partial data, the mergeProps dans deepMergeProps contains all props. So the VueJS will merge the prop with the response, but the response don't have the props.

Example props
```
[
    'user' => $user,
    'foo' => new MergeProp('foo value'),
]
```

If you reload with only `user`, the response will have  `mergeProps: ['foo']` but the `foo` is not there.

The same with the except.
