### PR TITLE
Include `onceProps` metadata for `fresh` props

### DIFF
--- a/src/Onceable.php
+++ b/src/Onceable.php
@@ -20,6 +20,11 @@ interface Onceable
     public function shouldResolveOnce(): bool;
 
     /**
+     * Determine if the prop was marked as fresh.
+     */
+    public function markedAsFresh(): bool;
+
+    /**
      * Get the custom key for resolving the once prop.
      */
     public function getKey(): ?string;

--- a/src/Onceable.php
+++ b/src/Onceable.php
@@ -22,7 +22,7 @@ interface Onceable
     /**
      * Determine if the prop was marked as fresh.
      */
-    public function markedAsFresh(): bool;
+    public function shouldBeRefreshed(): bool;
 
     /**
      * Get the custom key for resolving the once prop.

--- a/src/ResolvesOnce.php
+++ b/src/ResolvesOnce.php
@@ -18,6 +18,11 @@ trait ResolvesOnce
     protected bool $once = false;
 
     /**
+     * Indicates if the prop was marked as fresh.
+     */
+    protected bool $fresh = false;
+
+    /**
      * The expiration time in seconds.
      */
     protected ?int $ttl = null;
@@ -54,6 +59,14 @@ trait ResolvesOnce
     }
 
     /**
+     * Determine if the prop was marked as fresh.
+     */
+    public function markedAsFresh(): bool
+    {
+        return $this->fresh;
+    }
+
+    /**
      * Get the custom key for resolving the once prop.
      */
     public function getKey(): ?string
@@ -80,7 +93,7 @@ trait ResolvesOnce
      */
     public function fresh(bool $value = true): static
     {
-        $this->once = ! $value;
+        $this->fresh = $value;
 
         return $this;
     }

--- a/src/ResolvesOnce.php
+++ b/src/ResolvesOnce.php
@@ -18,9 +18,9 @@ trait ResolvesOnce
     protected bool $once = false;
 
     /**
-     * Indicates if the prop was marked as fresh.
+     * Indicates if the prop should be forcefully refreshed.
      */
-    protected bool $fresh = false;
+    protected bool $refresh = false;
 
     /**
      * The expiration time in seconds.
@@ -59,11 +59,11 @@ trait ResolvesOnce
     }
 
     /**
-     * Determine if the prop was marked as fresh.
+     * Determine if the prop should be forcefully refreshed.
      */
