### PR TITLE
[2.x] Introduce `ProvidesInertiaProps` interface

### DIFF
--- a/src/ProvidesInertiaProperties.php
+++ b/src/ProvidesInertiaProperties.php
@@ -4,5 +4,5 @@ namespace Inertia;
 
 interface ProvidesInertiaProperties
 {
-    public function toInertiaProps(RenderContext $context): iterable;
+    public function toInertiaProperties(RenderContext $context): iterable;
 }

--- a/src/ProvidesInertiaProperties.php
+++ b/src/ProvidesInertiaProperties.php
@@ -2,7 +2,7 @@
 
 namespace Inertia;
 
-interface ProvidesInertiaProps
+interface ProvidesInertiaProperties
 {
     public function toInertiaProps(RenderContext $context): iterable;
 }

--- a/src/ProvidesInertiaProps.php
+++ b/src/ProvidesInertiaProps.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Inertia;
+
+interface ProvidesInertiaProps
+{
+    public function toInertiaProps(RenderContext $context): iterable;
+}

--- a/src/RenderContext.php
+++ b/src/RenderContext.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Inertia;
+
+use Illuminate\Http\Request;
+
+class RenderContext
+{
+    public function __construct(
+        public string $component,
+        public Request $request
+    ) {
+        //
+    }
+}

