### PR TITLE
[2.x] Add `assertInertiaFlash` and `assertInertiaFlashMissing` test response macros

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,8 @@ parameters:
 		- src/Testing/Concerns
 	ignoreErrors:
 		- '#Call to an undefined method.*TestResponse.*::assertInertia\(\)#'
+		- '#Call to an undefined method.*TestResponse.*::assertInertiaFlash\(\)#'
+		- '#Call to an undefined method.*TestResponse.*::assertInertiaFlashMissing\(\)#'
 		- '#Call to an undefined method.*TestResponse.*::inertiaPage\(\)#'
 		- '#Call to an undefined method.*TestResponse.*::inertiaProps\(\)#'
 		- '#Call to an undefined.*method.*Request::inertia\(\)#'

--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -233,18 +233,9 @@ class AssertableInertia extends AssertableJson
      */
     public function hasFlash(string $key, mixed $expected = null): self
     {
-        PHPUnit::assertTrue(
-            Arr::has($this->flash, $key),
-            sprintf('Inertia Flash Data is missing key [%s].', $key)
-        );
-
-        if (func_num_args() > 1) {
-            PHPUnit::assertSame(
-                $expected,
-                Arr::get($this->flash, $key),
-                sprintf('Inertia Flash Data [%s] does not match expected value.', $key)
-            );
-        }
+        func_num_args() > 1
+            ? static::assertFlashHas($this->flash, $key, $expected)
+            : static::assertFlashHas($this->flash, $key);
 
         return $this;
     }
@@ -254,12 +245,43 @@ class AssertableInertia extends AssertableJson
      */
     public function missingFlash(string $key): self
     {
-        PHPUnit::assertFalse(
-            Arr::has($this->flash, $key),
-            sprintf('Inertia Flash Data has unexpected key [%s].', $key)
-        );
+        static::assertFlashMissing($this->flash, $key);
 
         return $this;
+    }
+
+    /**
+     * Assert that the given flash data array contains the given key, optionally with the expected value.
+     *
+     * @param  array<string, mixed>  $flash
+     */
+    public static function assertFlashHas(array $flash, string $key, mixed $expected = null): void
+    {
+        PHPUnit::assertTrue(
+            Arr::has($flash, $key),
+            sprintf('Inertia Flash Data is missing key [%s].', $key)
+        );
+
+        if (func_num_args() > 2) {
+            PHPUnit::assertSame(
+                $expected,
+                Arr::get($flash, $key),
+                sprintf('Inertia Flash Data [%s] does not match expected value.', $key)
+            );
+        }
+    }
+
+    /**
+     * Assert that the given flash data array does not contain the given key.
+     *
+     * @param  array<string, mixed>  $flash
+     */
+    public static function assertFlashMissing(array $flash, string $key): void
+    {
+        PHPUnit::assertFalse(
+            Arr::has($flash, $key),
+            sprintf('Inertia Flash Data has unexpected key [%s].', $key)
+        );
     }
 
     /**

--- a/src/Testing/TestResponseMacros.php
+++ b/src/Testing/TestResponseMacros.php
@@ -4,6 +4,7 @@ namespace Inertia\Testing;
 
 use Closure;
 use Illuminate\Support\Arr;
+use Inertia\SessionKey;
 
 class TestResponseMacros
 {
@@ -53,6 +54,42 @@ class TestResponseMacros
             $page = AssertableInertia::fromTestResponse($this)->toArray();
 
             return Arr::get($page['props'], $propName);
+        };
+    }
+
+    /**
+     * Register the 'assertInertiaFlash' macro for TestResponse.
+     *
+     * @return Closure
+     */
+    public function assertInertiaFlash()
+    {
+        return function (string $key, mixed $expected = null) {
+            /** @phpstan-ignore-next-line */
+            $flash = $this->session()->get(SessionKey::FlashData->value, []);
+
+            func_num_args() > 1
+                ? AssertableInertia::assertFlashHas($flash, $key, $expected)
+                : AssertableInertia::assertFlashHas($flash, $key);
+
+            return $this;
+        };
+    }
+
+    /**
+     * Register the 'assertInertiaFlashMissing' macro for TestResponse.
+     *
+     * @return Closure
+     */
+    public function assertInertiaFlashMissing()
+    {
+        return function (string $key) {
+            /** @phpstan-ignore-next-line */
+            $flash = $this->session()->get(SessionKey::FlashData->value, []);
+
+            AssertableInertia::assertFlashMissing($flash, $key);
+
+            return $this;
         };
     }
 }

