### PR TITLE
[3.x] Make `clearHistory` and `encryptHistory` optional in page object

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -183,10 +183,10 @@ class Response implements Responsable
                 'props' => $resolvedProps,
                 'url' => $this->getUrl($request),
                 'version' => $this->version,
-                'clearHistory' => $this->clearHistory,
-                'encryptHistory' => $this->encryptHistory,
             ],
             $resolvedMetadata,
+            $this->resolveClearHistory($request),
+            $this->resolveEncryptHistory($request),
             $this->resolveFlashData($request),
             $this->resolvePreserveFragment($request),
         );
@@ -196,6 +196,26 @@ class Response implements Responsable
         }
 
         return ResponseFactory::view($this->rootView, $this->viewData + ['page' => $page]);
+    }
+
+    /**
+     * Resolve the clear history flag.
+     *
+     * @return array<string, mixed>
+     */
+    protected function resolveClearHistory(Request $request): array
+    {
+        return $this->clearHistory ? ['clearHistory' => true] : [];
+    }
+
+    /**
+     * Resolve the encrypt history flag.
+     *
+     * @return array<string, mixed>
+     */
+    protected function resolveEncryptHistory(Request $request): array
+    {
+        return $this->encryptHistory ? ['encryptHistory' => true] : [];
     }
 
     /**

--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -78,8 +78,6 @@ class AssertableInertia extends AssertableJson
             PHPUnit::assertArrayHasKey('props', $page);
             PHPUnit::assertArrayHasKey('url', $page);
             PHPUnit::assertArrayHasKey('version', $page);
-            PHPUnit::assertArrayHasKey('encryptHistory', $page);
-            PHPUnit::assertArrayHasKey('clearHistory', $page);
         } catch (AssertionFailedError $e) {
             PHPUnit::fail('Not a valid Inertia response.');
         }
@@ -88,8 +86,8 @@ class AssertableInertia extends AssertableJson
         $instance->component = $page['component'];
         $instance->url = $page['url'];
         $instance->version = $page['version'];
-        $instance->encryptHistory = $page['encryptHistory'];
-        $instance->clearHistory = $page['clearHistory'];
+        $instance->encryptHistory = isset($page['encryptHistory']);
+        $instance->clearHistory = isset($page['clearHistory']);
         $instance->deferredProps = $page['deferredProps'] ?? [];
         $instance->flash = $page['flash'] ?? [];
 
@@ -291,14 +289,16 @@ class AssertableInertia extends AssertableJson
      */
     public function toArray()
     {
-        return [
-            'component' => $this->component,
-            'props' => $this->prop(),
-            'url' => $this->url,
-            'version' => $this->version,
-            'encryptHistory' => $this->encryptHistory,
-            'clearHistory' => $this->clearHistory,
-            'flash' => $this->flash,
-        ];
+        return array_merge(
+            [
+                'component' => $this->component,
+                'props' => $this->prop(),
+                'url' => $this->url,
+                'version' => $this->version,
+                'flash' => $this->flash,
+            ],
+            $this->encryptHistory ? ['encryptHistory' => true] : [],
+            $this->clearHistory ? ['clearHistory' => true] : [],
+        );
     }
 }

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -28,8 +28,6 @@ class ControllerTest extends TestCase
             ],
             'url' => '/',
             'version' => '',
-            'encryptHistory' => false,
-            'clearHistory' => false,
         ]);
     }
 }

--- a/tests/DirectiveTest.php
+++ b/tests/DirectiveTest.php
@@ -55,7 +55,7 @@ class DirectiveTest extends TestCase
     {
         Config::set(['inertia.ssr.enabled' => false]);
 
-        $html = '<script data-page="app" type="application/json">{"component":"Foo\/Bar","props":{"foo":"bar"},"url":"\/test","version":"","encryptHistory":false,"clearHistory":false}</script><div id="app"></div>';
+        $html = '<script data-page="app" type="application/json">{"component":"Foo\/Bar","props":{"foo":"bar"},"url":"\/test","version":""}</script><div id="app"></div>';
 
         $this->assertSame($html, $this->renderView('@inertia', ['page' => self::EXAMPLE_PAGE_OBJECT]));
         $this->assertSame($html, $this->renderView('@inertia()', ['page' => self::EXAMPLE_PAGE_OBJECT]));
@@ -77,7 +77,7 @@ class DirectiveTest extends TestCase
     {
         Config::set(['inertia.ssr.enabled' => false]);
 
-        $html = '<script data-page="foo" type="application/json">{"component":"Foo\/Bar","props":{"foo":"bar"},"url":"\/test","version":"","encryptHistory":false,"clearHistory":false}</script><div id="foo"></div>';
+        $html = '<script data-page="foo" type="application/json">{"component":"Foo\/Bar","props":{"foo":"bar"},"url":"\/test","version":""}</script><div id="foo"></div>';
 
         $this->assertSame($html, $this->renderView('@inertia(foo)', ['page' => self::EXAMPLE_PAGE_OBJECT]));
         $this->assertSame($html, $this->renderView("@inertia('foo')", ['page' => self::EXAMPLE_PAGE_OBJECT]));

--- a/tests/HistoryTest.php
+++ b/tests/HistoryTest.php
@@ -22,11 +22,8 @@ class HistoryTest extends TestCase
         ]);
 
         $response->assertSuccessful();
