### PR TITLE
[2.x] Add initial props resolver for Initial Page Load

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void version(\Closure|string|null $version)
  * @method static string getVersion()
  * @method static void resolveUrlUsing(\Closure|null $urlResolver = null)
+ * @method static void resolveInitialProps(\Closure|null $initialPropsResolver = null)
  * @method static \Inertia\OptionalProp optional(callable $callback)
  * @method static \Inertia\LazyProp lazy(callable $callback)
  * @method static \Inertia\DeferProp defer(callable $callback, string $group = 'default')

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -76,6 +76,16 @@ class Middleware
     }
 
     /**
+     * Defines the initial props that are shared by default.
+     *
+     * @return \Closure|null
+     */
+    public function initialPropsResolver()
+    {
+        return null;
+    }
+
+    /**
      * Handle the incoming request.
      *
      * @return \Symfony\Component\HttpFoundation\Response
@@ -91,6 +101,10 @@ class Middleware
 
         if ($urlResolver = $this->urlResolver()) {
             Inertia::resolveUrlUsing($urlResolver);
+        }
+
+        if ($initialPropsResolver = $this->initialPropsResolver()) {
+            Inertia::resolveInitialPropsUsing($initialPropsResolver);
         }
 
         $response = $next($request);

--- a/src/Response.php
+++ b/src/Response.php
@@ -82,6 +82,11 @@ class Response implements Responsable
     protected ?Closure $urlResolver = null;
 
     /**
+     * The initial props resolver callback.
+     */
+    protected ?Closure $initialPropsResolver = null;
+
+    /**
      * Create a new Inertia response instance.
      *
      * @param  array<array-key, mixed|\Inertia\ProvidesInertiaProperties>  $props
@@ -92,7 +97,8 @@ class Response implements Responsable
         string $rootView = 'app',
         string $version = '',
         bool $encryptHistory = false,
-        ?Closure $urlResolver = null
+        ?Closure $urlResolver = null,
+        ?Closure $initialPropsResolver = null,
     ) {
         $this->component = $component;
         $this->props = $props;
@@ -101,6 +107,7 @@ class Response implements Responsable
         $this->clearHistory = session()->pull('inertia.clear_history', false);
         $this->encryptHistory = $encryptHistory;
         $this->urlResolver = $urlResolver;
+        $this->initialPropsResolver = $initialPropsResolver;
     }
 
     /**
@@ -188,6 +195,7 @@ class Response implements Responsable
             $this->resolveMergeProps($request),
             $this->resolveDeferredProps($request),
             $this->resolveCacheDirections($request),
+            $this->resolveInitialProps($request),
         );
 
         if ($request->header(Header::INERTIA)) {
@@ -506,6 +514,26 @@ class Response implements Responsable
             ->pluck('key');
 
         return $deferredProps->isNotEmpty() ? ['deferredProps' => $deferredProps->toArray()] : [];
+    }
+
+    /**
+     * Resolve initial props.
+     *
+     * @return array<string, mixed>
+     */
+    public function resolveInitialProps(Request $request): array
+    {
+        if ($request->header(Header::INERTIA)) {
+            return [];
+        }
+
+        if ($this->initialPropsResolver === null) {
+            return [];
+        }
+
+        $initialProps = App::call($this->initialPropsResolver, ['request' => $request]);
+
+        return empty($initialProps) ? [] : ['initialProps' => $initialProps];
     }
 
     /**

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -62,6 +62,13 @@ class ResponseFactory
     protected $urlResolver;
 
     /**
+     * The initial props resolver callback.
+     *
+     * @var Closure|null
+     */
+    protected $initialPropsResolver;
+
+    /**
      * Set the root view template for Inertia responses. This template
      * serves as the HTML wrapper that contains the Inertia root element
      * where the frontend application will be mounted.
@@ -147,6 +154,14 @@ class ResponseFactory
     public function resolveUrlUsing(?Closure $urlResolver = null): void
     {
         $this->urlResolver = $urlResolver;
+    }
+
+    /**
+     * Set the initial props resolver.
+     */
+    public function resolveInitialPropsUsing(?Closure $initialPropsResolver = null): void
+    {
+        $this->initialPropsResolver = $initialPropsResolver;
     }
 
     /**
@@ -262,6 +277,7 @@ class ResponseFactory
             $this->getVersion(),
             $this->encryptHistory ?? config('inertia.history.encrypt', false),
             $this->urlResolver,
+            $this->initialPropsResolver,
         );
     }
 

--- a/tests/InitialPropTest.php
+++ b/tests/InitialPropTest.php
@@ -10,7 +10,7 @@ use Inertia\Tests\Stubs\ExampleMiddleware;
 
 class InitialPropTest extends TestCase
 {
-    public function test_initial_props_accessibility()
+    public function test_initial_props_accessibility(): void
     {
         $this->prepareMockEndpoint();
 
@@ -23,7 +23,7 @@ class InitialPropTest extends TestCase
         );
     }
 
-    public function test_initial_props_are_not_accessible()
+    public function test_initial_props_are_not_accessible(): void
     {
         $this->prepareMockEndpoint();
 

--- a/tests/InitialPropTest.php
+++ b/tests/InitialPropTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+use Inertia\Tests\Stubs\CustomInitialPropsResolverMiddleware;
+use Inertia\Tests\Stubs\ExampleMiddleware;
+
+class InitialPropTest extends TestCase
+{
+    public function test_initial_props_accessibility()
+    {
+        $this->prepareMockEndpoint();
+
+        $response = $this->withoutExceptionHandling()->get('/');
+
+        $response->assertSuccessful();
+        $this->assertSame(
+            '<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;errors&quot;:{}},&quot;url&quot;:&quot;\/&quot;,&quot;version&quot;:&quot;&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;initialProps&quot;:{&quot;initial&quot;:true,&quot;appName&quot;:&quot;test&quot;}}"></div>',
+            $response->content(),
+        );
+    }
+
+    public function test_initial_props_are_not_accessible()
+    {
+        $this->prepareMockEndpoint();
+
+        $response = $this->withoutExceptionHandling()->get('/', [
+            'X-Inertia' => 'true',
+        ]);
+
+        $response->assertSuccessful();
+        $response->assertJsonMissingPath('initialProps');
+    }
+
+    private function prepareMockEndpoint(): \Illuminate\Routing\Route
+    {
+        return Route::middleware([StartSession::class, ExampleMiddleware::class, CustomInitialPropsResolverMiddleware::class])->get('/', function () {
+            return Inertia::render('User/Edit');
+        });
+    }
+}

--- a/tests/Stubs/CustomInitialPropsResolverMiddleware.php
+++ b/tests/Stubs/CustomInitialPropsResolverMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Inertia\Tests\Stubs;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\ResponseFactory;
+use Inertia\Middleware;
+use PHPUnit\Framework\Assert;
+
+class CustomInitialPropsResolverMiddleware extends Middleware
+{
+    public function initialPropsResolver()
+    {
+        return function ($request, ResponseFactory $otherDependency) {
+            Assert::assertInstanceOf(Request::class, $request);
+            Assert::assertInstanceOf(ResponseFactory::class, $otherDependency);
+
+            return [
+                'initial' => true,
+                'appName' => 'test',
+            ];
+        };
+    }
+}

--- a/tests/Stubs/CustomInitialPropsResolverMiddleware.php
+++ b/tests/Stubs/CustomInitialPropsResolverMiddleware.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Assert;
 
 class CustomInitialPropsResolverMiddleware extends Middleware
 {
-    public function initialPropsResolver()
+    public function initialPropsResolver(): callable
     {
         return function ($request, ResponseFactory $otherDependency) {
             Assert::assertInstanceOf(Request::class, $request);


### PR DESCRIPTION
This PR adds support for an `initial` prop option in Inertia.js shared props. It allows developers to define props that should be sent **only with the initial page load** and excluded from subsequent Inertia responses.

This enhancement is particularly useful for values like configuration settings, application metadata, or other static data that doesn't need to be included with every request — reducing payload size and improving response efficiency.

**Example:**

```php
public function initialPropsResolver(): callable
{
    return function (Request $request) {
        return [
            'locale' => 'en',
            'appName' => 'Test App',
            'translations' => [
                'en' => 'English',
                'es' => 'Spanish',
            ],
        ];
    };
}
```

In this example, the defined props (`locale`, `appName`, `translations`) will be shared only on the first Inertia response.

**Why this matters:**

As discussed in [Inertia.js Discussion #993](https://github.com/inertiajs/inertia/discussions/993), there's a recurring need to send certain props — such as app settings, tokens, or translation strings — only with the initial page load, during the app's initial load. This feature provides a clean, built-in solution for that use case.

> [!NOTE]
> If this PR proves useful and is approved for integration, I'd be happy to work on adding the corresponding support in the Inertia.js client-side adapter as well.

See: https://github.com/inertiajs/inertia-laravel/pull/760/