--- a/tests/Testing/TestResponseMacrosTest.php
+++ b/tests/Testing/TestResponseMacrosTest.php
@@ -2,10 +2,14 @@
 
 namespace Inertia\Tests\Testing;
 
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Illuminate\Testing\TestResponse;
 use Inertia\Inertia;
+use Inertia\Middleware;
 use Inertia\Tests\TestCase;
+use PHPUnit\Framework\AssertionFailedError;
 
 class TestResponseMacrosTest extends TestCase
 {
@@ -76,5 +80,67 @@ class TestResponseMacrosTest extends TestCase
 
         $this->assertSame('qux', $response->inertiaProps('bar.baz'));
         $this->assertSame('John', $response->inertiaProps('users.0.name'));
+    }
+
+    public function test_it_can_assert_flash_data_on_redirect_responses(): void
+    {
+        $middleware = [StartSession::class, Middleware::class];
+
+        Route::middleware($middleware)->post('/users', function () {
+            return Inertia::flash([
+                'message' => 'User created!',
+                'notification' => ['type' => 'success'],
+            ])->back();
+        });
+
+        $this->post('/users')
+            ->assertRedirect()
+            ->assertInertiaFlash('message')
+            ->assertInertiaFlash('message', 'User created!')
+            ->assertInertiaFlash('notification.type', 'success')
+            ->assertInertiaFlashMissing('error')
+            ->assertInertiaFlashMissing('notification.other');
+    }
+
+    public function test_assert_has_inertia_flash_fails_when_key_is_missing(): void
+    {
+        $middleware = [StartSession::class, Middleware::class];
+
+        Route::middleware($middleware)->post('/users', function () {
+            return Inertia::flash('message', 'Hello')->back();
+        });
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia Flash Data is missing key [other].');
+
+        $this->post('/users')->assertInertiaFlash('other');
+    }
+
+    public function test_assert_has_inertia_flash_fails_when_value_does_not_match(): void
+    {
+        $middleware = [StartSession::class, Middleware::class];
+
+        Route::middleware($middleware)->post('/users', function () {
+            return Inertia::flash('message', 'Hello')->back();
+        });
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia Flash Data [message] does not match expected value.');
+
+        $this->post('/users')->assertInertiaFlash('message', 'Different');
+    }
+
+    public function test_assert_missing_inertia_flash_fails_when_key_exists(): void
+    {
+        $middleware = [StartSession::class, Middleware::class];
+
+        Route::middleware($middleware)->post('/users', function () {
+            return Inertia::flash('message', 'Hello')->back();
+        });
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Inertia Flash Data has unexpected key [message].');
+
+        $this->post('/users')->assertInertiaFlashMissing('message');
     }
 }


### PR DESCRIPTION
The existing `hasFlash()` and `missingFlash()` assertions on `AssertableInertia` only work on rendered Inertia page responses. On redirects (`Inertia::flash()->back()`), `assertInertia()` can't be used since there's no rendered page.

This PR adds `assertInertiaFlash()` and `assertInertiaFlashMissing()` macros directly on `TestResponse`, which assert against the session.

```php
$response = $this->post('/users');

$response->assertRedirect('/dashboard')
    ->assertInertiaFlash('message')
    ->assertInertiaFlash('message', 'User created!')
    ->assertInertiaFlash('notification.type', 'success')
    ->assertInertiaFlashMissing('error');
```

Fixes #825