-        $response->assertJson([
-            'component' => 'User/Edit',
-            'encryptHistory' => false,
-            'clearHistory' => false,
-        ]);
+        $response->assertJsonMissing(['encryptHistory' => true]);
+        $response->assertJsonMissing(['clearHistory' => true]);
     }
 
     public function test_the_history_can_be_encrypted(): void
@@ -116,10 +113,7 @@ class HistoryTest extends TestCase
         ]);
 
         $response->assertSuccessful();
-        $response->assertJson([
-            'component' => 'User/Edit',
-            'encryptHistory' => false,
-        ]);
+        $response->assertJsonMissing(['encryptHistory' => true]);
     }
 
     public function test_the_history_can_be_cleared(): void
@@ -160,7 +154,7 @@ class HistoryTest extends TestCase
         ]);
 
         $response->assertSuccessful();
-        $response->assertContent('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"errors":{}},"url":"\/users","version":"","clearHistory":true,"encryptHistory":false}</script><div id="app"></div>');
+        $response->assertContent('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"errors":{}},"url":"\/users","version":"","clearHistory":true}</script><div id="app"></div>');
     }
 
     public function test_the_fragment_is_not_preserved_by_default(): void

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -57,9 +57,9 @@ class ResponseTest extends TestCase
         $this->assertSame('Jonathan', $page['props']['user']['name']);
         $this->assertSame('/user/123', $page['url']);
         $this->assertSame('123', $page['version']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false}</script><div id="app"></div>', $view->render());
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123"}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_deferred_prop(): void
@@ -93,9 +93,9 @@ class ResponseTest extends TestCase
         $this->assertSame([
             'default' => ['foo'],
         ], $page['deferredProps']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo"]}}</script><div id="app"></div>', $view->render());
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","deferredProps":{"default":["foo"]}}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_deferred_prop_and_multiple_groups(): void
@@ -136,9 +136,9 @@ class ResponseTest extends TestCase
             'default' => ['foo', 'bar'],
             'custom' => ['baz'],
         ], $page['deferredProps']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deferredProps":{"default":["foo","bar"],"custom":["baz"]}}</script><div id="app"></div>', $view->render());
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"}},"url":"\/user\/123","version":"123","deferredProps":{"default":["foo","bar"],"custom":["baz"]}}</script><div id="app"></div>', $view->render());
     }
 
     /**
@@ -244,9 +244,9 @@ class ResponseTest extends TestCase
             'foo',
             'bar',
         ], $page['mergeProps']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"]}</script><div id="app"></div>', $view->render());
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","mergeProps":["foo","bar"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_merge_props_that_should_prepend(): void
@@ -278,9 +278,9 @@ class ResponseTest extends TestCase
         $this->assertSame('123', $page['version']);
         $this->assertSame(['bar'], $page['mergeProps']);
         $this->assertSame(['foo'], $page['prependProps']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["bar"],"prependProps":["foo"]}</script><div id="app"></div>', $view->render());
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","mergeProps":["bar"],"prependProps":["foo"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_merge_props_that_has_nested_paths_to_append_and_prepend(): void
@@ -313,9 +313,9 @@ class ResponseTest extends TestCase
         $this->assertSame(['foo.data'], $page['mergeProps']);
         $this->assertSame(['bar.data.items'], $page['prependProps']);
         $this->assertArrayNotHasKey('matchPropsOn', $page);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":{"data":[{"id":1},{"id":2}]},"bar":{"data":{"items":[{"uuid":1},{"uuid":2}]}}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo.data"],"prependProps":["bar.data.items"]}</script><div id="app"></div>', $view->render());
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":{"data":[{"id":1},{"id":2}]},"bar":{"data":{"items":[{"uuid":1},{"uuid":2}]}}},"url":"\/user\/123","version":"123","mergeProps":["foo.data"],"prependProps":["bar.data.items"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_merge_props_that_has_nested_paths_to_append_and_prepend_with_match_on_strategies(): void
@@ -348,9 +348,9 @@ class ResponseTest extends TestCase
         $this->assertSame(['foo.data'], $page['mergeProps']);
         $this->assertSame(['bar.data.items'], $page['prependProps']);
         $this->assertSame(['foo.data.id', 'bar.data.items.uuid'], $page['matchPropsOn']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":{"data":[{"id":1},{"id":2}]},"bar":{"data":{"items":[{"uuid":1},{"uuid":2}]}}},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo.data"],"prependProps":["bar.data.items"],"matchPropsOn":["foo.data.id","bar.data.items.uuid"]}</script><div id="app"></div>', $view->render());
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":{"data":[{"id":1},{"id":2}]},"bar":{"data":{"items":[{"uuid":1},{"uuid":2}]}}},"url":"\/user\/123","version":"123","mergeProps":["foo.data"],"prependProps":["bar.data.items"],"matchPropsOn":["foo.data.id","bar.data.items.uuid"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_deep_merge_props(): void
@@ -384,9 +384,9 @@ class ResponseTest extends TestCase
             'foo',
             'bar',
         ], $page['deepMergeProps']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"]}</script><div id="app"></div>', $view->render());
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","deepMergeProps":["foo","bar"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_match_on_props(): void
@@ -425,9 +425,9 @@ class ResponseTest extends TestCase
             'foo.foo-key',
             'bar.bar-key',
         ], $page['matchPropsOn']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"matchPropsOn":["foo.foo-key","bar.bar-key"]}</script><div id="app"></div>', $view->render());
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"foo":"foo value","bar":"bar value"},"url":"\/user\/123","version":"123","deepMergeProps":["foo","bar"],"matchPropsOn":["foo.foo-key","bar.bar-key"]}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_defer_and_merge_props(): void
@@ -466,9 +466,9 @@ class ResponseTest extends TestCase
             'foo',
             'bar',
         ], $page['mergeProps']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"mergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}</script><div id="app"></div>', $view->render());
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","mergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}</script><div id="app"></div>', $view->render());
     }
 
     public function test_server_response_with_defer_and_deep_merge_props(): void
@@ -507,9 +507,9 @@ class ResponseTest extends TestCase
             'foo',
             'bar',
         ], $page['deepMergeProps']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"deepMergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}</script><div id="app"></div>', $view->render());
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"user":{"name":"Jonathan"},"bar":"bar value"},"url":"\/user\/123","version":"123","deepMergeProps":["foo","bar"],"deferredProps":{"default":["foo"]}}</script><div id="app"></div>', $view->render());
     }
 
     public function test_exclude_merge_props_from_partial_only_response(): void
@@ -1316,10 +1316,10 @@ class ResponseTest extends TestCase
         $this->assertSame('bar', $page['props']['foo']);
         $this->assertSame('/user/123', $page['url']);
         $this->assertSame('123', $page['version']);
-        $this->assertFalse($page['clearHistory']);
-        $this->assertFalse($page['encryptHistory']);
+        $this->assertArrayNotHasKey('clearHistory', $page);
+        $this->assertArrayNotHasKey('encryptHistory', $page);
         $this->assertSame(['foo' => ['prop' => 'foo', 'expiresAt' => null]], $page['onceProps']);
-        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"foo":"bar"},"url":"\/user\/123","version":"123","clearHistory":false,"encryptHistory":false,"onceProps":{"foo":{"prop":"foo","expiresAt":null}}}</script><div id="app"></div>', $view->render());
+        $this->assertSame('<script data-page="app" type="application/json">{"component":"User\/Edit","props":{"foo":"bar"},"url":"\/user\/123","version":"123","onceProps":{"foo":{"prop":"foo","expiresAt":null}}}</script><div id="app"></div>', $view->render());
     }
 
     public function test_fresh_once_props_are_included_on_initial_page_load(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,7 +14,7 @@ abstract class TestCase extends Orchestra
     /**
      * Example Page Objects.
      */
