### PR TITLE
[2.x] Improve inertia helper docblock

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -6,7 +6,7 @@ if (! function_exists('inertia')) {
      *
      * @param  null|string  $component
      * @param  array|\Illuminate\Contracts\Support\Arrayable  $props
-     * @return \Inertia\ResponseFactory|\Inertia\Response
+     * @return ($component is null ? \Inertia\ResponseFactory : \Inertia\Response) 
      */
     function inertia($component = null, $props = [])
     {


### PR DESCRIPTION
Improved the docblock for the inertia function, which will now be better processed by tools such as PHPStan. A similar structure is used, for example, in the "response" function in Laravel’s core framework.