### PR TITLE
update return type in Middleware share method

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -48,7 +48,7 @@ class Middleware
      *
      * @see https://inertiajs.com/shared-data
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function share(Request $request)
     {


### PR DESCRIPTION
Update the docBlock of the share method in `Middleware` to specify the return type as `array<string, mixed>`, aligning it with the type used in the `middleware.stub` class.