### PR TITLE
[2.x] Support for checking if the component exists when rendering

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -31,6 +31,36 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Pages
+    |--------------------------------------------------------------------------
+    |
+    | If you want to ensure that the pages exist, you can set `ensure_pages_exist` to true.
+    | This will throw an exception if the component does not exist on the filesystem
+    | when rendering a page. You may configure this separately for testing.
+    |
+    */
+
+    'ensure_pages_exist' => false,
+
+    'page_paths' => [
+
+        resource_path('js/Pages'),
+
+    ],
+
+    'page_extensions' => [
+
+        'js',
+        'jsx',
+        'svelte',
+        'ts',
+        'tsx',
+        'vue',
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Testing
     |--------------------------------------------------------------------------
     |
@@ -39,28 +69,15 @@ return [
     | attempts to locate the component as a file relative to any of the
     | paths AND with any of the extensions specified here.
     |
+    | By default, it uses the `page_paths` and `page_extensions` settings
+    | defined above. You may override these values for testing purposes
+    | by adding these two keys to this `testing` array.
+    |
     */
 
     'testing' => [
 
         'ensure_pages_exist' => true,
-
-        'page_paths' => [
-
-            resource_path('js/Pages'),
-
-        ],
-
-        'page_extensions' => [
-
-            'js',
-            'jsx',
-            'svelte',
-            'ts',
-            'tsx',
-            'vue',
-
-        ],
 
     ],
 

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -25,6 +25,8 @@ return [
 
         'url' => env('INERTIA_SSR_URL', 'http://127.0.0.1:13714'),
 
+        'dispatch_without_bundle' => (bool) env('INERTIA_SSR_DISPATCH_WITHOUT_BUNDLE', false),
+
         // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
 
     ],

--- a/src/ComponentNotFoundException.php
+++ b/src/ComponentNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Inertia;
+
+use InvalidArgumentException;
+
+class ComponentNotFoundException extends InvalidArgumentException {}

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response as BaseResponse;
 use Illuminate\Support\Traits\Macroable;
 use Inertia\Support\Header;
+use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirect;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
@@ -159,10 +160,26 @@ class ResponseFactory
     }
 
     /**
+     * @throws ComponentNotFoundException
+     */
+    protected function findComponentOrFail(string $component): void
+    {
+        try {
+            app('inertia.view-finder')->find($component);
+        } catch (InvalidArgumentException) {
+            throw new ComponentNotFoundException("Inertia page component [{$component}] not found.");
+        }
+    }
+
+    /**
      * @param  array|Arrayable  $props
      */
     public function render(string $component, $props = []): Response
     {
+        if (config('inertia.ensure_pages_exist', false)) {
+            $this->findComponentOrFail($component);
+        }
+
         if ($props instanceof Arrayable) {
             $props = $props->toArray();
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -32,11 +32,19 @@ class ServiceProvider extends BaseServiceProvider
         $this->registerTestingMacros();
         $this->registerMiddleware();
 
+        $this->app->bind('inertia.view-finder', function ($app) {
+            return new FileViewFinder(
+                $app['files'],
+                $app['config']->get('inertia.page_paths'),
+                $app['config']->get('inertia.page_extensions')
+            );
+        });
+
         $this->app->bind('inertia.testing.view-finder', function ($app) {
             return new FileViewFinder(
                 $app['files'],
-                $app['config']->get('inertia.testing.page_paths'),
-                $app['config']->get('inertia.testing.page_extensions')
+                $app['config']->get('inertia.testing.page_paths', fn () => $app['config']->get('inertia.page_paths')),
+                $app['config']->get('inertia.testing.page_extensions', fn () => $app['config']->get('inertia.page_extensions'))
             );
         });
     }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -12,6 +12,7 @@ use Illuminate\Session\Store;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Route;
 use Inertia\AlwaysProp;
+use Inertia\ComponentNotFoundException;
 use Inertia\DeferProp;
 use Inertia\Inertia;
 use Inertia\LazyProp;
@@ -375,5 +376,23 @@ class ResponseFactoryTest extends TestCase
                 'foo' => 'bar',
             ],
         ]);
+    }
+
+    public function test_will_throw_exception_if_component_does_not_exist_when_ensuring_is_enabled(): void
+    {
+        config()->set('inertia.ensure_pages_exist', true);
+
+        $this->expectException(ComponentNotFoundException::class);
+        $this->expectExceptionMessage('Inertia page component [foo] not found.');
+
+        (new ResponseFactory)->render('foo');
+    }
+
+    public function test_will_not_throw_exception_if_component_does_not_exist_when_ensuring_is_disabled(): void
+    {
+        config()->set('inertia.ensure_pages_exist', false);
+
+        $response = (new ResponseFactory)->render('foo');
+        $this->assertInstanceOf(\Inertia\Response::class, $response);
     }
 }


### PR DESCRIPTION
This PR brings support for checking whether a component exists when sending it to the frontend using `Inertia::render()`. This idea was brought up in #272. It uses the same logic as that in the `AssertableInertia` class, but you can configure it separately from each other.

I think I would not enable this in production (though it's always enabled with Blade), but definitely in development. There's no clear indication on the frontend when you pass the wrong component, and I've been bitten by this a few times, so this would be a nice timesaver.