### PR TITLE
[3.x] Remove `pages.use_data_attribute_for_initial_page` config

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -59,10 +59,6 @@ return [
     | The `paths` and `extensions` options define where to look for page
     | components and which file extensions to consider.
     |
-    | By default, the initial page data is passed via a script element.
-    | Set `use_data_attribute_for_initial_page` to true to use a data
-    | attribute on the root element instead.
-    |
     */
 
     'pages' => [
@@ -85,8 +81,6 @@ return [
             'vue',
 
         ],
-
-        'use_data_attribute_for_initial_page' => (bool) env('INERTIA_USE_DATA_ATTRIBUTE_FOR_INITIAL_PAGE', false),
 
     ],
 

--- a/src/Directive.php
+++ b/src/Directive.php
@@ -23,8 +23,6 @@ class Directive
 
             if ($__inertiaSsrResponse) {
                 echo $__inertiaSsrResponse->body;
-            } elseif (config(\'inertia.pages.use_data_attribute_for_initial_page\')) {
-                ?><div id="'.$id.'" data-page="{{ json_encode($page) }}"></div><?php
             } else {
                 ?><script data-page="'.$id.'" type="application/json">{!! json_encode($page) !!}</script><div id="'.$id.'"></div><?php
             }

--- a/tests/DirectiveTest.php
+++ b/tests/DirectiveTest.php
@@ -63,21 +63,6 @@ class DirectiveTest extends TestCase
         $this->assertSame($html, $this->renderView("@inertia('')", ['page' => self::EXAMPLE_PAGE_OBJECT]));
     }
 
-    public function test_inertia_directive_renders_the_root_element_with_data_attribute(): void
-    {
-        Config::set([
-            'inertia.ssr.enabled' => false,
-            'inertia.pages.use_data_attribute_for_initial_page' => true,
-        ]);
-
-        $html = '<div id="app" data-page="{&quot;component&quot;:&quot;Foo\/Bar&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;},&quot;url&quot;:&quot;\/test&quot;,&quot;version&quot;:&quot;&quot;,&quot;encryptHistory&quot;:false,&quot;clearHistory&quot;:false}"></div>';
-
-        $this->assertSame($html, $this->renderView('@inertia', ['page' => self::EXAMPLE_PAGE_OBJECT]));
-        $this->assertSame($html, $this->renderView('@inertia()', ['page' => self::EXAMPLE_PAGE_OBJECT]));
-        $this->assertSame($html, $this->renderView('@inertia("")', ['page' => self::EXAMPLE_PAGE_OBJECT]));
-        $this->assertSame($html, $this->renderView("@inertia('')", ['page' => self::EXAMPLE_PAGE_OBJECT]));
-    }
-
     public function test_inertia_directive_renders_server_side_rendered_content_when_enabled(): void
     {
         Config::set(['inertia.ssr.enabled' => true]);
@@ -93,20 +78,6 @@ class DirectiveTest extends TestCase
         Config::set(['inertia.ssr.enabled' => false]);
 
         $html = '<script data-page="foo" type="application/json">{"component":"Foo\/Bar","props":{"foo":"bar"},"url":"\/test","version":"","encryptHistory":false,"clearHistory":false}</script><div id="foo"></div>';
-
-        $this->assertSame($html, $this->renderView('@inertia(foo)', ['page' => self::EXAMPLE_PAGE_OBJECT]));
-        $this->assertSame($html, $this->renderView("@inertia('foo')", ['page' => self::EXAMPLE_PAGE_OBJECT]));
-        $this->assertSame($html, $this->renderView('@inertia("foo")', ['page' => self::EXAMPLE_PAGE_OBJECT]));
-    }
-
-    public function test_inertia_directive_can_use_a_different_root_element_id_when_using_data_attribute(): void
-    {
-        Config::set([
-            'inertia.ssr.enabled' => false,
-            'inertia.pages.use_data_attribute_for_initial_page' => true,
-        ]);
-
-        $html = '<div id="foo" data-page="{&quot;component&quot;:&quot;Foo\/Bar&quot;,&quot;props&quot;:{&quot;foo&quot;:&quot;bar&quot;},&quot;url&quot;:&quot;\/test&quot;,&quot;version&quot;:&quot;&quot;,&quot;encryptHistory&quot;:false,&quot;clearHistory&quot;:false}"></div>';
 
         $this->assertSame($html, $this->renderView('@inertia(foo)', ['page' => self::EXAMPLE_PAGE_OBJECT]));
         $this->assertSame($html, $this->renderView("@inertia('foo')", ['page' => self::EXAMPLE_PAGE_OBJECT]));


### PR DESCRIPTION
This removes the `pages.use_data_attribute_for_initial_page` config option, which allowed passing the initial page data via a `data-page` attribute on the root element instead of the default `<script>` tag.