### PR TITLE
Fix flash data loss on non-Inertia redirects

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -122,6 +122,10 @@ class Middleware
         $response = $next($request);
         $response->headers->set('Vary', Header::INERTIA);
 
+        if ($response->isRedirect()) {
+            $this->reflash($request);
+        }
+
         if (! $request->header(Header::INERTIA)) {
             return $response;
         }
@@ -136,10 +140,6 @@ class Middleware
 
         if ($response->getStatusCode() === 302 && in_array($request->method(), ['PUT', 'PATCH', 'DELETE'])) {
             $response->setStatusCode(303);
-        }
-
-        if ($response->isRedirect()) {
-            $this->reflash($request);
         }
 
         return $response;

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -407,6 +407,27 @@ class MiddlewareTest extends TestCase
         ]);
     }
 
+    public function test_flash_data_is_preserved_on_non_inertia_redirect(): void
+    {
+        Route::middleware([StartSession::class, Middleware::class])->get('/action', function () {
+            Inertia::flash('message', 'Success!');
+
+            return redirect('/dashboard');
+        });
+
+        Route::middleware([StartSession::class, Middleware::class])->get('/dashboard', function () {
+            return Inertia::render('Dashboard');
+        });
+
+        $response = $this->get('/action');
+        $response->assertRedirect('/dashboard');
+
+        $response = $this->get('/dashboard', ['X-Inertia' => 'true']);
+        $response->assertJson([
+            'flash' => ['message' => 'Success!'],
+        ]);
+    }
+
     /**
      * @param  array<string, mixed>  $shared
      */


### PR DESCRIPTION
When a non-Inertia request sets flash data and redirects to an Inertia page, the flash data was being lost because the middleware returned early before calling `reflash()`.