### PR TITLE
[3.x] Clean up config file structure

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -40,59 +40,26 @@ return [
     | components exist on disk when rendering a page. This is useful for
     | catching missing or misnamed components.
     |
-    | The `page_paths` and `page_extensions` options define where to look
-    | for page components and which file extensions to consider.
+    | The `paths` and `extensions` options define where to look for page
+    | components and which file extensions to consider.
+    |
+    | By default, the initial page data is passed via a script element.
+    | Set `use_data_attribute_for_initial_page` to true to use a data
+    | attribute on the root element instead.
     |
     */
 
-    'ensure_pages_exist' => false,
+    'pages' => [
 
-    'page_paths' => [
+        'ensure_pages_exist' => false,
 
-        resource_path('js/Pages'),
-
-    ],
-
-    'page_extensions' => [
-
-        'js',
-        'jsx',
-        'svelte',
-        'ts',
-        'tsx',
-        'vue',
-
-    ],
-
-    'use_script_element_for_initial_page' => (bool) env('INERTIA_USE_SCRIPT_ELEMENT_FOR_INITIAL_PAGE', false),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Testing
-    |--------------------------------------------------------------------------
-    |
-    | The values described here are used to locate Inertia components on the
-    | filesystem. For instance, when using `assertInertia`, the assertion
-    | attempts to locate the component as a file relative to any of the
-    | paths AND with any of the extensions specified here.
-    |
-    | Note: In a future release, the `page_paths` and `page_extensions`
-    | options below will be removed. The root-level options above
-    | will be used for both application and testing purposes.
-    |
-    */
-
-    'testing' => [
-
-        'ensure_pages_exist' => true,
-
-        'page_paths' => [
+        'paths' => [
 
             resource_path('js/Pages'),
 
         ],
 
-        'page_extensions' => [
+        'extensions' => [
 
             'js',
             'jsx',
@@ -103,7 +70,41 @@ return [
 
         ],
 
+        'use_data_attribute_for_initial_page' => (bool) env('INERTIA_USE_DATA_ATTRIBUTE_FOR_INITIAL_PAGE', false),
+
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Testing
+    |--------------------------------------------------------------------------
+    |
+    | When using `assertInertia`, the assertion attempts to locate the
+    | component as a file relative to the `pages.paths` AND with any of
+    | the `pages.extensions` specified above.
+    |
+    | You can disable this behavior by setting `ensure_pages_exist`
+    | to false.
+    |
+    */
+
+    'testing' => [
+
+        'ensure_pages_exist' => true,
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | History
+    |--------------------------------------------------------------------------
+    |
+    | Enable `encrypt` to encrypt page data before it is stored in the
+    | browser's history state, preventing sensitive information from
+    | being accessible after logout. Can also be enabled per-request
+    | or via the `inertia.encrypt` middleware.
+    |
+    */
 
     'history' => [
 

--- a/src/Directive.php
+++ b/src/Directive.php
@@ -23,10 +23,10 @@ class Directive
 
             if ($__inertiaSsrResponse) {
                 echo $__inertiaSsrResponse->body;
-            } elseif (config(\'inertia.use_script_element_for_initial_page\')) {
-                ?><script data-page="'.$id.'" type="application/json">{!! json_encode($page) !!}</script><div id="'.$id.'"></div><?php
-            } else {
+            } elseif (config(\'inertia.pages.use_data_attribute_for_initial_page\')) {
                 ?><div id="'.$id.'" data-page="{{ json_encode($page) }}"></div><?php
+            } else {
+                ?><script data-page="'.$id.'" type="application/json">{!! json_encode($page) !!}</script><div id="'.$id.'"></div><?php
             }
         ?>';
 

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -281,7 +281,7 @@ class ResponseFactory
             throw new InvalidArgumentException('Component argument must be of type string or a string BackedEnum');
         }
 
-        if (config('inertia.ensure_pages_exist', false)) {
+        if (config('inertia.pages.ensure_pages_exist', false)) {
             $this->findComponentOrFail($component);
         }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -39,16 +39,8 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->bind('inertia.view-finder', function ($app) {
             return new FileViewFinder(
                 $app['files'],
-                $app['config']->get('inertia.page_paths'),
-                $app['config']->get('inertia.page_extensions')
-            );
-        });
-
-        $this->app->bind('inertia.testing.view-finder', function ($app) {
-            return new FileViewFinder(
-                $app['files'],
-                $app['config']->get('inertia.testing.page_paths'),
-                $app['config']->get('inertia.testing.page_extensions')
+                $app['config']->get('inertia.pages.paths'),
+                $app['config']->get('inertia.pages.extensions')
             );
         });
     }

--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -107,7 +107,7 @@ class AssertableInertia extends AssertableJson
 
         if ($shouldExist || (is_null($shouldExist) && config('inertia.testing.ensure_pages_exist', true))) {
             try {
-                app('inertia.testing.view-finder')->find($value);
+                app('inertia.view-finder')->find($value);
             } catch (InvalidArgumentException $exception) {
                 PHPUnit::fail(sprintf('Inertia page component file [%s] does not exist.', $value));
             }

--- a/tests/DirectiveTest.php
+++ b/tests/DirectiveTest.php
@@ -55,7 +55,7 @@ class DirectiveTest extends TestCase
     {
         Config::set(['inertia.ssr.enabled' => false]);
 
-        $html = '<div id="app" data-page="{&quot;component&quot;:&quot;Foo\/Bar&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;},&quot;url&quot;:&quot;\/test&quot;,&quot;version&quot;:&quot;&quot;,&quot;encryptHistory&quot;:false,&quot;clearHistory&quot;:false}"></div>';
+        $html = '<script data-page="app" type="application/json">{"component":"Foo\/Bar","props":{"foo":"bar"},"url":"\/test","version":"","encryptHistory":false,"clearHistory":false}</script><div id="app"></div>';
 
         $this->assertSame($html, $this->renderView('@inertia', ['page' => self::EXAMPLE_PAGE_OBJECT]));
         $this->assertSame($html, $this->renderView('@inertia()', ['page' => self::EXAMPLE_PAGE_OBJECT]));
@@ -63,14 +63,14 @@ class DirectiveTest extends TestCase
         $this->assertSame($html, $this->renderView("@inertia('')", ['page' => self::EXAMPLE_PAGE_OBJECT]));
     }
 
-    public function test_inertia_directive_renders_the_root_element_and_script_element(): void
+    public function test_inertia_directive_renders_the_root_element_with_data_attribute(): void
     {
         Config::set([
             'inertia.ssr.enabled' => false,
-            'inertia.use_script_element_for_initial_page' => true,
+            'inertia.pages.use_data_attribute_for_initial_page' => true,
         ]);
 
-        $html = '<script data-page="app" type="application/json">{"component":"Foo\/Bar","props":{"foo":"bar"},"url":"\/test","version":"","encryptHistory":false,"clearHistory":false}</script><div id="app"></div>';
+        $html = '<div id="app" data-page="{&quot;component&quot;:&quot;Foo\/Bar&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;},&quot;url&quot;:&quot;\/test&quot;,&quot;version&quot;:&quot;&quot;,&quot;encryptHistory&quot;:false,&quot;clearHistory&quot;:false}"></div>';
 
         $this->assertSame($html, $this->renderView('@inertia', ['page' => self::EXAMPLE_PAGE_OBJECT]));
         $this->assertSame($html, $this->renderView('@inertia()', ['page' => self::EXAMPLE_PAGE_OBJECT]));
@@ -92,21 +92,21 @@ class DirectiveTest extends TestCase
     {
         Config::set(['inertia.ssr.enabled' => false]);
 
-        $html = '<div id="foo" data-page="{&quot;component&quot;:&quot;Foo\/Bar&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;},&quot;url&quot;:&quot;\/test&quot;,&quot;version&quot;:&quot;&quot;,&quot;encryptHistory&quot;:false,&quot;clearHistory&quot;:false}"></div>';
+        $html = '<script data-page="foo" type="application/json">{"component":"Foo\/Bar","props":{"foo":"bar"},"url":"\/test","version":"","encryptHistory":false,"clearHistory":false}</script><div id="foo"></div>';
 
         $this->assertSame($html, $this->renderView('@inertia(foo)', ['page' => self::EXAMPLE_PAGE_OBJECT]));
         $this->assertSame($html, $this->renderView("@inertia('foo')", ['page' => self::EXAMPLE_PAGE_OBJECT]));
         $this->assertSame($html, $this->renderView('@inertia("foo")', ['page' => self::EXAMPLE_PAGE_OBJECT]));
     }
 
-    public function test_inertia_directive_can_use_a_different_root_element_id_when_using_script_element(): void
+    public function test_inertia_directive_can_use_a_different_root_element_id_when_using_data_attribute(): void
     {
         Config::set([
             'inertia.ssr.enabled' => false,
-            'inertia.use_script_element_for_initial_page' => true,
+            'inertia.pages.use_data_attribute_for_initial_page' => true,
         ]);
 
-        $html = '<script data-page="foo" type="application/json">{"component":"Foo\/Bar","props":{"foo":"bar"},"url":"\/test","version":"","encryptHistory":false,"clearHistory":false}</script><div id="foo"></div>';
+        $html = '<div id="foo" data-page="{&quot;component&quot;:&quot;Foo\/Bar&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;},&quot;url&quot;:&quot;\/test&quot;,&quot;version&quot;:&quot;&quot;,&quot;encryptHistory&quot;:false,&quot;clearHistory&quot;:false}"></div>';
 
         $this->assertSame($html, $this->renderView('@inertia(foo)', ['page' => self::EXAMPLE_PAGE_OBJECT]));
         $this->assertSame($html, $this->renderView("@inertia('foo')", ['page' => self::EXAMPLE_PAGE_OBJECT]));

--- a/tests/HistoryTest.php
+++ b/tests/HistoryTest.php
@@ -160,6 +160,6 @@ class HistoryTest extends TestCase
         ]);
 
         $response->assertSuccessful();
-        $response->assertContent('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;errors&quot;:{}},&quot;url&quot;:&quot;\/users&quot;,&quot;version&quot;:&quot;&quot;,&quot;clearHistory&quot;:true,&quot;encryptHistory&quot;:false}"></div>');
+        $response->assertContent('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"errors":{}},"url":"\/users","version":"","clearHistory":true,"encryptHistory":false}</script><div id="app"></div>');
     }
 }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -518,7 +518,7 @@ class ResponseFactoryTest extends TestCase
 
     public function test_will_throw_exception_if_component_does_not_exist_when_ensuring_is_enabled(): void
     {
-        config()->set('inertia.ensure_pages_exist', true);
+        config()->set('inertia.pages.ensure_pages_exist', true);
 
         $this->expectException(ComponentNotFoundException::class);
         $this->expectExceptionMessage('Inertia page component [foo] not found.');
@@ -528,7 +528,7 @@ class ResponseFactoryTest extends TestCase
 
     public function test_will_not_throw_exception_if_component_does_not_exist_when_ensuring_is_disabled(): void
     {
-        config()->set('inertia.ensure_pages_exist', false);
+        config()->set('inertia.pages.ensure_pages_exist', false);
 
         $response = (new ResponseFactory)->render('foo');
         $this->assertInstanceOf(\Inertia\Response::class, $response);

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -59,7 +59,7 @@ class ResponseTest extends TestCase
         $this->assertSame('123', $page['version']);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_deferred_prop(): void
@@ -95,7 +95,7 @@ class ResponseTest extends TestCase
         ], $page['deferredProps']);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deferredProps&quot;:{&quot;default&quot;:[&quot;foo&quot;]}}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo"]}}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_deferred_prop_and_multiple_groups(): void
@@ -138,7 +138,7 @@ class ResponseTest extends TestCase
         ], $page['deferredProps']);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deferredProps&quot;:{&quot;default&quot;:[&quot;foo&quot;,&quot;bar&quot;],&quot;custom&quot;:[&quot;baz&quot;]}}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo","bar"],"custom":["baz"]}}</script><div id="app"></div>', $view->render());
     }
 
     /**
@@ -246,7 +246,7 @@ class ResponseTest extends TestCase
         ], $page['mergeProps']);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:&quot;foo value&quot;,&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;mergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;]}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_merge_props_that_should_prepend(): void
@@ -280,7 +280,7 @@ class ResponseTest extends TestCase
         $this->assertSame(['foo'], $page['prependProps']);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:&quot;foo value&quot;,&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;mergeProps&quot;:[&quot;bar&quot;],&quot;prependProps&quot;:[&quot;foo&quot;]}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["bar"],"prependProps":["foo"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_merge_props_that_has_nested_paths_to_append_and_prepend(): void
@@ -315,7 +315,7 @@ class ResponseTest extends TestCase
         $this->assertArrayNotHasKey('matchPropsOn', $page);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:{&quot;data&quot;:[{&quot;id&quot;:1},{&quot;id&quot;:2}]},&quot;bar&quot;:{&quot;data&quot;:{&quot;items&quot;:[{&quot;uuid&quot;:1},{&quot;uuid&quot;:2}]}}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;mergeProps&quot;:[&quot;foo.data&quot;],&quot;prependProps&quot;:[&quot;bar.data.items&quot;]}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":{"data":[{"id":1},{"id":2}]},"bar":{"data":{"items":[{"uuid":1},{"uuid":2}]}}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo.data"],"prependProps":["bar.data.items"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_merge_props_that_has_nested_paths_to_append_and_prepend_with_match_on_strategies(): void
@@ -350,7 +350,7 @@ class ResponseTest extends TestCase
         $this->assertSame(['foo.data.id', 'bar.data.items.uuid'], $page['matchPropsOn']);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:{&quot;data&quot;:[{&quot;id&quot;:1},{&quot;id&quot;:2}]},&quot;bar&quot;:{&quot;data&quot;:{&quot;items&quot;:[{&quot;uuid&quot;:1},{&quot;uuid&quot;:2}]}}},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;mergeProps&quot;:[&quot;foo.data&quot;],&quot;prependProps&quot;:[&quot;bar.data.items&quot;],&quot;matchPropsOn&quot;:[&quot;foo.data.id&quot;,&quot;bar.data.items.uuid&quot;]}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":{"data":[{"id":1},{"id":2}]},"bar":{"data":{"items":[{"uuid":1},{"uuid":2}]}}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo.data"],"prependProps":["bar.data.items"],"matchPropsOn":["foo.data.id","bar.data.items.uuid"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_deep_merge_props(): void
@@ -386,7 +386,7 @@ class ResponseTest extends TestCase
         ], $page['deepMergeProps']);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:&quot;foo value&quot;,&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deepMergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;]}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_match_on_props(): void
@@ -427,7 +427,7 @@ class ResponseTest extends TestCase
         ], $page['matchPropsOn']);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;foo&quot;:&quot;foo value&quot;,&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deepMergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;],&quot;matchPropsOn&quot;:[&quot;foo.foo-key&quot;,&quot;bar.bar-key&quot;]}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"matchPropsOn":["foo.foo-key","bar.bar-key"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_defer_and_merge_props(): void
@@ -468,7 +468,7 @@ class ResponseTest extends TestCase
         ], $page['mergeProps']);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;mergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;],&quot;deferredProps&quot;:{&quot;default&quot;:[&quot;foo&quot;]}}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_defer_and_deep_merge_props(): void
@@ -509,7 +509,7 @@ class ResponseTest extends TestCase
         ], $page['deepMergeProps']);
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;user&quot;:{&quot;name&quot;:&quot;Jonathan&quot;},&quot;bar&quot;:&quot;bar value&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;deepMergeProps&quot;:[&quot;foo&quot;,&quot;bar&quot;],&quot;deferredProps&quot;:{&quot;default&quot;:[&quot;foo&quot;]}}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}</script><div id="app"></div>', $view->render());
     }
 
     public function test_exclude_merge_props_from_partial_only_response(): void
@@ -1259,7 +1259,7 @@ class ResponseTest extends TestCase
         $this->assertFalse($page['clearHistory']);
         $this->assertFalse($page['encryptHistory']);
         $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
-        $this->assertSame('<div id="app" data-page="{&quot;component&quot;:&quot;User\/Edit&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;},&quot;url&quot;:&quot;\/user\/123&quot;,&quot;version&quot;:&quot;123&quot;,&quot;clearHistory&quot;:false,&quot;encryptHistory&quot;:false,&quot;onceProps&quot;:{&quot;foo&quot;:{&quot;prop&quot;:&quot;foo&quot;,&quot;expiresAt&quot;:null}}}"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"foo":"bar"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"onceProps":{"foo":{"prop":"foo","expiresAt":null}}}</script><div id="app"></div>', $view->render());
     }
 
     public function test_fresh_once_props_are_included_on_initial_page_load(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,7 +31,7 @@ abstract class TestCase extends Orchestra
 
         Inertia::setRootView('welcome');
         config()->set('inertia.testing.ensure_pages_exist', false);
-        config()->set('inertia.testing.page_paths', [realpath(__DIR__)]);
+        config()->set('inertia.pages.paths', [realpath(__DIR__)]);
     }
 
     /**

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -119,7 +119,7 @@ class AssertableInertiaTest extends TestCase
         );
 
         config()->set('inertia.testing.ensure_pages_exist', true);
-        config()->set('inertia.testing.page_paths', [realpath(__DIR__)]);
+        config()->set('inertia.pages.paths', [realpath(__DIR__)]);
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Inertia page component file [fixtures/ExamplePage] does not exist.');
 
@@ -135,7 +135,7 @@ class AssertableInertiaTest extends TestCase
         );
 
         config()->set('inertia.testing.ensure_pages_exist', true);
-        config()->set('inertia.testing.page_extensions', ['bin', 'exe', 'svg']);
+        config()->set('inertia.pages.extensions', ['bin', 'exe', 'svg']);
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Inertia page component file [fixtures/ExamplePage] does not exist.');
 


### PR DESCRIPTION
This PR cleans up the config file for 3.x.

- Renames `use_script_element_for_initial_page` to `use_data_attribute_for_initial_page` and flips the default so the script element approach is the default (opt-in for data attribute).
- Nests page-related options (`ensure_pages_exist`, `paths`, `extensions`, `use_data_attribute_for_initial_page`) under a pages key.
- Removes the duplicate `page_paths` and `page_extensions` from the testing section, reusing the pages config for both application and testing purposes.
