### PR TITLE
[2.x] Restore `testing.page_paths` and `testing.page_extensions` configs

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -43,7 +43,6 @@ return [
     | The `page_paths` and `page_extensions` options define where to look
     | for page components and which file extensions to consider.
     |
-    |
     */
 
     'ensure_pages_exist' => false,

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -36,9 +36,13 @@ return [
     | Pages
     |--------------------------------------------------------------------------
     |
-    | If you want to ensure that the pages exist, you can set `ensure_pages_exist` to true.
-    | This will throw an exception if the component does not exist on the filesystem
-    | when rendering a page. You may configure this separately for testing.
+    | Set `ensure_pages_exist` to true if you want to enforce that Inertia page
+    | components exist on disk when rendering a page. This is useful for
+    | catching missing or misnamed components.
+    |
+    | The `page_paths` and `page_extensions` options define where to look
+    | for page components and which file extensions to consider.
+    |
     |
     */
 
@@ -71,15 +75,32 @@ return [
     | attempts to locate the component as a file relative to any of the
     | paths AND with any of the extensions specified here.
     |
-    | By default, it uses the `page_paths` and `page_extensions` settings
-    | defined above. You may override these values for testing purposes
-    | by adding these two keys to this `testing` array.
+    | Note: In a future release, the `page_paths` and `page_extensions`
+    | options below will be removed. The root-level options above
+    | will be used for both application and testing purposes.
     |
     */
 
     'testing' => [
 
         'ensure_pages_exist' => true,
+
+        'page_paths' => [
+
+            resource_path('js/Pages'),
+
+        ],
+
+        'page_extensions' => [
+
+            'js',
+            'jsx',
+            'svelte',
+            'ts',
+            'tsx',
+            'vue',
+
+        ],
 
     ],
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -43,8 +43,8 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->bind('inertia.testing.view-finder', function ($app) {
             return new FileViewFinder(
                 $app['files'],
-                $app['config']->get('inertia.testing.page_paths', fn () => $app['config']->get('inertia.page_paths')),
-                $app['config']->get('inertia.testing.page_extensions', fn () => $app['config']->get('inertia.page_extensions'))
+                $app['config']->get('inertia.testing.page_paths'),
+                $app['config']->get('inertia.testing.page_extensions')
             );
         });
     }


### PR DESCRIPTION
Follow-up PR to #749 to prevent breaking changes due to missing config keys.