### PR TITLE
[2.x] Prevent Boost conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,9 @@
     "suggest": {
         "ext-pcntl": "Recommended when running the Inertia SSR server via the `inertia:start-ssr` artisan command."
     },
+    "conflict": {
+        "laravel/boost": "<2.2.0"
+    },
     "scripts": {
         "test": "phpunit",
         "lint": "pint",


### PR DESCRIPTION
This PR adds a `conflict` entry in `composer.json` to prevent installing `laravel/boost` below `2.2.0`, which may crash when rendering the guidelines shipped with this package.