-    public function markedAsFresh(): bool
+    public function shouldBeRefreshed(): bool
     {
-        return $this->fresh;
+        return $this->refresh;
     }
 
     /**
@@ -93,7 +93,7 @@ trait ResolvesOnce
      */
     public function fresh(bool $value = true): static
     {
-        $this->fresh = $value;
+        $this->refresh = $value;
 
         return $this;
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -297,11 +297,19 @@ class Response implements Responsable
 
         return collect($props)
             ->reject(function ($prop, string $key) use ($loadedProps) {
-                if ($prop instanceof Onceable) {
-                    return !$prop->markedAsFresh() && $prop->shouldResolveOnce() && in_array($prop->getKey() ?? $key, $loadedProps);
+                if (! $prop instanceof Onceable) {
+                    return false;
                 }
 
-                return false;
+                if (! $prop->shouldResolveOnce()) {
+                    return false;
+                }
+
+                if ($prop->shouldBeRefreshed()) {
+                    return false;
+                }
+
+                return in_array($prop->getKey() ?? $key, $loadedProps);
             })
             ->all();
     }
@@ -659,7 +667,7 @@ class Response implements Responsable
     public function resolveOnceProps(Request $request): array
     {
         $onceProps = collect($this->props)
-            ->filter(fn ($prop) => $prop instanceof Onceable && ($prop->shouldResolveOnce() || $prop->markedAsFresh()))
+            ->filter(fn ($prop) => $prop instanceof Onceable && $prop->shouldResolveOnce())
             ->only($this->getOnlyProps($request))
             ->except($this->getExceptProps($request))
             ->mapWithKeys(fn (Onceable $prop, string $key) => [$prop->getKey() ?? $key => [

--- a/src/Response.php
+++ b/src/Response.php
@@ -298,7 +298,7 @@ class Response implements Responsable
         return collect($props)
             ->reject(function ($prop, string $key) use ($loadedProps) {
                 if ($prop instanceof Onceable) {
-                    return $prop->shouldResolveOnce() && in_array($prop->getKey() ?? $key, $loadedProps);
+                    return !$prop->markedAsFresh() && $prop->shouldResolveOnce() && in_array($prop->getKey() ?? $key, $loadedProps);
                 }
 
                 return false;
@@ -659,7 +659,7 @@ class Response implements Responsable
     public function resolveOnceProps(Request $request): array
     {
         $onceProps = collect($this->props)
-            ->filter(fn ($prop) => $prop instanceof Onceable && $prop->shouldResolveOnce())
+            ->filter(fn ($prop) => $prop instanceof Onceable && ($prop->shouldResolveOnce() || $prop->markedAsFresh()))
             ->only($this->getOnlyProps($request))
             ->except($this->getExceptProps($request))
             ->mapWithKeys(fn (Onceable $prop, string $key) => [$prop->getKey() ?? $key => [

--- a/tests/OncePropTest.php
+++ b/tests/OncePropTest.php
@@ -54,7 +54,7 @@ class OncePropTest extends TestCase
     {
         $onceProp = new OnceProp(fn () => 'value');
 
-        $this->assertFalse($onceProp->markedAsFresh());
+        $this->assertFalse($onceProp->shouldBeRefreshed());
     }
 
     public function test_is_fresh_returns_true_after_fresh_called(): void
@@ -62,7 +62,7 @@ class OncePropTest extends TestCase
         $onceProp = new OnceProp(fn () => 'value');
         $onceProp->fresh();
 
-        $this->assertTrue($onceProp->markedAsFresh());
+        $this->assertTrue($onceProp->shouldBeRefreshed());
     }
 
     public function test_is_fresh_returns_false_after_fresh_false_called(): void
@@ -71,6 +71,6 @@ class OncePropTest extends TestCase
         $onceProp->fresh();
         $onceProp->fresh(false);
 
-        $this->assertFalse($onceProp->markedAsFresh());
+        $this->assertFalse($onceProp->shouldBeRefreshed());
     }
 }

--- a/tests/OncePropTest.php
+++ b/tests/OncePropTest.php
@@ -50,14 +50,14 @@ class OncePropTest extends TestCase
         $this->assertSame('Baz', $onceProp->getKey());
     }
 
-    public function test_is_fresh_returns_false_by_default(): void
+    public function test_should_not_be_refreshed_by_default(): void
     {
         $onceProp = new OnceProp(fn () => 'value');
 
         $this->assertFalse($onceProp->shouldBeRefreshed());
     }
 
-    public function test_is_fresh_returns_true_after_fresh_called(): void
+    public function test_can_forcefully_refresh(): void
     {
         $onceProp = new OnceProp(fn () => 'value');
         $onceProp->fresh();
@@ -65,7 +65,7 @@ class OncePropTest extends TestCase
         $this->assertTrue($onceProp->shouldBeRefreshed());
     }
 
-    public function test_is_fresh_returns_false_after_fresh_false_called(): void
+    public function test_can_disable_forceful_refresh(): void
     {
         $onceProp = new OnceProp(fn () => 'value');
         $onceProp->fresh();

--- a/tests/OncePropTest.php
+++ b/tests/OncePropTest.php
@@ -49,4 +49,26 @@ class OncePropTest extends TestCase
         $onceProp->as(TestUnitEnum::Baz);
         $this->assertSame('Baz', $onceProp->getKey());
     }
+
+    public function test_fresh_disables_once_resolution(): void
+    {
+        $onceProp = new OnceProp(fn () => 'value');
+
+        $this->assertTrue($onceProp->shouldResolveOnce());
+
+        $result = $onceProp->fresh();
+        $this->assertSame($onceProp, $result);
+        $this->assertFalse($onceProp->shouldResolveOnce());
+    }
+
+    public function test_fresh_with_false_enables_once_resolution(): void
+    {
+        $onceProp = new OnceProp(fn () => 'value');
+        $onceProp->fresh();
+
+        $this->assertFalse($onceProp->shouldResolveOnce());
+
+        $onceProp->fresh(false);
+        $this->assertTrue($onceProp->shouldResolveOnce());
+    }
 }

--- a/tests/OncePropTest.php
+++ b/tests/OncePropTest.php
@@ -50,25 +50,27 @@ class OncePropTest extends TestCase
         $this->assertSame('Baz', $onceProp->getKey());
     }
 
-    public function test_fresh_disables_once_resolution(): void
+    public function test_is_fresh_returns_false_by_default(): void
     {
         $onceProp = new OnceProp(fn () => 'value');
 
-        $this->assertTrue($onceProp->shouldResolveOnce());
-
-        $result = $onceProp->fresh();
-        $this->assertSame($onceProp, $result);
-        $this->assertFalse($onceProp->shouldResolveOnce());
+        $this->assertFalse($onceProp->markedAsFresh());
     }
 
-    public function test_fresh_with_false_enables_once_resolution(): void
+    public function test_is_fresh_returns_true_after_fresh_called(): void
     {
         $onceProp = new OnceProp(fn () => 'value');
         $onceProp->fresh();
 
-        $this->assertFalse($onceProp->shouldResolveOnce());
+        $this->assertTrue($onceProp->markedAsFresh());
+    }
 
+    public function test_is_fresh_returns_false_after_fresh_false_called(): void
+    {
+        $onceProp = new OnceProp(fn () => 'value');
+        $onceProp->fresh();
         $onceProp->fresh(false);
-        $this->assertTrue($onceProp->shouldResolveOnce());
+
+        $this->assertFalse($onceProp->markedAsFresh());
     }
 }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -589,7 +589,7 @@ class ResponseFactoryTest extends TestCase
         $this->assertNotNull($data['onceProps']['app-settings']['expiresAt']);
     }
 
-    public function test_fresh_removes_prop_from_once_props_but_keeps_it_in_props(): void
+    public function test_fresh_keeps_prop_in_once_props_and_in_props(): void
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
             return Inertia::render('User/Edit', [
@@ -605,8 +605,10 @@ class ResponseFactoryTest extends TestCase
             'props' => [
                 'settings' => ['theme' => 'dark'],
             ],
+            'onceProps' => [
+                'settings' => ['prop' => 'settings', 'expiresAt' => null],
+            ],
         ]);
-        $this->assertArrayNotHasKey('onceProps', $response->json());
     }
 
     public function test_once_prop_without_fresh_is_present_in_both_props_and_once_props(): void

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -589,7 +589,7 @@ class ResponseFactoryTest extends TestCase
         $this->assertNotNull($data['onceProps']['app-settings']['expiresAt']);
     }
 
-    public function test_fresh_keeps_prop_in_once_props_and_in_props(): void
+    public function test_forcefully_refreshing_a_once_prop_includes_it_in_once_props(): void
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
             return Inertia::render('User/Edit', [
@@ -611,7 +611,7 @@ class ResponseFactoryTest extends TestCase
         ]);
     }
 
