### PR TITLE
Add test helpers for Flash Data

### DIFF
--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -231,7 +231,7 @@ class AssertableInertia extends AssertableJson
     /**
      * Assert that the Flash Data contains the given key, optionally with the expected value.
      */
-    public function flash(string $key, mixed $expected = null): self
+    public function hasFlash(string $key, mixed $expected = null): self
     {
         PHPUnit::assertTrue(
             Arr::has($this->flash, $key),

--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -56,6 +56,13 @@ class AssertableInertia extends AssertableJson
     private $deferredProps;
 
     /**
+     * The Flash Data (if any).
+     *
+     * @var array<string, mixed>
+     */
+    private $flash;
+
+    /**
      * Create an AssertableInertia instance from a test response.
      *
      * @param  TestResponse<Response>  $response
@@ -84,6 +91,7 @@ class AssertableInertia extends AssertableJson
         $instance->encryptHistory = $page['encryptHistory'];
         $instance->clearHistory = $page['clearHistory'];
         $instance->deferredProps = $page['deferredProps'] ?? [];
+        $instance->flash = $page['flash'] ?? [];
 
         return $instance;
     }
@@ -221,6 +229,40 @@ class AssertableInertia extends AssertableJson
     }
 
     /**
+     * Assert that the Flash Data contains the given key, optionally with the expected value.
+     */
+    public function flash(string $key, mixed $expected = null): self
+    {
+        PHPUnit::assertTrue(
+            Arr::has($this->flash, $key),
+            sprintf('Inertia Flash Data is missing key [%s].', $key)
+        );
+
+        if (func_num_args() > 1) {
+            PHPUnit::assertSame(
+                $expected,
+                Arr::get($this->flash, $key),
+                sprintf('Inertia Flash Data [%s] does not match expected value.', $key)
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the Flash Data does not contain the given key.
+     */
+    public function missingFlash(string $key): self
+    {
+        PHPUnit::assertFalse(
+            Arr::has($this->flash, $key),
+            sprintf('Inertia Flash Data has unexpected key [%s].', $key)
+        );
+
+        return $this;
+    }
+
+    /**
      * Convert the instance to an array.
      *
      * @return array<string, mixed>
@@ -234,6 +276,7 @@ class AssertableInertia extends AssertableJson
             'version' => $this->version,
             'encryptHistory' => $this->encryptHistory,
             'clearHistory' => $this->clearHistory,
+            'flash' => $this->flash,
         ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,11 +35,13 @@ abstract class TestCase extends Orchestra
     }
 
     /**
-     * @param  array<int, class-string>  $middleware
+     * @param  class-string|array<int, class-string>  $middleware
      * @return TestResponse<Response>
      */
-    protected function makeMockRequest(mixed $view, array $middleware = []): TestResponse
+    protected function makeMockRequest(mixed $view, string|array $middleware = []): TestResponse
     {
+        $middleware = is_array($middleware) ? $middleware : [$middleware];
+
         app('router')->middleware($middleware)->get('/example-url', function () use ($view) {
             return is_callable($view) ? $view() : $view;
         });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,11 +35,12 @@ abstract class TestCase extends Orchestra
     }
 
     /**
+     * @param  array<int, class-string>  $middleware
      * @return TestResponse<Response>
      */
-    protected function makeMockRequest(mixed $view): TestResponse
+    protected function makeMockRequest(mixed $view, array $middleware = []): TestResponse
     {
-        app('router')->get('/example-url', function () use ($view) {
+        app('router')->middleware($middleware)->get('/example-url', function () use ($view) {
             return is_callable($view) ? $view() : $view;
         });
 

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -400,9 +400,9 @@ class AssertableInertiaTest extends TestCase
         );
 
         $response->assertInertia(function (AssertableInertia $inertia) {
-            $inertia->flash('message');
-            $inertia->flash('message', 'Hello World');
-            $inertia->flash('notification.type', 'success');
+            $inertia->hasFlash('message');
+            $inertia->hasFlash('message', 'Hello World');
+            $inertia->hasFlash('notification.type', 'success');
             $inertia->missingFlash('other');
             $inertia->missingFlash('notification.other');
         });
@@ -415,7 +415,7 @@ class AssertableInertiaTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Inertia Flash Data is missing key [message].');
 
-        $response->assertInertia(fn (AssertableInertia $inertia) => $inertia->flash('message'));
+        $response->assertInertia(fn (AssertableInertia $inertia) => $inertia->hasFlash('message'));
     }
 
     public function test_the_flash_assertion_fails_when_value_does_not_match(): void
@@ -428,7 +428,7 @@ class AssertableInertiaTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Inertia Flash Data [message] does not match expected value.');
 
-        $response->assertInertia(fn (AssertableInertia $inertia) => $inertia->flash('message', 'Different'));
+        $response->assertInertia(fn (AssertableInertia $inertia) => $inertia->hasFlash('message', 'Different'));
     }
 
     public function test_the_missing_flash_assertion_fails_when_key_exists(): void
@@ -459,6 +459,6 @@ class AssertableInertiaTest extends TestCase
         });
 
         $this->get('/action')->assertRedirect('/dashboard');
-        $this->get('/dashboard')->assertInertia(fn (AssertableInertia $inertia) => $inertia->flash('message', 'Success!'));
+        $this->get('/dashboard')->assertInertia(fn (AssertableInertia $inertia) => $inertia->hasFlash('message', 'Success!'));
     }
 }

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -3,7 +3,9 @@
 namespace Inertia\Tests\Testing;
 
 use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
+use Inertia\Middleware;
 use Inertia\Testing\AssertableInertia;
 use Inertia\Tests\TestCase;
 use PHPUnit\Framework\AssertionFailedError;
@@ -394,7 +396,7 @@ class AssertableInertiaTest extends TestCase
                 'message' => 'Hello World',
                 'notification' => ['type' => 'success'],
             ]),
