### PR TITLE
[3.x] Expose shared prop keys in page response

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -106,6 +106,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Expose Shared Prop Keys
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, each page response includes a `sharedProps` metadata key
+    | listing the top-level prop keys that were registered via `Inertia::share`.
+    | The frontend can use this to carry shared props over during instant visits.
+    |
+    */
+
+    'expose_shared_prop_keys' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | History
     |--------------------------------------------------------------------------
     |

--- a/src/PropsResolver.php
+++ b/src/PropsResolver.php
@@ -121,6 +121,13 @@ class PropsResolver
     protected $onceProps = [];
 
     /**
+     * The top-level keys of shared props.
+     *
+     * @var array<int, string>
+     */
+    protected $sharedPropKeys = [];
+
+    /**
      * Create a new props resolver instance.
      */
     public function __construct(Request $request, string $component)
@@ -137,17 +144,45 @@ class PropsResolver
     }
 
     /**
-     * Resolve the given props and collect their metadata.
+     * Resolve the given shared and page props, collecting their metadata.
      *
-     * @param  array<array-key, mixed>  $props
+     * @param  array<array-key, mixed|\Inertia\ProvidesInertiaProperties>  $shared
+     * @param  array<array-key, mixed|\Inertia\ProvidesInertiaProperties>  $props
      * @return array{array<string, mixed>, array<string, mixed>}
      */
-    public function resolve(array $props): array
+    public function resolve(array $shared, array $props): array
     {
+        $props = array_merge($this->resolveSharedProps($shared), $props);
+
         return [
             $this->resolveProps($this->unpackDotProps($props)),
             $this->buildMetadata(),
         ];
+    }
+
+    /**
+     * Resolve shared property providers and collect shared prop keys.
+     *
+     * @param  array<array-key, mixed|\Inertia\ProvidesInertiaProperties>  $shared
+     * @return array<string, mixed>
+     */
+    protected function resolveSharedProps(array $shared): array
+    {
+        $resolved = $this->resolvePropertyProviders($shared);
+
+        if (! config('inertia.expose_shared_prop_keys', true)) {
+            return $resolved;
+        }
+
+        foreach (array_keys($resolved) as $key) {
+            $this->sharedPropKeys[] = str_contains((string) $key, '.')
+                ? strstr((string) $key, '.', true)
+                : (string) $key;
+        }
+
+        $this->sharedPropKeys = array_values(array_unique($this->sharedPropKeys));
+
+        return $resolved;
     }
 
     /**
@@ -184,6 +219,7 @@ class PropsResolver
     protected function buildMetadata(): array
     {
         return array_filter([
+            'sharedProps' => $this->sharedPropKeys,
             'mergeProps' => $this->mergeProps,
             'prependProps' => $this->prependProps,
             'deepMergeProps' => $this->deepMergeProps,

--- a/src/Response.php
+++ b/src/Response.php
@@ -81,19 +81,29 @@ class Response implements Responsable
     protected ?Closure $urlResolver = null;
 
     /**
+     * The shared properties (before merge with page props).
+     *
+     * @var array<array-key, mixed|\Inertia\ProvidesInertiaProperties>
+     */
+    protected array $sharedProps = [];
+
+    /**
      * Create a new Inertia response instance.
      *
+     * @param  array<array-key, mixed|\Inertia\ProvidesInertiaProperties>  $sharedProps
      * @param  array<array-key, mixed|\Inertia\ProvidesInertiaProperties>  $props
      */
     public function __construct(
         string $component,
+        array $sharedProps,
         array $props,
         string $rootView = 'app',
         string $version = '',
         bool $encryptHistory = false,
-        ?Closure $urlResolver = null
+        ?Closure $urlResolver = null,
     ) {
         $this->component = $component;
+        $this->sharedProps = $sharedProps;
         $this->props = $props;
         $this->rootView = $rootView;
         $this->version = $version;
@@ -175,7 +185,7 @@ class Response implements Responsable
     public function toResponse($request)
     {
         $resolver = new PropsResolver($request, $this->component);
-        [$resolvedProps, $resolvedMetadata] = $resolver->resolve($this->props);
+        [$resolvedProps, $resolvedMetadata] = $resolver->resolve($this->sharedProps, $this->props);
 
         $page = array_merge(
             [

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -324,7 +324,8 @@ class ResponseFactory
 
         return new Response(
             $component,
-            array_merge($this->sharedProps, $props),
+            $this->sharedProps,
+            $props,
             $this->rootView,
             $this->getVersion(),
             $this->encryptHistory ?? config('inertia.history.encrypt', false),

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -30,6 +30,7 @@ class ControllerTest extends TestCase
             'version' => '',
             'encryptHistory' => false,
             'clearHistory' => false,
+            'sharedProps' => ['errors'],
         ]);
     }
 }

--- a/tests/HistoryTest.php
+++ b/tests/HistoryTest.php
@@ -160,7 +160,7 @@ class HistoryTest extends TestCase
         ]);
 
         $response->assertSuccessful();