-    protected const EXAMPLE_PAGE_OBJECT = ['component' => 'Foo/Bar', 'props' => ['foo' => 'bar'], 'url' => '/test', 'version' => '', 'encryptHistory' => false, 'clearHistory' => false];
+    protected const EXAMPLE_PAGE_OBJECT = ['component' => 'Foo/Bar', 'props' => ['foo' => 'bar'], 'url' => '/test', 'version' => ''];
 
     protected function getPackageProviders($app): array
     {

--- a/tests/Testing/TestResponseMacrosTest.php
+++ b/tests/Testing/TestResponseMacrosTest.php
@@ -51,8 +51,8 @@ class TestResponseMacrosTest extends TestCase
             $this->assertSame(['bar' => 'baz'], $page['props']);
             $this->assertSame('/example-url', $page['url']);
             $this->assertSame('', $page['version']);
-            $this->assertFalse($page['encryptHistory']);
-            $this->assertFalse($page['clearHistory']);
+            $this->assertArrayNotHasKey('encryptHistory', $page);
+            $this->assertArrayNotHasKey('clearHistory', $page);
         });
     }
 


### PR DESCRIPTION
This PR makes `clearHistory` and `encryptHistory` optional in the page object, only including them when `true`. 

This matches the existing behavior of `flash`, `deferredProps`, etc. Previously, every response included `"clearHistory":false,"encryptHistory":false` even when history wasn't being cleared or encrypted.