### PR TITLE
[3.x] Exception handling via `Inertia::handleExceptionsUsing()`

### DIFF
--- a/src/ExceptionResponse.php
+++ b/src/ExceptionResponse.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Inertia;
+
+use Illuminate\Contracts\Http\Kernel as KernelContract;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class ExceptionResponse implements Responsable
+{
+    protected ?string $component = null;
+
+    /** @var array<string, mixed> */
+    protected array $props = [];
+
+    protected bool $includeSharedData = false;
+
+    protected ?string $rootView = null;
+
+    /** @var class-string<Middleware>|null */
+    protected ?string $middlewareClass = null;
+
+    public function __construct(
+        public readonly Throwable $exception,
+        public readonly Request $request,
+        public readonly Response $response,
+        protected readonly Router $router,
+        protected readonly KernelContract $kernel,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $props
+     */
+    public function render(string $component, array $props = []): static
+    {
+        $this->component = $component;
+        $this->props = $props;
+
+        return $this;
+    }
+
+    /**
+     * @param  class-string<Middleware>|null  $middlewareClass
+     */
+    public function withSharedData(?string $middlewareClass = null): static
+    {
+        $this->includeSharedData = true;
+
+        if ($middlewareClass) {
+            $this->middlewareClass = $middlewareClass;
+        }
+
+        return $this;
+    }
+
+    public function rootView(string $rootView): static
+    {
+        $this->rootView = $rootView;
+
+        return $this;
+    }
+
+    public function statusCode(): int
+    {
+        return $this->response->getStatusCode();
+    }
+
+    /**
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function toResponse($request): Response
+    {
+        if ($this->component === null) {
+            return $this->response;
+        }
+
+        $middleware = $this->resolveMiddleware();
+
+        if ($middleware) {
+            Inertia::version(fn () => $middleware->version($this->request));
+            Inertia::setRootView($this->rootView ?? $middleware->rootView($this->request));
+        } elseif ($this->rootView) {
+            Inertia::setRootView($this->rootView);
+        }
+
+        if ($this->includeSharedData && $middleware) {
+            Inertia::share($middleware->share($this->request));
+
+            foreach ($middleware->shareOnce($this->request) as $key => $value) {
+                if ($value instanceof OnceProp) {
+                    Inertia::share($key, $value);
+                } else {
+                    Inertia::shareOnce($key, $value);
+                }
+            }
+        }
+
+        return Inertia::render($this->component, $this->props)
+            ->toResponse($this->request)
+            ->setStatusCode($this->response->getStatusCode());
+    }
+
+    protected function resolveMiddleware(): ?Middleware
+    {
+        if ($this->middlewareClass) {
+            return app($this->middlewareClass);
+        }
+
+        $class = $this->resolveMiddlewareFromRoute() ?? $this->resolveMiddlewareFromKernel();
+
+        if ($class) {
+            return app($class);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return class-string<Middleware>|null
+     */
+    protected function resolveMiddlewareFromRoute(): ?string
+    {
+        $route = $this->request->route();
+
+        if (! $route) {
+            return null;
+        }
+
+        foreach ($this->router->gatherRouteMiddleware($route) as $middleware) {
+            if (! is_string($middleware)) {
+                continue;
+            }
+
+            $class = head(explode(':', $middleware));
+
+            if (is_a($class, Middleware::class, true)) {
+                return $class;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return class-string<Middleware>|null
+     */
+    protected function resolveMiddlewareFromKernel(): ?string
+    {
+        foreach ($this->kernel->getMiddlewareGroups() as $group) {
+            foreach ($group as $middleware) {
+                if (is_string($middleware) && is_a($middleware, Middleware::class, true)) {
+                    return $middleware;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ExceptionResponse.php
+++ b/src/ExceptionResponse.php
@@ -43,15 +43,18 @@ class ExceptionResponse implements Responsable
     }
 
     /**
-     * @param  class-string<Middleware>|null  $middlewareClass
+     * @param  class-string<Middleware>  $middlewareClass
      */
-    public function withSharedData(?string $middlewareClass = null): static
+    public function usingMiddleware(string $middlewareClass): static
+    {
+        $this->middlewareClass = $middlewareClass;
+
+        return $this;
+    }
+
+    public function withSharedData(): static
     {
         $this->includeSharedData = true;
-
-        if ($middlewareClass) {
-            $this->middlewareClass = $middlewareClass;
-        }
 
         return $this;
     }

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Inertia\Response render(string $component, array<array-key, mixed>|\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|\Inertia\ProvidesInertiaProperties $props = [])
  * @method static \Illuminate\Http\RedirectResponse back(int $status = 302, array<string, string> $headers = [], mixed $fallback = false)
  * @method static \Symfony\Component\HttpFoundation\Response location(string|\Symfony\Component\HttpFoundation\RedirectResponse $url)
+ * @method static void handleExceptionsUsing(callable $callback)
  * @method static \Inertia\ResponseFactory flash(string|array<string, mixed> $key, mixed $value = null)
  * @method static array<string, mixed> getFlashed(?\Illuminate\Http\Request $request = null)
  * @method static void macro(string $name, object|callable $macro)

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -4,8 +4,11 @@ namespace Inertia;
 
 use BackedEnum;
 use Closure;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Request as HttpRequest;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Redirect;
@@ -314,6 +317,31 @@ class ResponseFactory
         }
 
         return $url instanceof SymfonyRedirect ? $url : Redirect::away($url);
+    }
+
+    /**
+     * Register a callback to handle HTTP exceptions for Inertia requests.
+     */
+    public function handleExceptionsUsing(callable $callback): void
+    {
+        /** @var \Illuminate\Foundation\Exceptions\Handler $handler */
+        $handler = app(ExceptionHandler::class);
+
+        $handler->respondUsing(function ($response, $e, $request) use ($callback) {
+            $result = $callback(new ExceptionResponse(
+                $e,
+                $request,
+                $response,
+                app(Router::class),
+                app(Kernel::class),
+            ));
+
+            if ($result instanceof ExceptionResponse) {
+                return $result->toResponse($request);
+            }
+
+            return $result ?? $response;
+        });
     }
 
     /**

--- a/tests/ExceptionResponseTest.php
+++ b/tests/ExceptionResponseTest.php
@@ -112,7 +112,8 @@ class ExceptionResponseTest extends TestCase
     {
         Inertia::handleExceptionsUsing(function (ExceptionResponse $response) {
             return $response->render('Error', ['status' => $response->statusCode()])
-                ->withSharedData(Stubs\HttpExceptionMiddleware::class);
+                ->usingMiddleware(Stubs\HttpExceptionMiddleware::class)
+                ->withSharedData();
         });
 
         Route::middleware([StartSession::class, Middleware::class])->get('/', function () {

--- a/tests/ExceptionResponseTest.php
+++ b/tests/ExceptionResponseTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Route;
+use Inertia\ExceptionResponse;
+use Inertia\Inertia;
+use Inertia\Middleware;
+
+class ExceptionResponseTest extends TestCase
+{
+    public function test_exceptions_are_not_intercepted_without_handler(): void
+    {
+        Route::middleware([StartSession::class, Middleware::class])->get('/', function () {
+            abort(500);
+        });
+
+        $response = $this->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertStatus(500);
+        $this->assertFalse($response->headers->has('X-Inertia'));
+    }
+
+    public function test_exceptions_can_render_inertia_pages(): void
+    {
+        Inertia::handleExceptionsUsing(function (ExceptionResponse $response) {
+            return $response->render('Error', [
+                'status' => $response->statusCode(),
+                'message' => $response->exception->getMessage(),
+            ]);
+        });
+
+        Route::middleware([StartSession::class, Middleware::class])->get('/', function () {
+            abort(500, 'Something went wrong');
+        });
+
+        $response = $this->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertStatus(500);
+        $response->assertJson([
+            'component' => 'Error',
+            'props' => [
+                'status' => 500,
+                'message' => 'Something went wrong',
+            ],
+        ]);
+    }
+
+    public function test_exceptions_can_return_redirects(): void
+    {
+        Inertia::handleExceptionsUsing(function (ExceptionResponse $response) {
+            if ($response->statusCode() === 419) {
+                return redirect()->to('/login');
+            }
+
+            return $response->render('Error', ['status' => $response->statusCode()]);
+        });
+
+        Route::middleware([StartSession::class, Middleware::class])->get('/', function () {
+            abort(419);
+        });
+
+        $response = $this->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_exceptions_can_fall_through_to_default(): void
+    {
+        Inertia::handleExceptionsUsing(function (ExceptionResponse $response) {
+            if ($response->statusCode() === 500) {
+                return null;
+            }
+
+            return $response->render('Error', ['status' => $response->statusCode()]);
+        });
+
+        Route::middleware([StartSession::class, Middleware::class])->get('/', function () {
+            abort(500);
+        });
+
+        $response = $this->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertStatus(500);
+        $this->assertFalse($response->headers->has('X-Inertia'));
+    }
+
+    public function test_exceptions_with_shared_data(): void
+    {
+        $kernel = $this->app->make(\Illuminate\Contracts\Http\Kernel::class);
+        $kernel->appendMiddlewareToGroup('web', Stubs\HttpExceptionMiddleware::class);
+
+        Inertia::handleExceptionsUsing(function (ExceptionResponse $response) {
+            return $response->render('Error', ['status' => $response->statusCode()])
+                ->withSharedData();
+        });
+
+        $response = $this->get('/non-existent-page', ['X-Inertia' => 'true']);
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'component' => 'Error',
+            'props' => [
+                'status' => 404,
+                'appName' => 'My App',
+            ],
+        ]);
+    }
+
+    public function test_exceptions_with_shared_data_from_explicit_middleware(): void
+    {
+        Inertia::handleExceptionsUsing(function (ExceptionResponse $response) {
+            return $response->render('Error', ['status' => $response->statusCode()])
+                ->withSharedData(Stubs\HttpExceptionMiddleware::class);
+        });
+
+        Route::middleware([StartSession::class, Middleware::class])->get('/', function () {
+            abort(500);
+        });
+
+        $response = $this->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertStatus(500);
+        $response->assertJson([
+            'component' => 'Error',
+            'props' => [
+                'status' => 500,
+                'appName' => 'My App',
+            ],
+        ]);
+    }
+
+    public function test_exceptions_without_shared_data(): void
+    {
+        $kernel = $this->app->make(\Illuminate\Contracts\Http\Kernel::class);
+        $kernel->appendMiddlewareToGroup('web', Stubs\HttpExceptionMiddleware::class);
+
+        Inertia::handleExceptionsUsing(function (ExceptionResponse $response) {
+            return $response->render('Error', ['status' => $response->statusCode()]);
+        });
+
+        $response = $this->get('/non-existent-page', ['X-Inertia' => 'true']);
+
+        $response->assertStatus(404);
+        $page = $response->json();
+        $this->assertSame('Error', $page['component']);
+        $this->assertSame(404, $page['props']['status']);
+        $this->assertArrayNotHasKey('appName', $page['props']);
+    }
+
+    public function test_exceptions_with_custom_root_view(): void
+    {
+        Inertia::handleExceptionsUsing(function (ExceptionResponse $response) {
+            return $response->render('Error', ['status' => $response->statusCode()])
+                ->rootView('custom');
+        });
+
+        Route::middleware([StartSession::class, Middleware::class])->get('/', function () {
+            abort(500);
+        });
+
+        $response = $this->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertStatus(500);
+        $response->assertJson(['component' => 'Error']);
+    }
+
+    public function test_exceptions_outside_middleware_are_handled(): void
+    {
+        $kernel = $this->app->make(\Illuminate\Contracts\Http\Kernel::class);
+        $kernel->appendMiddlewareToGroup('web', Middleware::class);
+
+        Inertia::handleExceptionsUsing(function (ExceptionResponse $response) {
+            return $response->render('Error', ['status' => $response->statusCode()]);
+        });
+
+        $response = $this->get('/non-existent-page', ['X-Inertia' => 'true']);
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'component' => 'Error',
+            'props' => [
+                'status' => 404,
+            ],
+        ]);
+    }
+}

--- a/tests/Stubs/HttpExceptionMiddleware.php
+++ b/tests/Stubs/HttpExceptionMiddleware.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Inertia\Tests\Stubs;
+
+use Illuminate\Http\Request;
+use Inertia\Middleware;
+
+class HttpExceptionMiddleware extends Middleware
+{
+    public function share(Request $request): array
+    {
+        return array_merge(parent::share($request), [
+            'appName' => 'My App',
+        ]);
+    }
+}


### PR DESCRIPTION
This PR adds a first-party way to handle HTTP exceptions in Inertia apps. The [currently recommended approach](https://inertiajs.com/error-handling) uses `$exceptions->respond()` directly:

```php
$exceptions->respond(function (Response $response, Throwable $exception, Request $request) {
    if (in_array($response->getStatusCode(), [500, 503, 404, 403])) {
        return Inertia::render('Error', ['status' => $response->getStatusCode()])
            ->toResponse($request)
            ->setStatusCode($response->getStatusCode());
    }

    return $response;
});
```

The problem is that the exception handler runs outside the middleware stack, so shared data, the root view, and asset versioning from the Inertia middleware are all missing. This has been a [long-standing pain point](https://github.com/inertiajs/inertia-laravel/issues/176).

With this PR, you may use `handleExceptionsUsing()` instead:

```php
use Inertia\ExceptionResponse;
use Inertia\Inertia;

Inertia::handleExceptionsUsing(function (ExceptionResponse $response) {
    if ($response->statusCode() === 419) {
        return back()->with(['message' => 'The page expired, please try again.']);
    }

    if (in_array($response->statusCode(), [500, 503, 404, 403])) {
        return $response->render('Error', ['status' => $response->statusCode()])
            ->withSharedData();
    }
});
```

The callback receives an `ExceptionResponse` that holds the original `exception`, `request`, and `response` as public properties. Calling `render()` returns an Inertia page with the correct status code. You may chain `withSharedData()` to include shared data from the Inertia middleware, or `rootView()` to override the root view.

The Inertia middleware is auto-resolved from the matched route or the kernel's middleware groups, so `withSharedData()` just works in most setups. You may also pass an explicit middleware class: `usingMiddleware(HandleInertiaRequests::class)`.

Returning `null` falls through to Laravel's default exception rendering.

Fixes #176.