### PR TITLE
Fix flash data loss on Inertia::location() (409) responses

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -122,7 +122,11 @@ class Middleware
         $response = $next($request);
         $response->headers->set('Vary', Header::INERTIA);
 
-        if ($response->isRedirect() || $response->getStatusCode() === 409) {
+        if ($response->isRedirect()) {
+            $this->reflash($request);
+        }
+
+        if ($response->getStatusCode() === 409 && $response->headers->has(Header::LOCATION)) {
             $this->reflash($request);
         }
 

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -122,7 +122,7 @@ class Middleware
         $response = $next($request);
         $response->headers->set('Vary', Header::INERTIA);
 
-        if ($response->isRedirect()) {
+        if ($response->isRedirect() || $response->getStatusCode() === 409) {
             $this->reflash($request);
         }
 

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -13,6 +13,7 @@ use Illuminate\Support\ViewErrorBag;
 use Inertia\AlwaysProp;
 use Inertia\Inertia;
 use Inertia\Middleware;
+use Inertia\SessionKey;
 use Inertia\Tests\Stubs\CustomUrlResolverMiddleware;
 use Inertia\Tests\Stubs\ExampleMiddleware;
 use Inertia\Tests\Stubs\WithAllErrorsMiddleware;
@@ -442,5 +443,25 @@ class MiddlewareTest extends TestCase
                 return Inertia::render('User/Edit', ['user' => ['name' => 'Jonathan']])->toResponse($request);
             });
         });
+    }
+
+    public function test_flash_data_is_preserved_on_inertia_location_responses(): void
+    {
+        Route::middleware([StartSession::class, Middleware::class])
+            ->get('/external-redirect', function () {
+                Inertia::flash('status', 'Redirecting to external site...');
+
+                return Inertia::location('https://google.com');
+            });
+
+        $response = $this->get('/external-redirect', ['X-Inertia' => 'true']);
+
+        $response->assertStatus(409);
+        $response->assertHeader('X-Inertia-Location', 'https://google.com');
+
+        $this->assertEquals(
+            ['status' => 'Redirecting to external site...'],
+            session(SessionKey::FlashData->value)
+        );
     }
 }


### PR DESCRIPTION
Inertia v2.0 uses 409 Conflict for location redirects. Currently, the Middleware only reflashes session data for standard 3xx redirects. This PR ensures that flash data is preserved when using Inertia::location(), maintaining parity with standard redirect behavior.