-        $response->assertContent('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"errors":{}},"url":"\/users","version":"","clearHistory":true,"encryptHistory":false}</script><div id="app"></div>');
+        $response->assertContent('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"errors":{}},"url":"\/users","version":"","clearHistory":true,"encryptHistory":false,"sharedProps":["errors"]}</script><div id="app"></div>');
     }
 
     public function test_the_fragment_is_not_preserved_by_default(): void

--- a/tests/PropsResolverTest.php
+++ b/tests/PropsResolverTest.php
@@ -935,7 +935,7 @@ class PropsResolverTest extends TestCase
      */
     protected function makePage(Request $request, array $props): array
     {
-        $response = new Response('TestComponent', $props, 'app', '123');
+        $response = new Response('TestComponent', [], $props, 'app', '123');
         $response = $response->toResponse($request);
 
         if ($response instanceof JsonResponse) {

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -735,6 +735,211 @@ class ResponseFactoryTest extends TestCase
         ]);
     }
 
+    public function test_shared_props_tracking_can_be_disabled(): void
+    {
+        config()->set('inertia.expose_shared_prop_keys', false);
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::share('app_name', 'My App');
+
+            return Inertia::render('User/Edit');
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $data = $response->json();
+        $this->assertArrayNotHasKey('sharedProps', $data);
+        $this->assertSame('My App', $data['props']['app_name']);
+    }
+
+    public function test_shared_props_metadata_includes_keys_from_middleware_share(): void
+    {
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            return Inertia::render('User/Edit', [
+                'user' => ['name' => 'Jonathan'],
+            ]);
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'component' => 'User/Edit',
+            'props' => [
+                'user' => ['name' => 'Jonathan'],
+            ],
+            'sharedProps' => ['errors'],
+        ]);
+    }
+
+    public function test_shared_props_metadata_includes_keys_from_inertia_share(): void
+    {
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::share('app_name', 'My App');
+
+            return Inertia::render('User/Edit');
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'sharedProps' => ['errors', 'app_name'],
+        ]);
+    }
+
+    public function test_shared_props_metadata_includes_dot_notation_keys_as_top_level(): void
+    {
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::share('auth.user', ['name' => 'Jonathan']);
+
+            return Inertia::render('User/Edit');
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'sharedProps' => ['errors', 'auth'],
+        ]);
+    }
+
+    public function test_shared_props_metadata_includes_keys_from_share_once(): void
+    {
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::shareOnce('permissions', fn () => ['admin' => true]);
+
+            return Inertia::render('User/Edit');
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'props' => [
+                'permissions' => ['admin' => true],
+            ],
+            'sharedProps' => ['errors', 'permissions'],
+        ]);
+    }
+
+    public function test_shared_props_metadata_includes_keys_from_provides_inertia_properties(): void
+    {
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::share(new ExampleInertiaPropsProvider([
+                'app_name' => 'My App',
+                'locale' => 'en',
+            ]));
+
+            return Inertia::render('User/Edit');
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'props' => [
+                'app_name' => 'My App',
+                'locale' => 'en',
+            ],
+            'sharedProps' => ['errors', 'app_name', 'locale'],
+        ]);
+    }
+
+    public function test_shared_props_metadata_includes_page_specific_override_keys(): void
+    {
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::share('auth', ['user' => null]);
+
+            return Inertia::render('User/Edit', [
+                'auth' => ['user' => ['name' => 'Jonathan']],
+            ]);
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'props' => [
+                'auth' => ['user' => ['name' => 'Jonathan']],
+            ],
+            'sharedProps' => ['errors', 'auth'],
+        ]);
+    }
+
+    public function test_shared_props_metadata_with_multiple_share_calls(): void
+    {
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::share('app_name', 'My App');
+            Inertia::share('locale', 'en');
+            Inertia::shareOnce('permissions', fn () => ['admin' => true]);
+
+            return Inertia::render('User/Edit');
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'sharedProps' => ['errors', 'app_name', 'locale', 'permissions'],
+        ]);
+    }
+
+    public function test_shared_props_metadata_with_array_share(): void
+    {
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::share([
+                'flash' => fn () => ['message' => 'Hello'],
+                'auth' => fn () => ['user' => ['name' => 'Jonathan']],
+            ]);
+
+            return Inertia::render('User/Edit');
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'sharedProps' => ['errors', 'flash', 'auth'],
+        ]);
+    }
+
+    public function test_shared_props_metadata_includes_already_loaded_once_props(): void
+    {
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::shareOnce('permissions', fn () => ['admin' => true]);
+
+            return Inertia::render('User/Edit');
+        });
+
+        $response = $this->withoutExceptionHandling()->get('/', [
+            'X-Inertia' => 'true',
+            'X-Inertia-Except-Once-Props' => 'permissions',
+        ]);
+
+        $response->assertSuccessful();
+        $data = $response->json();
+
+        // The once-prop value should be excluded from props since the client already has it
+        $this->assertArrayNotHasKey('permissions', $data['props']);
+
+        // But its key should still appear in the sharedProps metadata
+        $this->assertContains('permissions', $data['sharedProps']);
+
+        // And its onceProps metadata should also be preserved
+        $this->assertArrayHasKey('permissions', $data['onceProps']);
+    }
+
     public function test_without_ssr_registers_paths_with_gateway(): void
     {
         Inertia::withoutSsr(['admin/*', 'nova/*']);

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -30,7 +30,7 @@ class ResponseTest extends TestCase
 {
     public function test_can_macro(): void
     {
-        $response = new Response('User/Edit', []);
+        $response = new Response('User/Edit', [], []);
         $response->macro('foo', function () {
             return 'bar';
         });
@@ -44,7 +44,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/user/123', 'GET');
 
         $user = ['name' => 'Jonathan'];
-        $response = new Response('User/Edit', ['user' => $user], 'app', '123');
+        $response = new Response('User/Edit', [], ['user' => $user], 'app', '123');
         /** @var BaseResponse $response */
         $response = $response->toResponse($request);
         $view = $response->getOriginalContent();
@@ -69,6 +69,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => new DeferProp(function () {
@@ -105,6 +106,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => new DeferProp(function () {
@@ -163,6 +165,7 @@ class ResponseTest extends TestCase
 
         $response = new Response(
             'User/Index',
+            [],
             [
                 'users' => new ScrollProp(['data' => [['id' => 1]]], 'data', new class implements ProvidesScrollMetadata
                 {
@@ -220,6 +223,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => new MergeProp('foo value'),
@@ -256,6 +260,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => (new MergeProp('foo value'))->prepend(),
@@ -290,6 +295,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => (new MergeProp(['data' => [['id' => 1], ['id' => 2]]]))->append('data'),
@@ -325,6 +331,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => (new MergeProp(['data' => [['id' => 1], ['id' => 2]]]))->append('data', 'id'),
@@ -360,6 +367,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => (new MergeProp('foo value'))->deepMerge(),
@@ -396,6 +404,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => (new MergeProp('foo value'))->matchOn('foo-key')->deepMerge(),
@@ -437,6 +446,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => (new DeferProp(function () {
@@ -478,6 +488,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => (new DeferProp(function () {
@@ -522,6 +533,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => new MergeProp('foo value'),
@@ -554,6 +566,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => new MergeProp('foo value'),
@@ -587,6 +600,7 @@ class ResponseTest extends TestCase
         $user = ['name' => 'Jonathan'];
         $response = new Response(
             'User/Edit',
+            [],
             [
                 'user' => $user,
                 'foo' => new MergeProp('foo value'),
@@ -614,7 +628,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia' => 'true']);
 
         $user = (object) ['name' => 'Jonathan'];
-        $response = new Response('User/Edit', ['user' => $user], 'app', '123');
+        $response = new Response('User/Edit', [], ['user' => $user], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -631,7 +645,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/user/123', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'user' => ['name' => 'Jonathan'],
             'results' => new DeferProp(fn () => ['data' => ['item1', 'item2']], 'default'),
         ], 'app', '123');
@@ -655,7 +669,7 @@ class ResponseTest extends TestCase
 
         $resource = new FakeResource(['name' => 'Jonathan']);
 
-        $response = new Response('User/Edit', ['user' => $resource], 'app', '123');
+        $response = new Response('User/Edit', [], ['user' => $resource], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -672,7 +686,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/users', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $response = new Response('User/Index', [
+        $response = new Response('User/Index', [], [
             'users' => fn () => [['name' => 'Jonathan']],
             'organizations' => fn () => [['name' => 'Inertia']],
         ], 'app', '123');
@@ -699,7 +713,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia-Partial-Data' => 'users']);
         $request->headers->add(['X-Inertia-Partial-Component' => 'User/Index']);
 
-        $response = new Response('User/Index', [
+        $response = new Response('User/Index', [], [
             'users' => fn () => [['name' => 'Jonathan']],
             'organizations' => fn () => [['name' => 'Inertia']],
         ], 'app', '123');
@@ -734,7 +748,7 @@ class ResponseTest extends TestCase
             return new class($page) extends ResourceCollection {};
         };
 
-        $response = new Response('User/Index', ['users' => $callable], 'app', '123');
+        $response = new Response('User/Index', [], ['users' => $callable], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -789,7 +803,7 @@ class ResponseTest extends TestCase
             ];
         };
 
-        $response = new Response('User/Index', ['something' => $callable], 'app', '123');
+        $response = new Response('User/Index', [], ['something' => $callable], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -833,7 +847,7 @@ class ResponseTest extends TestCase
 
         $resource = FakeResource::make(['name' => 'Jonathan']);
 
-        $response = new Response('User/Edit', ['user' => $resource], 'app', '123');
+        $response = new Response('User/Edit', [], ['user' => $resource], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -857,7 +871,7 @@ class ResponseTest extends TestCase
             ->andReturn($user)
             ->getMock();
 
-        $response = new Response('User/Edit', ['user' => $promise], 'app', '123');
+        $response = new Response('User/Edit', [], ['user' => $promise], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -877,7 +891,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia-Partial-Data' => 'partial']);
 
         $user = (object) ['name' => 'Jonathan'];
-        $response = new Response('User/Edit', ['user' => $user, 'partial' => 'partial-data'], 'app', '123');
+        $response = new Response('User/Edit', [], ['user' => $user, 'partial' => 'partial-data'], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -901,7 +915,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia-Partial-Except' => 'user']);
 
         $user = (object) ['name' => 'Jonathan'];
-        $response = new Response('User/Edit', ['user' => $user, 'partial' => 'partial-data'], 'app', '123');
+        $response = new Response('User/Edit', [], ['user' => $user, 'partial' => 'partial-data'], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -921,7 +935,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'auth' => [
                 'user' => fn () => ['name' => 'Jonathan'],
                 'token' => 'value',
@@ -941,7 +955,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'auth' => fn () => [
                 'user' => fn () => ['name' => 'Jonathan'],
                 'token' => 'value',
@@ -961,7 +975,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'auth' => fn () => [
                 'user' => ['name' => 'Jonathan'],
                 'pending' => Inertia::optional(fn () => 'secret'),
@@ -1000,7 +1014,7 @@ class ResponseTest extends TestCase
             ],
         ];
 
-        $response = new Response('User/Edit', $props);
+        $response = new Response('User/Edit', [], $props);
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1035,7 +1049,7 @@ class ResponseTest extends TestCase
             ],
         ];
 
-        $response = new Response('User/Edit', $props);
+        $response = new Response('User/Edit', [], $props);
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1054,7 +1068,7 @@ class ResponseTest extends TestCase
             return 'An optional value';
         });
 
-        $response = new Response('Users', ['users' => [], 'optional' => $optionalProp], 'app', '123');
+        $response = new Response('Users', [], ['users' => [], 'optional' => $optionalProp], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1074,7 +1088,7 @@ class ResponseTest extends TestCase
             return 'An optional value';
         });
 
-        $response = new Response('Users', ['users' => [], 'optional' => $optionalProp], 'app', '123');
+        $response = new Response('Users', [], ['users' => [], 'optional' => $optionalProp], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1100,7 +1114,7 @@ class ResponseTest extends TestCase
             };
         });
 
-        $response = new Response('Users', ['users' => [], 'defer' => $deferProp], 'app', '123');
+        $response = new Response('Users', [], ['users' => [], 'defer' => $deferProp], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1133,7 +1147,7 @@ class ResponseTest extends TestCase
             }),
         ];
 
-        $response = new Response('User/Edit', $props, 'app', '123');
+        $response = new Response('User/Edit', [], $props, 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1147,7 +1161,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'always' => new AlwaysProp('date'),
             'merge' => new MergeProp('trim'),
         ], 'app', '123');
@@ -1164,7 +1178,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'foo' => 'bar',
             new class implements ProvidesInertiaProperties
             {
@@ -1198,7 +1212,7 @@ class ResponseTest extends TestCase
         Inertia::share('items', ['foo']);
         Inertia::share('deep.foo.bar', ['foo']);
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'items' => new MergeWithSharedProp(['bar']),
             'deep' => [
                 'foo' => [
@@ -1232,7 +1246,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/products/123', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $response = new Response('User/Edit', $props, 'app', '123');
+        $response = new Response('User/Edit', [], $props, 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData(true);
@@ -1260,7 +1274,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/products/123', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $response = new Response('User/Edit', $props, 'app', '123');
+        $response = new Response('User/Edit', [], $props, 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData(true);
@@ -1274,7 +1288,7 @@ class ResponseTest extends TestCase
     public function test_props_can_be_added_using_the_with_method(): void
     {
         $request = Request::create('/user/123', 'GET');
-        $response = new Response('User/Edit', [], 'app', '123');
+        $response = new Response('User/Edit', [], [], 'app', '123');
 
         $response->with(['foo' => 'bar', 'baz' => 'qux'])
             ->with(['quux' => 'corge'])
@@ -1303,7 +1317,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', ['foo' => Inertia::once(fn () => 'bar')], 'app', '123');
+        $response = new Response('User/Edit', [], ['foo' => Inertia::once(fn () => 'bar')], 'app', '123');
         /** @var BaseResponse $response */
         $response = $response->toResponse($request);
         $view = $response->getOriginalContent();
@@ -1326,7 +1340,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', ['foo' => Inertia::once(fn () => 'bar')->fresh()], 'app', '123');
+        $response = new Response('User/Edit', [], ['foo' => Inertia::once(fn () => 'bar')->fresh()], 'app', '123');
         /** @var BaseResponse $response */
         $response = $response->toResponse($request);
         $view = $response->getOriginalContent();
@@ -1350,7 +1364,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/user/123', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'foo' => Inertia::once(fn () => 'bar')->as('baz')->until(now()->addMinute()),
         ], 'app', '123');
         /** @var JsonResponse $response */
@@ -1372,7 +1386,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia' => 'true']);
         $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
 
-        $response = new Response('User/Edit', ['foo' => Inertia::once(fn () => 'bar')], 'app', '123');
+        $response = new Response('User/Edit', [], ['foo' => Inertia::once(fn () => 'bar')], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1391,7 +1405,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/user/123', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $response = new Response('User/Edit', ['foo' => Inertia::once(fn () => 'bar')], 'app', '123');
+        $response = new Response('User/Edit', [], ['foo' => Inertia::once(fn () => 'bar')], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1411,7 +1425,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia' => 'true']);
         $request->headers->add(['X-Inertia-Except-Once-Props' => 'baz']);
 
-        $response = new Response('User/Edit', ['foo' => Inertia::once(fn () => 'bar')], 'app', '123');
+        $response = new Response('User/Edit', [], ['foo' => Inertia::once(fn () => 'bar')], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1433,7 +1447,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia-Partial-Data' => 'foo']);
         $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
 
-        $response = new Response('User/Edit', ['foo' => Inertia::once(fn () => 'bar')], 'app', '123');
+        $response = new Response('User/Edit', [], ['foo' => Inertia::once(fn () => 'bar')], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1455,7 +1469,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia-Partial-Data' => 'foo']);
         $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'foo' => Inertia::once(fn () => 'bar'),
             'baz' => Inertia::once(fn () => 'qux'),
         ], 'app', '123');
@@ -1483,7 +1497,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia-Partial-Except' => 'foo']);
         $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'foo' => Inertia::once(fn () => 'bar'),
             'baz' => Inertia::once(fn () => 'qux'),
         ], 'app', '123');
@@ -1509,7 +1523,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia' => 'true']);
         $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
 
-        $response = new Response('User/Edit', ['foo' => Inertia::once(fn () => 'bar')->fresh()], 'app', '123');
+        $response = new Response('User/Edit', [], ['foo' => Inertia::once(fn () => 'bar')->fresh()], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1531,7 +1545,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia' => 'true']);
         $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo,baz']);
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'foo' => Inertia::once(fn () => 'bar')->fresh(),
             'baz' => Inertia::once(fn () => 'qux'),
         ], 'app', '123');
@@ -1558,7 +1572,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia' => 'true']);
         $request->headers->add(['X-Inertia-Except-Once-Props' => 'defer']);
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'defer' => Inertia::defer(fn () => 'value')->once(),
         ], 'app', '123');
         /** @var JsonResponse $response */
@@ -1585,7 +1599,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia-Partial-Data' => 'defer']);
         $request->headers->add(['X-Inertia-Except-Once-Props' => 'defer']);
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'defer' => Inertia::defer(fn () => 'value')->once(),
         ], 'app', '123');
         /** @var JsonResponse $response */
@@ -1611,7 +1625,7 @@ class ResponseTest extends TestCase
 
         $resource = new FakeResource(["\x00*\x00_invalid_key" => 'for object']);
 
-        $response = new Response('User/Edit', ['resource' => $resource], 'app', '123');
+        $response = new Response('User/Edit', [], ['resource' => $resource], 'app', '123');
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData(true);
@@ -1631,7 +1645,7 @@ class ResponseTest extends TestCase
         $request->headers->set('X_FORWARDED_PREFIX', '/sub/directory');
 
         $user = ['name' => 'Jonathan'];
-        $response = new Response('User/Edit', ['user' => $user], 'app', '123');
+        $response = new Response('User/Edit', [], ['user' => $user], 'app', '123');
         /** @var BaseResponse $response */
         $response = $response->toResponse($request);
         $view = $response->getOriginalContent();
@@ -1651,7 +1665,7 @@ class ResponseTest extends TestCase
         ]);
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $response = new Response('Product/Show', []);
+        $response = new Response('Product/Show', [], []);
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1664,7 +1678,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/users/', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $response = new Response('User/Index', []);
+        $response = new Response('User/Index', [], []);
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1677,7 +1691,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/users/?page=1&sort=name', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $response = new Response('User/Index', []);
+        $response = new Response('User/Index', [], []);
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1690,7 +1704,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/users', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $response = new Response('User/Index', []);
+        $response = new Response('User/Index', [], []);
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1703,7 +1717,7 @@ class ResponseTest extends TestCase
         $request = Request::create('/users?page=1&sort=name', 'GET');
         $request->headers->add(['X-Inertia' => 'true']);
 
-        $response = new Response('User/Index', []);
+        $response = new Response('User/Index', [], []);
         /** @var JsonResponse $response */
         $response = $response->toResponse($request);
         $page = $response->getData();
@@ -1715,7 +1729,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'user' => ['name' => 'Jonathan'],
             new class implements ProvidesInertiaProperties
             {
@@ -1743,7 +1757,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'user' => ['name' => 'Jonathan'],
             new class implements ProvidesInertiaProperties
             {
@@ -1777,7 +1791,7 @@ class ResponseTest extends TestCase
         $request->headers->add(['X-Inertia-Partial-Component' => 'User/Edit']);
         $request->headers->add(['X-Inertia-Partial-Data' => 'foo']);
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'user' => ['name' => 'Jonathan'],
             new class implements ProvidesInertiaProperties
             {
@@ -1801,7 +1815,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'user' => ['name' => 'Jonathan'],
             new class implements ProvidesInertiaProperties
             {
@@ -1827,7 +1841,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'user' => ['name' => 'Jonathan'],
             new class implements ProvidesInertiaProperties
             {
@@ -1853,7 +1867,7 @@ class ResponseTest extends TestCase
     {
         $request = Request::create('/user/123', 'GET');
 
-        $response = new Response('User/Edit', [
+        $response = new Response('User/Edit', [], [
             'user' => ['name' => 'Jonathan'],
             new class implements ProvidesInertiaProperties
             {

--- a/tests/ScrollPropTest.php
+++ b/tests/ScrollPropTest.php
@@ -183,6 +183,7 @@ class ScrollPropTest extends TestCase
 
         $response = new Response(
             'Users/Index',
+            [],
             [
                 'users' => (new ScrollProp(fn () => User::query()->paginate(15)))->defer(),
             ],
@@ -209,6 +210,7 @@ class ScrollPropTest extends TestCase
 
         $response = new Response(
             'Users/Index',
+            [],
             [
                 'users' => (new ScrollProp(fn () => User::query()->paginate(15)))->defer(),
             ],
@@ -233,6 +235,7 @@ class ScrollPropTest extends TestCase
 
         $response = new Response(
             'Users/Index',
+            [],
             [
                 'users' => (new ScrollProp(fn () => User::query()->paginate(15)))->defer('custom-group'),
             ],


### PR DESCRIPTION
This PR adds a `sharedProps` metadata key to the page response, listing the top-level prop keys registered via `Inertia::share()`. This follows the same pattern as `mergeProps`, `deferredProps`, and `onceProps`.

```json
{
  "component": "Dashboard",
  "props": { "auth": {...}, "errors": {}, "stats": {...} },
  "sharedProps": ["auth", "errors"]
}
```

After merging shared and page-specific props in `ResponseFactory::render()`, the distinction between the two was lost. The frontend had no way to know which props were shared across all pages versus specific to the current page. This is needed for [instant visits](https://github.com/inertiajs/inertia/pull/2907), where the frontend swaps to the target component before the server responds and needs to know which props to carry over from the current page.

`ResponseFactory` now passes shared props and page props as separate arguments to `Response`, which forwards both to `PropsResolver`. The resolver merges them internally after collecting the shared keys.

The feature is enabled by default. You may disable it via the `expose_shared_prop_keys` config option.