### PR TITLE
[2.x] Refactored `ssr.dispatch_without_bundle` to `ssr.ensure_bundle_exists`

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -25,7 +25,7 @@ return [
 
         'url' => env('INERTIA_SSR_URL', 'http://127.0.0.1:13714'),
 
-        'dispatch_without_bundle' => (bool) env('INERTIA_SSR_DISPATCH_WITHOUT_BUNDLE', false),
+        'ensure_bundle_exists' => (bool) env('INERTIA_SSR_ENSURE_BUNDLE_EXISTS', true),
 
         // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
 

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -67,7 +67,7 @@ class HttpGateway implements Gateway, HasHealthCheck
      */
     protected function shouldDispatchWithoutBundle(): bool
     {
-        return config('inertia.ssr.dispatch_without_bundle', false);
+        return ! config('inertia.ssr.ensure_bundle_exists', true);
     }
 
     /**

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -63,11 +63,11 @@ class HttpGatewayTest extends TestCase
         $this->assertEquals('<div id="app">SSR Response</div>', $response->body);
     }
 
-    public function test_it_uses_the_configured_http_url__when_bundle_file_detection_is_disabled()
+    public function test_it_uses_the_configured_http_url_when_bundle_file_detection_is_disabled()
     {
         config([
             'inertia.ssr.enabled' => true,
-            'inertia.ssr.dispatch_without_bundle' => true,
+            'inertia.ssr.ensure_bundle_exists' => false,
             'inertia.ssr.bundle' => null,
         ]);
 


### PR DESCRIPTION
Feel a bit off to set `dispatch_without_bundle` to `true` to disable something.