### PR TITLE
Added `loadDeferredProps()` method to `AssertableInertia` class

### DIFF
--- a/src/ProvidesInertiaProperties.php
+++ b/src/ProvidesInertiaProperties.php
@@ -9,7 +9,7 @@ interface ProvidesInertiaProperties
      * to dynamically provide properties that will be serialized and sent
      * to the frontend.
      *
-     * @return array<string, mixed>
+     * @return iterable<string, mixed>
      */
     public function toInertiaProperties(RenderContext $context): iterable;
 }

--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -51,7 +51,7 @@ class AssertableInertia extends AssertableJson
     /**
      * The deferred props (if any).
      *
-     * @var array
+     * @var array<string, array<int, string>>
      */
     private $deferredProps;
 
@@ -130,6 +130,8 @@ class AssertableInertia extends AssertableJson
 
     /**
      * Load the deferred props for the given groups and perform assertions on the response.
+     *
+     * @param  Closure|array<int, string>|string  $groupsOrCallback
      */
     public function loadDeferredProps(Closure|array|string $groupsOrCallback, ?Closure $callback = null): self
     {

--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -4,6 +4,7 @@ namespace Inertia\Testing;
 
 use Closure;
 use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Illuminate\Testing\TestResponse;
 use InvalidArgumentException;
@@ -48,6 +49,13 @@ class AssertableInertia extends AssertableJson
     private $clearHistory;
 
     /**
+     * The deferred props (if any).
+     *
+     * @var array
+     */
+    private $deferredProps;
+
+    /**
      * Create an AssertableInertia instance from a test response.
      *
      * @param  TestResponse<Response>  $response
@@ -75,6 +83,7 @@ class AssertableInertia extends AssertableJson
         $instance->version = $page['version'];
         $instance->encryptHistory = $page['encryptHistory'];
         $instance->clearHistory = $page['clearHistory'];
+        $instance->deferredProps = $page['deferredProps'] ?? [];
 
         return $instance;
     }
@@ -117,6 +126,22 @@ class AssertableInertia extends AssertableJson
         PHPUnit::assertSame($value, $this->version, 'Unexpected Inertia asset version.');
 
         return $this;
+    }
+
+    /**
+     * Load the deferred props for the given groups and perform assertions on the response.
+     */
+    public function loadDeferredProps(Closure|array|string $groupsOrCallback, ?Closure $callback = null): self
+    {
+        $callback = is_callable($groupsOrCallback) ? $groupsOrCallback : $callback;
+
+        $groups = is_callable($groupsOrCallback) ? array_keys($this->deferredProps) : Arr::wrap($groupsOrCallback);
+
+        $props = collect($groups)->flatMap(function ($group) {
+            return $this->deferredProps[$group] ?? [];
+        })->implode(',');
+
+        return $this->reloadOnly($props, $callback);
     }
 
     /**

--- a/tests/Stubs/ExampleInertiaPropsProvider.php
+++ b/tests/Stubs/ExampleInertiaPropsProvider.php
@@ -15,7 +15,7 @@ class ExampleInertiaPropsProvider implements ProvidesInertiaProperties
     ) {}
 
     /**
-     * @return array<string, mixed>
+     * @return iterable<string, mixed>
      */
     public function toInertiaProperties(RenderContext $context): iterable
     {

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -276,4 +276,55 @@ class AssertableInertiaTest extends TestCase
 
         $this->assertTrue($called);
     }
+
+    public function test_assert_against_deferred_props(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', [
+                'foo' => 'bar',
+                'deferred1' => Inertia::defer(fn () => 'baz'),
+                'deferred2' => Inertia::defer(fn () => 'qux', 'custom'),
+                'deferred3' => Inertia::defer(fn () => 'quux', 'custom'),
+            ])
+        );
+
+        $called = 0;
+
+        $response->assertInertia(function (AssertableInertia $inertia) use (&$called) {
+            $inertia->where('foo', 'bar');
+            $inertia->missing('deferred1');
+            $inertia->missing('deferred2');
+            $inertia->missing('deferred3');
+
+            $inertia->loadDeferredProps(function (AssertableInertia $inertia) use (&$called) {
+                $inertia->where('deferred1', 'baz');
+                $inertia->where('deferred2', 'qux');
+                $inertia->where('deferred3', 'quux');
+                $called++;
+            });
+
+            $inertia->loadDeferredProps('default', function (AssertableInertia $inertia) use (&$called) {
+                $inertia->where('deferred1', 'baz');
+                $inertia->missing('deferred2');
+                $inertia->missing('deferred3');
+                $called++;
+            });
+
+            $inertia->loadDeferredProps('custom', function (AssertableInertia $inertia) use (&$called) {
+                $inertia->missing('deferred1');
+                $inertia->where('deferred2', 'qux');
+                $inertia->where('deferred3', 'quux');
+                $called++;
+            });
+
+            $inertia->loadDeferredProps(['default', 'custom'], function (AssertableInertia $inertia) use (&$called) {
+                $inertia->where('deferred1', 'baz');
+                $inertia->where('deferred2', 'qux');
+                $inertia->where('deferred3', 'quux');
+                $called++;
+            });
+        });
+
+        $this->assertSame(4, $called);
+    }
 }


### PR DESCRIPTION
This PR introduces a `loadDeferredProps()` method on the `AssertableInertia` class, similar to testing partial reloads (see PR #738).

```php
Inertia::render('Index', [
    'foo' => 'bar',
    'deferred1' => Inertia::defer(fn () => 'baz'),
    'deferred2' => Inertia::defer(fn () => 'qux', 'custom'),
    'deferred3' => Inertia::defer(fn () => 'quux', 'custom'),
]);

//

$response->assertInertia(function (AssertableInertia $inertia) {
    $inertia->where('foo', 'bar');
    $inertia->missing('deferred1');
    $inertia->missing('deferred2');
    $inertia->missing('deferred3');

    $inertia->loadDeferredProps(function (AssertableInertia $inertia) {
        $inertia->where('deferred1', 'baz');
        $inertia->where('deferred2', 'qux');
        $inertia->where('deferred3', 'quux');
    });
});
```

You can also load a specific group.

```php
$inertia->loadDeferredProps('default', function (AssertableInertia $inertia) {
    //
});
```

Or multiple.

```php
$inertia->loadDeferredProps(['default', 'custom'], function (AssertableInertia $inertia) {
    //
});
```