-    public function test_once_prop_without_fresh_is_present_in_both_props_and_once_props(): void
+    public function test_once_prop_is_included_in_once_props_by_default(): void
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
             return Inertia::render('User/Edit', [

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -588,4 +588,49 @@ class ResponseFactoryTest extends TestCase
         $this->assertEquals('settings', $data['onceProps']['app-settings']['prop']);
         $this->assertNotNull($data['onceProps']['app-settings']['expiresAt']);
     }
+
+    public function test_fresh_removes_prop_from_once_props_but_keeps_it_in_props(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            return Inertia::render('User/Edit', [
+                'settings' => Inertia::once(fn () => ['theme' => 'dark'])->fresh(),
+            ]);
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'component' => 'User/Edit',
+            'props' => [
+                'settings' => ['theme' => 'dark'],
+            ],
+        ]);
+        $this->assertArrayNotHasKey('onceProps', $response->json());
+    }
+
+    public function test_once_prop_without_fresh_is_present_in_both_props_and_once_props(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            return Inertia::render('User/Edit', [
+                'settings' => Inertia::once(fn () => ['theme' => 'dark']),
+            ]);
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'component' => 'User/Edit',
+            'props' => [
+                'settings' => ['theme' => 'dark'],
+            ],
+            'onceProps' => [
+                'settings' => [
+                    'prop' => 'settings',
+                    'expiresAt' => null,
+                ],
+            ],
+        ]);
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1223,6 +1223,27 @@ class ResponseTest extends TestCase
         $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;onceProps&quot;:{&quot;foo&quot;:{&quot;prop&quot;:&quot;foo&quot;,&quot;expiresAt&quot;:null}}}"></div>', $view->render());
     }
 
+    public function test_fresh_once_props_are_included_in_once_props_on_initial_page_load(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+
+        $response = new Response('User/Edit', ['foo' => Inertia::once(fn () => 'bar')->fresh()], 'app', '123');
+        /** @var BaseResponse $response */
+        $response = $response->toResponse($request);
+        $view = $response->getOriginalContent();
+        $page = $view->getData()['page'];
+
+        $this->assertInstanceOf(BaseResponse::class, $response);
+        $this->assertInstanceOf(View::class, $view);
+
+        $this->assertSame('User/Edit', $page['component']);
+        $this->assertSame('bar', $page['props']['foo']);
+        $this->assertSame('/user/123', $page['url']);
+        $this->assertSame('123', $page['version']);
+        $this->assertArrayHasKey('onceProps', $page);
+        $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
+    }
+
     public function test_once_props_are_resolved_with_a_custom_key_and_ttl_value(): void
     {
         $this->freezeSecond();
@@ -1400,7 +1421,10 @@ class ResponseTest extends TestCase
         $this->assertSame('bar', $page->props->foo);
         $this->assertSame('/user/123', $page->url);
         $this->assertSame('123', $page->version);
-        $this->assertFalse(isset($page->onceProps));
+        // fresh() props should still be in onceProps so the client can track them
+        $this->assertEquals((object) [
+            'foo' => (object) ['prop' => 'foo', 'expiresAt' => null],
+        ], $page->onceProps);
     }
 
     public function test_fresh_props_are_not_excluded_while_once_props_are_excluded(): void
