### PR TITLE
[2.x] Refactor `mergeStrategies` argument to `matchOn()` method

### DIFF
--- a/src/MergeProp.php
+++ b/src/MergeProp.php
@@ -13,13 +13,11 @@ class MergeProp implements Mergeable
 
     /**
      * @param  mixed  $value
-     * @param  string[]  $mergeStrategies
      */
-    public function __construct($value, array $mergeStrategies = [])
+    public function __construct($value)
     {
         $this->value = $value;
         $this->merge = true;
-        $this->mergeStrategies = $mergeStrategies;
     }
 
     public function __invoke()

--- a/src/MergesProps.php
+++ b/src/MergesProps.php
@@ -2,13 +2,15 @@
 
 namespace Inertia;
 
+use Illuminate\Support\Arr;
+
 trait MergesProps
 {
     protected bool $merge = false;
 
     protected bool $deepMerge = false;
 
-    protected array $mergeStrategies = [];
+    protected array $matchOn = [];
 
     public function merge(): static
     {
@@ -24,6 +26,13 @@ trait MergesProps
         return $this->merge();
     }
 
+    public function matchOn(string|array $matchOn): static
+    {
+        $this->matchOn = Arr::wrap($matchOn);
+
+        return $this;
+    }
+
     public function shouldMerge(): bool
     {
         return $this->merge;
@@ -34,8 +43,8 @@ trait MergesProps
         return $this->deepMerge;
     }
 
-    public function mergeStrategies(): array
+    public function matchesOn(): array
     {
-        return $this->mergeStrategies;
+        return $this->matchOn;
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -333,9 +333,9 @@ class Response implements Responsable
             ->filter(fn ($prop) => $prop->shouldDeepMerge())
             ->keys();
 
-        $mergeStrategies = $mergeProps
+        $matchPropsOn = $mergeProps
             ->map(function ($prop, $key) {
-                return collect($prop->mergeStrategies())
+                return collect($prop->matchesOn())
                     ->map(fn ($strategy) => $key.'.'.$strategy)
                     ->toArray();
             })
@@ -349,7 +349,7 @@ class Response implements Responsable
         return array_filter([
             'mergeProps' => $mergeProps->toArray(),
             'deepMergeProps' => $deepMergeProps->toArray(),
-            'mergeStrategies' => $mergeStrategies->toArray(),
+            'matchPropsOn' => $matchPropsOn->toArray(),
         ], fn ($prop) => count($prop) > 0);
     }
 

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -142,12 +142,10 @@ class ResponseFactory
 
     /**
      * @param  mixed  $value
-     *
-     * @parram null|string|string[]  $mergeStrategies
      */
-    public function deepMerge($value, $mergeStrategies = null): MergeProp
+    public function deepMerge($value): MergeProp
     {
-        return (new MergeProp($value, Arr::wrap($mergeStrategies)))->deepMerge();
+        return (new MergeProp($value))->deepMerge();
     }
 
     /**

--- a/tests/DeepMergePropTest.php
+++ b/tests/DeepMergePropTest.php
@@ -28,10 +28,17 @@ class DeepMergePropTest extends TestCase
         $this->assertInstanceOf(Request::class, $mergeProp());
     }
 
-    public function test_can_use_single_string_as_merge_strategy(): void
+    public function test_can_use_single_string_as_key_to_match_on(): void
     {
-        $mergeProp = (new MergeProp(['key' => 'value'], ['key']))->deepMerge();
+        $mergeProp = (new MergeProp(['key' => 'value']))->matchOn('key');
 
-        $this->assertEquals(['key'], $mergeProp->mergeStrategies());
+        $this->assertEquals(['key'], $mergeProp->matchesOn());
+    }
+
+    public function test_can_use_an_array_of_strings_as_keys_to_match_on(): void
+    {
+        $mergeProp = (new MergeProp(['key' => 'value']))->matchOn(['key', 'anotherKey']);
+
+        $this->assertEquals(['key', 'anotherKey'], $mergeProp->matchesOn());
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -210,8 +210,8 @@ class ResponseTest extends TestCase
             'User/Edit',
             [
                 'user' => $user,
-                'foo' => (new MergeProp('foo value', ['foo-key']))->deepMerge(),
-                'bar' => (new MergeProp('bar value', ['bar-key']))->deepMerge(),
+                'foo' => (new MergeProp('foo value'))->matchOn('foo-key')->deepMerge(),
+                'bar' => (new MergeProp('bar value'))->matchOn('bar-key')->deepMerge(),
             ],
             'app',
             '123'
@@ -231,13 +231,14 @@ class ResponseTest extends TestCase
             'foo',
             'bar',
         ], $page['deepMergeProps']);
+
         $this->assertSame([
             'foo.foo-key',
             'bar.bar-key',
-        ], $page['mergeStrategies']);
+        ], $page['matchPropsOn']);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:&quot;foo value&quot;,&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deepMergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;],&quot;mergeStrategies&quot;:[&quot;foo.foo-key&quot;,&quot;bar.bar-key&quot;]}"></div>', $view->render());
+        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:&quot;foo value&quot;,&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deepMergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;],&quot;matchPropsOn&quot;:[&quot;foo.foo-key&quot;,&quot;bar.bar-key&quot;]}"></div>', $view->render());
     }
 
     public function test_server_response_with_defer_and_merge_props(): void


### PR DESCRIPTION
This PR is a follow-up to PR #732 to improve the DX. It replaces the `mergeStrategies` argument and naming in favor of a `matchOn()` method:

```diff
- Inertia::deepMerge(User::paginate(), 'data.id']);
+ Inertia::deepMerge(User::paginate())->matchOn('data.id');
```

I'll soon open the JS counterpart in the Inertia repo for this.