### PR TITLE
Handle Connection Exceptions During Health Checks

### DIFF
--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -61,11 +61,15 @@ class HttpGateway implements Gateway, HasHealthCheck
      */
     public function isHealthy(): bool
     {
-        return rescue(
-            fn () => Http::get($this->getUrl('/health'))->successful(),
-            rescue: false,
-            report: false,
-        );
+        try {
+            return Http::get($this->getUrl('/health'))->successful();
+        } catch (Exception $e) {
+            if ($e instanceof StrayRequestException) {
+                throw $e;
+            }
+
+            return false;
+        }
     }
 
     /**

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -61,7 +61,11 @@ class HttpGateway implements Gateway, HasHealthCheck
      */
     public function isHealthy(): bool
     {
-        return Http::get($this->getUrl('/health'))->successful();
+        return rescue(
+            fn () => Http::get($this->getUrl('/health'))->successful(),
+            rescue: false,
+            report: false,
+        );
     }
 
     /**

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -124,7 +124,7 @@ class HttpGatewayTest extends TestCase
                 ->push(status: 500)
                 ->pushResponse(
                     fn ($request) => Create::rejectionFor(new ConnectException(
-                        $message ?? "cURL error 6: Could not resolve host: {$request->toPsrRequest()->getUri()->getHost()} (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for {$request->toPsrRequest()->getUri()}.",
+                        "cURL error 6: Could not resolve host: {$request->toPsrRequest()->getUri()->getHost()} (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for {$request->toPsrRequest()->getUri()}.",
                         $request->toPsrRequest(),
                     ))
                 ),

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -116,18 +116,29 @@ class HttpGatewayTest extends TestCase
         $this->assertNull($this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]));
     }
 
+    /**
+     * Create a new connection exception for use during stubbing.
+     *
+     * This is copied over from Laravel's Http::failedConnection() helper
+     * method, which is only available in Laravel 11.32.0 and later.
+     */
+    private static function rejectionForFailedConnection(?string $message = null): callable
+    {
+        return function ($request) use ($message) {
+            return Create::rejectionFor(new ConnectException(
+                $message ?? "cURL error 6: Could not resolve host: {$request->toPsrRequest()->getUri()->getHost()} (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for {$request->toPsrRequest()->getUri()}.",
+                $request->toPsrRequest(),
+            ));
+        };
+    }
+
     public function test_health_check_the_ssr_server(): void
     {
         Http::fake([
             $this->gateway->getUrl('health') => Http::sequence()
                 ->push(status: 200)
                 ->push(status: 500)
-                ->pushResponse(
-                    fn ($request) => Create::rejectionFor(new ConnectException(
-                        "cURL error 6: Could not resolve host: {$request->toPsrRequest()->getUri()->getHost()} (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for {$request->toPsrRequest()->getUri()}.",
-                        $request->toPsrRequest(),
-                    ))
-                ),
+                ->pushResponse(self::rejectionForFailedConnection()),
         ]);
 
         $this->assertTrue($this->gateway->isHealthy());

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -4,6 +4,8 @@ namespace Inertia\Tests;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Request;
 use Illuminate\Support\Facades\Http;
 use Inertia\Ssr\HttpGateway;
 
@@ -122,14 +124,11 @@ class HttpGatewayTest extends TestCase
      * This is copied over from Laravel's Http::failedConnection() helper
      * method, which is only available in Laravel 11.32.0 and later.
      */
-    private static function rejectionForFailedConnection(?string $message = null): callable
+    private static function rejectionForFailedConnection(): PromiseInterface
     {
-        return function ($request) use ($message) {
-            return Create::rejectionFor(new ConnectException(
-                $message ?? "cURL error 6: Could not resolve host: {$request->toPsrRequest()->getUri()->getHost()} (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for {$request->toPsrRequest()->getUri()}.",
-                $request->toPsrRequest(),
-            ));
-        };
+        return Create::rejectionFor(
+            new ConnectException('Connection refused', new Request('GET', '/'))
+        );
     }
 
     public function test_health_check_the_ssr_server(): void

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -119,10 +119,12 @@ class HttpGatewayTest extends TestCase
         Http::fake([
             $this->gateway->getUrl('health') => Http::sequence()
                 ->push(status: 200)
-                ->push(status: 500),
+                ->push(status: 500)
+                ->pushFailedConnection(),
         ]);
 
         $this->assertTrue($this->gateway->isHealthy());
+        $this->assertFalse($this->gateway->isHealthy());
         $this->assertFalse($this->gateway->isHealthy());
     }
 }

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -2,6 +2,8 @@
 
 namespace Inertia\Tests;
 
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Promise\Create;
 use Illuminate\Support\Facades\Http;
 use Inertia\Ssr\HttpGateway;
 
@@ -120,7 +122,12 @@ class HttpGatewayTest extends TestCase
             $this->gateway->getUrl('health') => Http::sequence()
                 ->push(status: 200)
                 ->push(status: 500)
-                ->pushFailedConnection(),
+                ->pushResponse(
+                    fn ($request) => Create::rejectionFor(new ConnectException(
+                        $message ?? "cURL error 6: Could not resolve host: {$request->toPsrRequest()->getUri()->getHost()} (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for {$request->toPsrRequest()->getUri()}.",
+                        $request->toPsrRequest(),
+                    ))
+                ),
         ]);
 
         $this->assertTrue($this->gateway->isHealthy());


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The HttpGateway currently determines whether the SSR server is healthy by looking at the status of the response to the health check endpoint. If the server is not available at all though, there will be no response and a ConnectionException will occur. This causes the check-ssr command to fail quite aggressively due to an exception getting thrown without being caught.

Instead of letting that exception fall through, it seems reasonable to rescue the exception in the isHealthy method and say that it's not healthy if an exception occurred. Additionally, I also feel it's reasonable to not report said exception, but I don't have a strong opinion either way. The way that I noticed this was from seeing this exception after deploying while waiting for the SSR server to start up. In that scenario, I'm not concerned with the ConnectionException as the command is the failure indicator that is actually useful.

I had originally wrote the test implementation using `->pushFailedConnection()`, but that was only added in Laravel 11. In order to keep the Laravel 10 support, I took the implementation of the exception from the PR that added it. https://github.com/laravel/framework/pull/53485