### PR TITLE
[2.x] Added `inertia:check-ssr` Artisan command and `isHealthy()` method on `HttpGateway`

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -25,7 +25,7 @@ return [
 
         'url' => env('INERTIA_SSR_URL', 'http://127.0.0.1:13714'),
 
-        'dispatch_without_bundle' => false,
+        'dispatch_without_bundle' => (bool) env('INERTIA_SSR_DISPATCH_WITHOUT_BUNDLE', false),
 
         // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
 

--- a/src/Commands/CheckSsr.php
+++ b/src/Commands/CheckSsr.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Inertia\Commands;
+
+use Illuminate\Console\Command;
+use Inertia\Ssr\Gateway;
+use Inertia\Ssr\HasHealthCheck;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'inertia:check-ssr')]
+class CheckSsr extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'inertia:check-ssr';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Check the Inertia SSR server health status';
+
+    /**
+     * check the SSR server via a Node process.
+     */
+    public function handle(Gateway $gateway): int
+    {
+        if (! $gateway instanceof HasHealthCheck) {
+            $this->error('The SSR gateway does not support health checks.');
+
+            return self::FAILURE;
+        }
+
+        ($check = $gateway->isHealthy())
+            ? $this->info('Inertia SSR server is running.')
+            : $this->error('Inertia SSR server is not running.');
+
+        return $check ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -68,6 +68,7 @@ class ServiceProvider extends BaseServiceProvider
             Commands\CreateMiddleware::class,
             Commands\StartSsr::class,
             Commands\StopSsr::class,
+            Commands\CheckSsr::class,
         ]);
     }
 

--- a/src/Ssr/HasHealthCheck.php
+++ b/src/Ssr/HasHealthCheck.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Inertia\Ssr;
+
+interface HasHealthCheck
+{
+    /**
+     * Determine if the SSR server is healthy.
+     */
+    public function isHealthy(): bool;
+}

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -5,8 +5,9 @@ namespace Inertia\Ssr;
 use Exception;
 use Illuminate\Http\Client\StrayRequestException;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 
-class HttpGateway implements Gateway
+class HttpGateway implements Gateway, HasHealthCheck
 {
     /**
      * Dispatch the Inertia page to the Server Side Rendering engine.
@@ -21,7 +22,7 @@ class HttpGateway implements Gateway
             return null;
         }
 
-        if (! $url = $this->getHttpUrl()) {
+        if (! $url = $this->getUrl('/render')) {
             return null;
         }
 
@@ -46,6 +47,14 @@ class HttpGateway implements Gateway
     }
 
     /**
+     * Determine if the SSR server is healthy.
+     */
+    public function isHealthy(): bool
+    {
+        return Http::get($this->getUrl('/health'))->successful();
+    }
+
+    /**
      * Determine if dispatch should proceed even if no bundle is detected.
      */
     protected function shouldDispatchWithoutBundle(): bool
@@ -62,10 +71,12 @@ class HttpGateway implements Gateway
     }
 
     /**
-     * Get the SSR URL from the configuration, ensuring it ends with '/render'.
+     * Get the SSR URL from the configuration, ensuring it ends with '/{$path}'.
      */
-    public function getHttpUrl(): ?string
+    public function getUrl(string $path): ?string
     {
-        return str_replace('/render', '', rtrim(config('inertia.ssr.url', 'http://127.0.0.1:13714'), '/')).'/render';
+        $path = Str::start($path, '/');
+
+        return str_replace($path, '', rtrim(config('inertia.ssr.url', 'http://127.0.0.1:13714'), '/')).$path;
     }
 }

--- a/tests/Commands/CheckSsrTest.php
+++ b/tests/Commands/CheckSsrTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Inertia\Ssr\Gateway;
+use Inertia\Ssr\HttpGateway;
+
+class CheckSsrTest extends TestCase
+{
+    public function test_success_on_healthy_ssr_server()
+    {
+        $this->mock(HttpGateway::class, fn ($mock) => $mock
+            ->shouldReceive('isHealthy')
+            ->andReturnTrue()
+            ->getMock()
+        );
+
+        $this->artisan('inertia:check-ssr')
+            ->expectsOutput('Inertia SSR server is running.')
+            ->assertExitCode(0);
+    }
+
+    public function test_failure_on_unhealthy_ssr_server()
+    {
+        $this->mock(HttpGateway::class, fn ($mock) => $mock
+            ->shouldReceive('isHealthy')
+            ->andReturnFalse()
+            ->getMock()
+        );
+
+        $this->artisan('inertia:check-ssr')
+            ->expectsOutput('Inertia SSR server is not running.')
+            ->assertExitCode(1);
+    }
+
+    public function test_failure_on_unsupported_gateway()
+    {
+        $this->mock(Gateway::class);
+
+        $this->artisan('inertia:check-ssr')
+            ->expectsOutput('The SSR gateway does not support health checks.')
+            ->assertExitCode(1);
+    }
+}

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -9,11 +9,14 @@ class HttpGatewayTest extends TestCase
 {
     protected HttpGateway $gateway;
 
+    protected string $renderUrl;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->gateway = new HttpGateway;
+        $this->renderUrl = $this->gateway->getUrl('render');
 
         Http::preventStrayRequests();
     }
@@ -46,7 +49,7 @@ class HttpGatewayTest extends TestCase
         ]);
 
         Http::fake([
-            $this->gateway->getHttpUrl() => Http::response(json_encode([
+            $this->renderUrl => Http::response(json_encode([
                 'head' => ['<title>SSR Test</title>', '<style></style>'],
                 'body' => '<div id="app">SSR Response</div>',
             ])),
@@ -69,7 +72,7 @@ class HttpGatewayTest extends TestCase
         ]);
 
         Http::fake([
-            $this->gateway->getHttpUrl() => Http::response(json_encode([
+            $this->renderUrl => Http::response(json_encode([
                 'head' => ['<title>SSR Test</title>', '<style></style>'],
                 'body' => '<div id="app">SSR Response</div>',
             ])),
@@ -91,7 +94,7 @@ class HttpGatewayTest extends TestCase
         ]);
 
         Http::fake([
-            $this->gateway->getHttpUrl() => Http::response(null, 500),
+            $this->renderUrl => Http::response(null, 500),
         ]);
 
         $this->assertNull($this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]));
@@ -105,9 +108,21 @@ class HttpGatewayTest extends TestCase
         ]);
 
         Http::fake([
-            $this->gateway->getHttpUrl() => Http::response('invalid json'),
+            $this->renderUrl => Http::response('invalid json'),
         ]);
 
         $this->assertNull($this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]));
+    }
+
+    public function test_health_check_the_ssr_server()
+    {
+        Http::fake([
+            $this->gateway->getUrl('health') => Http::sequence()
+                ->push(status: 200)
+                ->push(status: 500),
+        ]);
+
+        $this->assertTrue($this->gateway->isHealthy());
+        $this->assertFalse($this->gateway->isHealthy());
     }
 }


### PR DESCRIPTION
This PR addresses issues #703 and builds upon PR #751 and #673.

The Inertia SSR server has a [`/health`](https://github.com/inertiajs/inertia/blob/c76f35bd4ad9cd3c980cb6812dda51ef9bda5279/packages/core/src/server.ts#L42) endpoint built-in. I've added a `isHealthy()` method to the `HttpGateway` that performs a request against that endpoint. Then there's also an `inertia:check-ssr` Artisan command that's useful for deployments.