--- a/src/Response.php
+++ b/src/Response.php
@@ -165,7 +165,7 @@ class Response implements Responsable
                 // Pipe into a Collection to leverage Collection::getArrayableItems()
                 $newProps = array_merge(
                     $newProps,
-                    collect($value->toInertiaProps($renderContext))->all()
+                    collect($value->toInertiaProperties($renderContext))->all()
                 );
             } else {
                 $newProps[$key] = $value;

--- a/src/Response.php
+++ b/src/Response.php
@@ -50,13 +50,15 @@ class Response implements Responsable
     }
 
     /**
-     * @param  string|array  $key
+     * @param  string|array|ProvidesInertiaProps  $key
      * @param  mixed  $value
      * @return $this
      */
     public function with($key, $value = null): self
     {
-        if (is_array($key)) {
+        if ($key instanceof ProvidesInertiaProps) {
+            $this->props[] = $key;
+        } elseif (is_array($key)) {
             $this->props = array_merge($this->props, $key);
         } else {
             $this->props[$key] = $value;
@@ -131,6 +133,7 @@ class Response implements Responsable
      */
     public function resolveProperties(Request $request, array $props): array
     {
+        $props = $this->resolveInertiaPropsProviders($props, $request);
         $props = $this->resolvePartialProperties($props, $request);
         $props = $this->resolveArrayableProperties($props, $request);
         $props = $this->resolveAlways($props);
@@ -140,12 +143,36 @@ class Response implements Responsable
     }
 
     /**
+     * Resolve the ProvidesInertiaProps props.
+     */
+    public function resolveInertiaPropsProviders(array $props, Request $request): array
+    {
+        $newProps = [];
+
+        $renderContext = new RenderContext($this->component, $request);
+
+        foreach ($props as $key => $value) {
+            if (is_numeric($key) && $value instanceof ProvidesInertiaProps) {
+                // Pipe into a Collection to leverage Collection::getArrayableItems()
+                $newProps = array_merge(
+                    $newProps,
+                    collect($value->toInertiaProps($renderContext))->all()
+                );
+            } else {
+                $newProps[$key] = $value;
+            }
+        }
+
+        return $newProps;
+    }
+
+    /**
      * Resolve the `only` and `except` partial request props.
      */
     public function resolvePartialProperties(array $props, Request $request): array
     {
         if (! $this->isPartial($request)) {
-            return array_filter($this->props, static function ($prop) {
+            return array_filter($props, static function ($prop) {
                 return ! ($prop instanceof IgnoreFirstLoad);
             });
         }

--- a/src/Response.php
+++ b/src/Response.php
@@ -50,13 +50,13 @@ class Response implements Responsable
     }
 
     /**
-     * @param  string|array|ProvidesInertiaProps  $key
+     * @param  string|array|ProvidesInertiaProperties  $key
      * @param  mixed  $value
      * @return $this
      */
     public function with($key, $value = null): self
     {
-        if ($key instanceof ProvidesInertiaProps) {
+        if ($key instanceof ProvidesInertiaProperties) {
             $this->props[] = $key;
         } elseif (is_array($key)) {
             $this->props = array_merge($this->props, $key);
@@ -143,7 +143,7 @@ class Response implements Responsable
     }
 
     /**
-     * Resolve the ProvidesInertiaProps props.
+     * Resolve the ProvidesInertiaProperties props.
      */
     public function resolveInertiaPropsProviders(array $props, Request $request): array
     {
@@ -152,7 +152,7 @@ class Response implements Responsable
         $renderContext = new RenderContext($this->component, $request);
 
         foreach ($props as $key => $value) {
-            if (is_numeric($key) && $value instanceof ProvidesInertiaProps) {
+            if (is_numeric($key) && $value instanceof ProvidesInertiaProperties) {
                 // Pipe into a Collection to leverage Collection::getArrayableItems()
                 $newProps = array_merge(
                     $newProps,

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -157,9 +157,7 @@ class ResponseFactory
     {
         if ($props instanceof Arrayable) {
             $props = $props->toArray();
-        }
-
-        if ($props instanceof ProvidesInertiaProps) {
+        } elseif ($props instanceof ProvidesInertiaProps) {
             // Will be resolved in Response::resolveResponsableProperties()
             $props = [$props];
         }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -151,12 +151,17 @@ class ResponseFactory
     }
 
     /**
-     * @param  array|Arrayable  $props
+     * @param  array|Arrayable|ProvidesInertiaProps  $props
      */
     public function render(string $component, $props = []): Response
     {
         if ($props instanceof Arrayable) {
             $props = $props->toArray();
+        }
+
+        if ($props instanceof ProvidesInertiaProps) {
+            // Will be resolved in Response::resolveResponsableProperties()
+            $props = [$props];
         }
 
         return new Response(

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -151,13 +151,13 @@ class ResponseFactory
     }
 
     /**
-     * @param  array|Arrayable|ProvidesInertiaProps  $props
+     * @param  array|Arrayable|ProvidesInertiaProperties  $props
      */
     public function render(string $component, $props = []): Response
     {
         if ($props instanceof Arrayable) {
             $props = $props->toArray();
-        } elseif ($props instanceof ProvidesInertiaProps) {
+        } elseif ($props instanceof ProvidesInertiaProperties) {
             // Will be resolved in Response::resolveResponsableProperties()
             $props = [$props];
         }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -385,7 +385,7 @@ class ResponseFactoryTest extends TestCase
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
             return Inertia::render('User/Edit', new class implements ProvidesInertiaProperties
             {
-                public function toInertiaProps(RenderContext $context): iterable
+                public function toInertiaProperties(RenderContext $context): iterable
                 {
                     return [
                         'foo' => 'bar',

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -358,8 +358,6 @@ class ResponseFactoryTest extends TestCase
     public function test_will_accept_instances_of_provides_inertia_props()
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
-            Inertia::share('foo', 'bar');
-
             return Inertia::render('User/Edit', new class implements ProvidesInertiaProps
             {
                 public function toInertiaProps(RenderContext $context): iterable

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -17,6 +17,8 @@ use Inertia\Inertia;
 use Inertia\LazyProp;
 use Inertia\MergeProp;
 use Inertia\OptionalProp;
+use Inertia\ProvidesInertiaProps;
+use Inertia\RenderContext;
 use Inertia\ResponseFactory;
 use Inertia\Tests\Stubs\ExampleMiddleware;
 
@@ -335,6 +337,32 @@ class ResponseFactoryTest extends TestCase
             return Inertia::render('User/Edit', new class implements Arrayable
             {
                 public function toArray()
+                {
+                    return [
+                        'foo' => 'bar',
+                    ];
+                }
+            });
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+        $response->assertSuccessful();
+        $response->assertJson([
+            'component' => 'User/Edit',
+            'props' => [
+                'foo' => 'bar',
+            ],
+        ]);
+    }
+
+    public function test_will_accept_instances_of_provides_inertia_props()
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::share('foo', 'bar');
+
+            return Inertia::render('User/Edit', new class implements ProvidesInertiaProps
+            {
+                public function toInertiaProps(RenderContext $context): iterable
                 {
                     return [
                         'foo' => 'bar',

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -17,7 +17,7 @@ use Inertia\Inertia;
 use Inertia\LazyProp;
 use Inertia\MergeProp;
 use Inertia\OptionalProp;
-use Inertia\ProvidesInertiaProps;
+use Inertia\ProvidesInertiaProperties;
 use Inertia\RenderContext;
 use Inertia\ResponseFactory;
 use Inertia\Tests\Stubs\ExampleMiddleware;
@@ -358,7 +358,7 @@ class ResponseFactoryTest extends TestCase
     public function test_will_accept_instances_of_provides_inertia_props()
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
-            return Inertia::render('User/Edit', new class implements ProvidesInertiaProps
+            return Inertia::render('User/Edit', new class implements ProvidesInertiaProperties
             {
                 public function toInertiaProps(RenderContext $context): iterable
                 {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -17,7 +17,7 @@ use Inertia\DeferProp;
 use Inertia\Inertia;
 use Inertia\LazyProp;
 use Inertia\MergeProp;
-use Inertia\ProvidesInertiaProps;
+use Inertia\ProvidesInertiaProperties;
 use Inertia\RenderContext;
 use Inertia\Response;
 use Inertia\Tests\Stubs\FakeResource;
@@ -767,7 +767,7 @@ class ResponseTest extends TestCase
 
         $response = new Response('User/Edit', [
             'foo' => 'bar',
-            new class implements ProvidesInertiaProps
+            new class implements ProvidesInertiaProperties
             {
                 public function toInertiaProps(RenderContext $context): iterable
                 {
@@ -872,7 +872,7 @@ class ResponseTest extends TestCase
 
         $response->with(['foo' => 'bar', 'baz' => 'qux'])
             ->with(['quux' => 'corge'])
-            ->with(new class implements ProvidesInertiaProps
+            ->with(new class implements ProvidesInertiaProperties
             {
                 public function toInertiaProps(RenderContext $context): iterable
                 {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -832,7 +832,7 @@ class ResponseTest extends TestCase
             'foo' => 'bar',
             new class implements ProvidesInertiaProperties
             {
-                public function toInertiaProps(RenderContext $context): iterable
+                public function toInertiaProperties(RenderContext $context): iterable
                 {
                     return collect([
                         'baz' => 'qux',
@@ -937,7 +937,7 @@ class ResponseTest extends TestCase
             ->with(['quux' => 'corge'])
             ->with(new class implements ProvidesInertiaProperties
             {
-                public function toInertiaProps(RenderContext $context): iterable
+                public function toInertiaProperties(RenderContext $context): iterable
                 {
                     return collect(['grault' => 'garply']);
                 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -17,6 +17,8 @@ use Inertia\DeferProp;
 use Inertia\Inertia;
 use Inertia\LazyProp;
 use Inertia\MergeProp;
+use Inertia\ProvidesInertiaProps;
+use Inertia\RenderContext;
 use Inertia\Response;
 use Inertia\Tests\Stubs\FakeResource;
 use Inertia\Tests\Stubs\MergeWithSharedProp;
@@ -759,6 +761,33 @@ class ResponseTest extends TestCase
         $this->assertFalse(isset($page->props->user));
     }
 
+    public function test_inertia_responsable_objects(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+
+        $response = new Response('User/Edit', [
+            'foo' => 'bar',
+            new class implements ProvidesInertiaProps
+            {
+                public function toInertiaProps(RenderContext $context): iterable
+                {
+                    return collect([
+                        'baz' => 'qux',
+                    ]);
+                }
+            },
+            'quux' => 'corge',
+
+        ], 'app', '123');
+        $response = $response->toResponse($request);
+        $view = $response->getOriginalContent();
+        $page = $view->getData()['page'];
+
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertSame('qux', $page['props']['baz']);
+        $this->assertSame('corge', $page['props']['quux']);
+    }
+
     public function test_inertia_response_type_prop(): void
     {
         $request = Request::create('/user/123', 'GET');
@@ -834,6 +863,30 @@ class ResponseTest extends TestCase
         $this->assertSame('Jonathan Reinink', $auth['user']['name']);
         $this->assertTrue($auth['user.can']['do.stuff']);
         $this->assertFalse(array_key_exists('can', $auth));
+    }
+
+    public function test_props_can_be_added_using_the_with_method(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $response = new Response('User/Edit', [], 'app', '123');
+
+        $response->with(['foo' => 'bar', 'baz' => 'qux'])
+            ->with(['quux' => 'corge'])
+            ->with(new class implements ProvidesInertiaProps
+            {
+                public function toInertiaProps(RenderContext $context): iterable
+                {
+                    return collect(['grault' => 'garply']);
+                }
+            });
+
+        $response = $response->toResponse($request);
+        $view = $response->getOriginalContent();
+        $page = $view->getData()['page'];
+
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertSame('qux', $page['props']['baz']);
+        $this->assertSame('corge', $page['props']['quux']);
     }
 
     public function test_responsable_with_invalid_key(): void


### PR DESCRIPTION
This PR is an addition to #746 and inspired by [this comment](https://github.com/inertiajs/inertia-laravel/pull/746#issuecomment-2980262905). Given the one-letter difference in interface names, we might have to do some renaming to prevent confusion.

While `Inertia::render()` already support `Arrayable` as props, there's still room left to improve how we organize and reuse props, especially for complex pages. This new `ProvidesInertiaProps` interface has one method that allows you to return *multiple* props from a class, and then use multiple of these classes to gather your props for a page. 

Here's an example of a class implementing this interface:

```php
class LocalizationProps implements ProvidesInertiaProps
{
    public function toInertiaProps(RenderContext $context): iterable
    {
        return [
            'currentLocale' => app()->getLocale(),
            'fallbackLocale' => config('app.fallback_locale', 'en'),
            'availableLocales' => array_keys(config('app.locales', [])),
        ];
    }
}
```

You can use this directly in the `render()` and `with()` methods:

```php
public function index(LocalizationProps $localizationProps)
{
    return Inertia::render('UserProfile', $localizationProps);

    // or...

    return Inertia::render('UserProfile')->with($localizationProps);
}
```

Even cooler, you can combine these prop classes with your other props in an array (without using the spread operator):

```php
Inertia::render('UserProfile', [
    'user' => auth()->user(),
    $localizationProps,
]);
```

For complex pages with many reusable props, this can be a nice cleanup:

```php
public function index(LocalizationProps $localizationProps, PermissionsProps $permissionProps)
{
    return Inertia::render('UserProfile', [
        'user' => auth()->user(),
        $localizationProps,
        $permissionProps,
    ]);

    // or...

    return Inertia::render('UserProfile')
        ->with('user', auth()->user())
        ->with($localizationProps)
        ->with($permissionProps);
}
```

The `RenderContext` object contains the `Request` instance and the component name.