-            [StartSession::class]
+            StartSession::class
         );
 
         $response->assertInertia(function (AssertableInertia $inertia) {
@@ -420,7 +422,7 @@ class AssertableInertiaTest extends TestCase
     {
         $response = $this->makeMockRequest(
             fn () => Inertia::render('foo')->flash('message', 'Hello World'),
-            [StartSession::class]
+            StartSession::class
         );
 
         $this->expectException(AssertionFailedError::class);
@@ -433,12 +435,30 @@ class AssertableInertiaTest extends TestCase
     {
         $response = $this->makeMockRequest(
             fn () => Inertia::render('foo')->flash('message', 'Hello World'),
-            [StartSession::class]
+            StartSession::class
         );
 
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Inertia Flash Data has unexpected key [message].');
 
         $response->assertInertia(fn (AssertableInertia $inertia) => $inertia->missingFlash('message'));
+    }
+
+    public function test_the_flash_data_is_available_after_redirect(): void
+    {
+        $middleware = [StartSession::class, Middleware::class];
+
+        Route::middleware($middleware)->get('/action', function () {
+            Inertia::flash('message', 'Success!');
+
+            return redirect('/dashboard');
+        });
+
+        Route::middleware($middleware)->get('/dashboard', function () {
+            return Inertia::render('Dashboard');
+        });
+
+        $this->get('/action')->assertRedirect('/dashboard');
+        $this->get('/dashboard')->assertInertia(fn (AssertableInertia $inertia) => $inertia->flash('message', 'Success!'));
     }
 }

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -2,6 +2,7 @@
 
 namespace Inertia\Tests\Testing;
 
+use Illuminate\Session\Middleware\StartSession;
 use Inertia\Inertia;
 use Inertia\Testing\AssertableInertia;
 use Inertia\Tests\TestCase;
@@ -384,5 +385,60 @@ class AssertableInertiaTest extends TestCase
         });
 
         $this->assertSame(4, $called);
+    }
+
+    public function test_the_flash_data_can_be_asserted(): void
+    {
+        $response = $this->makeMockRequest(
+            fn () => Inertia::render('foo')->flash([
+                'message' => 'Hello World',
+                'notification' => ['type' => 'success'],
+            ]),
+            [StartSession::class]
+        );
+
+        $response->assertInertia(function (AssertableInertia $inertia) {
+            $inertia->flash('message');
+            $inertia->flash('message', 'Hello World');
+            $inertia->flash('notification.type', 'success');
+            $inertia->missingFlash('other');
+            $inertia->missingFlash('notification.other');
+        });
+    }
+
+    public function test_the_flash_assertion_fails_when_key_is_missing(): void
+    {
+        $response = $this->makeMockRequest(Inertia::render('foo'));
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia Flash Data is missing key [message].');
+
+        $response->assertInertia(fn (AssertableInertia $inertia) => $inertia->flash('message'));
+    }
+
+    public function test_the_flash_assertion_fails_when_value_does_not_match(): void
+    {
+        $response = $this->makeMockRequest(
+            fn () => Inertia::render('foo')->flash('message', 'Hello World'),
+            [StartSession::class]
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia Flash Data [message] does not match expected value.');
+
+        $response->assertInertia(fn (AssertableInertia $inertia) => $inertia->flash('message', 'Different'));
+    }
+
+    public function test_the_missing_flash_assertion_fails_when_key_exists(): void
+    {
+        $response = $this->makeMockRequest(
+            fn () => Inertia::render('foo')->flash('message', 'Hello World'),
+            [StartSession::class]
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia Flash Data has unexpected key [message].');
+
+        $response->assertInertia(fn (AssertableInertia $inertia) => $inertia->missingFlash('message'));
     }
 }


### PR DESCRIPTION
This adds `hasFlash()` and `missingFlash()` assertions to `AssertableInertia` for testing Flash Data.

  ```php
$response->assertInertia(function (AssertableInertia $page) {
    $page->hasFlash('message');
    $page->hasFlash('message', 'Item saved!');
    $page->hasFlash('notification.type', 'success');
    $page->missingFlash('error');
});
```