### PR TITLE
Handle array inputs in reloadOnly and reloadExcept

### DIFF
--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -192,7 +192,9 @@ class AssertableInertia extends AssertableJson
     public function reloadOnly(array|string $only, ?Closure $callback = null): self
     {
         return $this->reload(only: $only, callback: function (AssertableInertia $assertable) use ($only, $callback) {
-            $assertable->hasAll(explode(',', $only));
+            $props = is_array($only) ? $only : explode(',', $only);
+
+            $assertable->hasAll($props);
 
             if ($callback) {
                 $callback($assertable);
@@ -208,7 +210,9 @@ class AssertableInertia extends AssertableJson
     public function reloadExcept(array|string $except, ?Closure $callback = null): self
     {
         return $this->reload(except: $except, callback: function (AssertableInertia $assertable) use ($except, $callback) {
-            $assertable->missingAll(explode(',', $except));
+            $props = is_array($except) ? $except : explode(',', $except);
+
+            $assertable->missingAll($props);
 
             if ($callback) {
                 $callback($assertable);

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -249,6 +249,36 @@ class AssertableInertiaTest extends TestCase
         $this->assertTrue($called);
     }
 
+    public function test_lazy_props_can_be_evaluated_when_only_is_array(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', [
+                'foo' => 'bar',
+                'lazy1' => Inertia::optional(fn () => 'baz'),
+                'lazy2' => Inertia::optional(fn () => 'qux'),
+            ])
+        );
+
+        $called = false;
+
+        $response->assertInertia(function ($inertia) use (&$called) {
+            $inertia->where('foo', 'bar');
+            $inertia->missing('lazy1');
+            $inertia->missing('lazy2');
+
+            $result = $inertia->reloadOnly(['lazy1'], function ($inertia) use (&$called) {
+                $inertia->missing('foo');
+                $inertia->where('lazy1', 'baz');
+                $inertia->missing('lazy2');
+                $called = true;
+            });
+
+            $this->assertSame($result, $inertia);
+        });
+
+        $this->assertTrue($called);
+    }
+
     public function test_lazy_props_can_be_evaluated_with_except(): void
     {
         $response = $this->makeMockRequest(
@@ -267,6 +297,34 @@ class AssertableInertiaTest extends TestCase
             $inertia->missing('lazy2');
 
             $inertia->reloadExcept('lazy1', function ($inertia) use (&$called) {
+                $inertia->where('foo', 'bar');
+                $inertia->missing('lazy1');
+                $inertia->where('lazy2', 'qux');
+                $called = true;
+            });
+        });
+
+        $this->assertTrue($called);
+    }
+
+    public function test_lazy_props_can_be_evaluated_with_except_when_except_is_array(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', [
+                'foo' => 'bar',
+                'lazy1' => Inertia::lazy(fn () => 'baz'),
+                'lazy2' => Inertia::lazy(fn () => 'qux'),
+            ])
+        );
+
+        $called = false;
+
+        $response->assertInertia(function ($inertia) use (&$called) {
+            $inertia->where('foo', 'bar');
+            $inertia->missing('lazy1');
+            $inertia->missing('lazy2');
+
+            $inertia->reloadExcept(['lazy1'], function ($inertia) use (&$called) {
                 $inertia->where('foo', 'bar');
                 $inertia->missing('lazy1');
                 $inertia->where('lazy2', 'qux');


### PR DESCRIPTION
Fix reloadOnly/reloadExcept to accept array inputs.