### PR TITLE
Allow ScrollProp to be optional

### DIFF
--- a/src/LazyProp.php
+++ b/src/LazyProp.php
@@ -5,9 +5,9 @@ namespace Inertia;
 /**
  * @deprecated Use OptionalProp instead for clearer semantics.
  */
-class LazyProp implements IgnoreFirstLoad
+class LazyProp implements IgnoreFirstLoad, Optionable
 {
-    use ResolvesCallables;
+    use ResolvesCallables, OptionalProps;
 
     /**
      * The callback to resolve the property.
@@ -21,6 +21,7 @@ class LazyProp implements IgnoreFirstLoad
      */
     public function __construct(callable $callback)
     {
+        $this->optional = true;
         $this->callback = $callback;
     }
 

--- a/src/Optionable.php
+++ b/src/Optionable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Inertia;
+
+interface Optionable
+{
+    /**
+     * Determine if this property should be optional.
+     */
+    public function isOptional(): bool;
+}

--- a/src/OptionalProp.php
+++ b/src/OptionalProp.php
@@ -2,9 +2,9 @@
 
 namespace Inertia;
 
-class OptionalProp implements IgnoreFirstLoad, Onceable
+class OptionalProp implements IgnoreFirstLoad, Onceable, Optionable
 {
-    use ResolvesCallables, ResolvesOnce;
+    use ResolvesCallables, ResolvesOnce, OptionalProps;
 
     /**
      * The callback to resolve the property.
@@ -22,6 +22,7 @@ class OptionalProp implements IgnoreFirstLoad, Onceable
      */
     public function __construct(callable $callback)
     {
+        $this->optional = true;
         $this->callback = $callback;
     }
 

--- a/src/OptionalProps.php
+++ b/src/OptionalProps.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Inertia;
+
+trait OptionalProps
+{
+    /**
+     * Indicates if the property should be optional.
+     */
+    protected bool $optional = false;
+
+    /**
+     * Mark this property as optional.
+     */
+    public function optional(): static
+    {
+        $this->optional = true;
+
+        return $this;
+    }
+
+    public function isOptional(): bool
+    {
+        return $this->optional;
+    }
+}

--- a/src/Response.php
+++ b/src/Response.php
@@ -274,7 +274,8 @@ class Response implements Responsable
         if (! $this->isPartial($request)) {
             return array_filter($props, static function ($prop) {
                 return ! ($prop instanceof IgnoreFirstLoad)
-                    && ! ($prop instanceof Deferrable && $prop->shouldDefer());
+                    && ! ($prop instanceof Deferrable && $prop->shouldDefer())
+                    && ! ($prop instanceof Optionable && $prop->isOptional());
             });
         }
 
@@ -707,7 +708,7 @@ class Response implements Responsable
 
         $scrollProps = $this->getMergePropsForRequest($request, false)
             ->filter(fn (Mergeable $prop) => $prop instanceof ScrollProp)
-            ->reject(fn (ScrollProp $prop) => ! $isPartial && $prop->shouldDefer())
+            ->reject(fn (ScrollProp $prop) => ! $isPartial && ($prop->shouldDefer() || $prop->isOptional()))
             ->mapWithKeys(fn (ScrollProp $prop, string $key) => [$key => [
                 ...$prop->metadata(),
                 'reset' => in_array($key, $resetProps),

--- a/src/ScrollProp.php
+++ b/src/ScrollProp.php
@@ -13,9 +13,9 @@ use Inertia\Support\Header;
  *
  * @template T
  */
-class ScrollProp implements Deferrable, Mergeable
+class ScrollProp implements Deferrable, Mergeable, Optionable
 {
-    use DefersProps, MergesProps, ResolvesCallables;
+    use DefersProps, MergesProps, ResolvesCallables, OptionalProps;
 
     /**
      * The property value.

--- a/tests/ScrollPropTest.php
+++ b/tests/ScrollPropTest.php
@@ -248,4 +248,53 @@ class ScrollPropTest extends TestCase
         $this->assertArrayNotHasKey('users', $page['props']);
         $this->assertSame(['custom-group' => ['users']], $page['deferredProps']);
     }
+
+    public function test_optional_scroll_prop_is_excluded_from_initial_request(): void
+    {
+        $request = Request::create('/users', 'GET');
+
+        $response = new Response(
+            'Users/Index',
+            [
+                'users' => (new ScrollProp(fn () => User::query()->paginate(15)))->optional(),
+            ],
+            'app',
+            '123'
+        );
+
+        /** @var BaseResponse $response */
+        $response = $response->toResponse($request);
+        $view = $response->getOriginalContent();
+        $page = $view->getData()['page'];
+
+        $this->assertArrayNotHasKey('users', $page['props']);
+        $this->assertArrayNotHasKey('scrollProps', $page);
+    }
+
+    public function test_optional_scroll_prop_is_resolved_on_partial_request(): void
+    {
+        $request = Request::create('/users', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Partial-Component' => 'Users/Index']);
+        $request->headers->add(['X-Inertia-Partial-Data' => 'users']);
+
+        $response = new Response(
+            'Users/Index',
+            [
+                'users' => (new ScrollProp(fn () => User::query()->paginate(15)))->optional(),
+            ],
+            'app',
+            '123'
+        );
+
+        /** @var JsonResponse $response */
+        $response = $response->toResponse($request);
+        $page = $response->getData();
+
+        $this->assertObjectHasProperty('users', $page->props);
+        $this->assertCount(15, $page->props->users->data);
+        $this->assertObjectHasProperty('scrollProps', $page);
+        $this->assertEquals('page', $page->scrollProps->users->pageName);
+        $this->assertContains('users.data', $page->mergeProps);
+    }
 }


### PR DESCRIPTION
`Inertia::scroll()` is great for implementing infinite scrolling, but today it always loads as part of the initial response (or immediately after, when deferred).
This makes it awkward to use for **shared data** (e.g. notification list) that:

* should not always be loaded
* should only be fetched when actually needed
* should integrate naturally with `WhenVisible`


This PR adds an `optional()` modifier:

```php
Inertia::scroll(fn () => User::paginate())->optional();
```