@@ -1426,9 +1450,9 @@ class ResponseTest extends TestCase
         $this->assertFalse(isset($page->props->baz));
         $this->assertSame('/user/123', $page->url);
         $this->assertSame('123', $page->version);
-        // fresh() prop is NOT in onceProps, but baz IS in onceProps (even though excluded from props)
-        $this->assertFalse(isset($page->onceProps->foo));
+        // Both fresh() and once() props are in onceProps so the client can track them
         $this->assertEquals((object) [
+            'foo' => (object) ['prop' => 'foo', 'expiresAt' => null],
             'baz' => (object) ['prop' => 'baz', 'expiresAt' => null],
         ], $page->onceProps);
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1223,7 +1223,7 @@ class ResponseTest extends TestCase
         $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;onceProps&quot;:{&quot;foo&quot;:{&quot;prop&quot;:&quot;foo&quot;,&quot;expiresAt&quot;:null}}}"></div>', $view->render());
     }
 
-    public function test_fresh_once_props_are_included_in_once_props_on_initial_page_load(): void
+    public function test_fresh_once_props_are_included_on_initial_page_load(): void
     {
         $request = Request::create('/user/123', 'GET');
 
@@ -1421,7 +1421,6 @@ class ResponseTest extends TestCase
         $this->assertSame('bar', $page->props->foo);
         $this->assertSame('/user/123', $page->url);
         $this->assertSame('123', $page->version);
-        // fresh() props should still be in onceProps so the client can track them
         $this->assertEquals((object) [
             'foo' => (object) ['prop' => 'foo', 'expiresAt' => null],
         ], $page->onceProps);
@@ -1444,13 +1443,10 @@ class ResponseTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
 
         $this->assertSame('User/Edit', $page->component);
-        // fresh() prop is resolved even when in X-Inertia-Except-Once-Props header
         $this->assertSame('bar', $page->props->foo);
-        // once() prop is excluded when in X-Inertia-Except-Once-Props header
         $this->assertFalse(isset($page->props->baz));
         $this->assertSame('/user/123', $page->url);
         $this->assertSame('123', $page->version);
-        // Both fresh() and once() props are in onceProps so the client can track them
         $this->assertEquals((object) [
             'foo' => (object) ['prop' => 'foo', 'expiresAt' => null],
             'baz' => (object) ['prop' => 'baz', 'expiresAt' => null],

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1383,6 +1383,56 @@ class ResponseTest extends TestCase
         ], $page->onceProps);
     }
 
+    public function test_fresh_props_are_resolved_even_when_in_except_once_props_header(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
+
+        $response = new Response('User/Edit', ['foo' => Inertia::once(fn () => 'bar')->fresh()], 'app', '123');
+        /** @var JsonResponse $response */
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+
+        $this->assertSame('User/Edit', $page->component);
+        $this->assertSame('bar', $page->props->foo);
+        $this->assertSame('/user/123', $page->url);
+        $this->assertSame('123', $page->version);
+        $this->assertFalse(isset($page->onceProps));
+    }
+
+    public function test_fresh_props_are_not_excluded_while_once_props_are_excluded(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo,baz']);
+
+        $response = new Response('User/Edit', [
+            'foo' => Inertia::once(fn () => 'bar')->fresh(),
+            'baz' => Inertia::once(fn () => 'qux'),
+        ], 'app', '123');
+        /** @var JsonResponse $response */
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+
+        $this->assertSame('User/Edit', $page->component);
+        // fresh() prop is resolved even when in X-Inertia-Except-Once-Props header
+        $this->assertSame('bar', $page->props->foo);
+        // once() prop is excluded when in X-Inertia-Except-Once-Props header
+        $this->assertFalse(isset($page->props->baz));
+        $this->assertSame('/user/123', $page->url);
+        $this->assertSame('123', $page->version);
+        // fresh() prop is NOT in onceProps, but baz IS in onceProps (even though excluded from props)
+        $this->assertFalse(isset($page->onceProps->foo));
+        $this->assertEquals((object) [
+            'baz' => (object) ['prop' => 'baz', 'expiresAt' => null],
+        ], $page->onceProps);
+    }
+
     public function test_responsable_with_invalid_key(): void
     {
         $request = Request::create('/user/123', 'GET');


### PR DESCRIPTION
This PR fixes "fresh" once props meta being skipped while building onceProps metadata.

Before the fix, calling `fresh()` basically turned once props into regular props.

