### PR TITLE
[2.x] Ensure `reloadOnly` and `reloadExcept` handle string and array inputs uniformly

### DIFF
--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -164,13 +164,13 @@ class AssertableInertia extends AssertableJson
      */
     public function reloadOnly(array|string $only, ?Closure $callback = null): self
     {
-        return $this->reload(only: $only, callback: function (AssertableInertia $assertable) use ($only, $callback) {
-            $assertable->hasAll(explode(',', $only));
+        return $this->reload(callback: function (AssertableInertia $assertable) use ($only, $callback) {
+            $assertable->hasAll(is_array($only) ? $only : explode(',', $only));
 
             if ($callback) {
                 $callback($assertable);
             }
-        });
+        }, only: $only);
     }
 
     /**
@@ -180,13 +180,13 @@ class AssertableInertia extends AssertableJson
      */
     public function reloadExcept(array|string $except, ?Closure $callback = null): self
     {
-        return $this->reload(except: $except, callback: function (AssertableInertia $assertable) use ($except, $callback) {
-            $assertable->missingAll(explode(',', $except));
+        return $this->reload(callback: function (AssertableInertia $assertable) use ($except, $callback) {
+            $assertable->missingAll(is_array($except) ? $except : explode(',', $except));
 
             if ($callback) {
                 $callback($assertable);
             }
-        });
+        }, except: $except);
     }
 
     /**


### PR DESCRIPTION
This PR makes the input handling for reloadOnly and reloadExcept consistent, whether values are provided as arrays or comma-delimited strings. It prevents mismatches between how inputs are sent to the reload request and how assertions (hasAll/missingAll) interpret those inputs.


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
