### PR TITLE
Add a way to manually refresh once props. (#839)

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -27,6 +27,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Symfony\Component\HttpFoundation\Response location(string|\Symfony\Component\HttpFoundation\RedirectResponse $url)
  * @method static \Inertia\ResponseFactory flash(string|array<string, mixed> $key, mixed $value = null)
  * @method static array<string, mixed> getFlashed(?\Illuminate\Http\Request $request = null)
+ * @method static \Inertia\ResponseFactory refresh(string|array<string> ...$keys)
+ * @method static array<int, string> getRefreshed(?\Illuminate\Http\Request $request = null)
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -153,6 +153,10 @@ class Middleware
         if ($flashed = Inertia::getFlashed($request)) {
             $request->session()->flash(SessionKey::FlashData->value, $flashed);
         }
+
+        if ($refreshed = Inertia::getRefreshed($request)) {
+            $request->session()->flash(SessionKey::Refresh->value, $refreshed);
+        }
     }
 
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -304,18 +304,20 @@ class Response implements Responsable
      */
     public function resolveOnceProperties(array $props, Request $request): array
     {
-        if (! $this->isInertia($request) || $this->isPartial($request)) {
+        if (! $this->isInertia($request)) {
             return $props;
         }
 
+        $isPartial = $this->isPartial($request);
         $exceptOnceProps = $this->getExceptOnceProps($request);
+        $refreshedProps = Inertia::getRefreshed($request);
 
         if (count($exceptOnceProps) === 0) {
             return $props;
         }
 
         return collect($props)
-            ->reject(function ($prop, string $key) use ($exceptOnceProps) {
+            ->reject(function ($prop, string $key) use ($isPartial, $exceptOnceProps, $refreshedProps) {
                 if (! $prop instanceof Onceable) {
                     return false;
                 }
@@ -328,7 +330,17 @@ class Response implements Responsable
                     return false;
                 }
 
-                return in_array($prop->getKey() ?? $key, $exceptOnceProps);
+                $resolvedKey = $prop->getKey() ?? $key;
+
+                if (in_array($resolvedKey, $refreshedProps)) {
+                    return false;
+                }
+
+                if ($isPartial) {
+                    return false;
+                }
+
+                return in_array($resolvedKey, $exceptOnceProps);
             })
             ->all();
     }
@@ -663,12 +675,13 @@ class Response implements Responsable
         }
 
         $exceptOnceProps = $this->getExceptOnceProps($request);
+        $refreshedProps = Inertia::getRefreshed($request);
 
         $deferredProps = collect($this->props)
             ->filter(function ($prop) {
                 return $prop instanceof Deferrable && $prop->shouldDefer();
             })
-            ->reject(function (Deferrable $prop, string $key) use ($exceptOnceProps) {
+            ->reject(function (Deferrable $prop, string $key) use ($exceptOnceProps, $refreshedProps) {
                 if (! $prop instanceof Onceable) {
                     return false;
                 }
@@ -681,7 +694,13 @@ class Response implements Responsable
                     return false;
                 }
 
-                return in_array($prop->getKey() ?? $key, $exceptOnceProps);
+                $resolvedKey = $prop->getKey() ?? $key;
+
+                if (in_array($resolvedKey, $refreshedProps)) {
+                    return false;
+                }
+
+                return in_array($resolvedKey, $exceptOnceProps);
             })
             ->map(function (Deferrable $prop, $key) {
                 return [

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -363,4 +363,33 @@ class ResponseFactory
 
         return $request->hasSession() ? $request->session()->get(SessionKey::FlashData->value, []) : [];
     }
+
+    /**
+     * Mark once props to be refreshed on the next response. Forces the specified
+     * once props to be re-evaluated and re-sent, regardless of whether they
+     * have already been sent to the client.
+     *
+     * @param  string|array<int, string>  ...$keys
+     */
+    public function refresh(string|array ...$keys): self
+    {
+        session()->now(SessionKey::Refresh->value, array_values(array_unique([
+            ...$this->getRefreshed(),
+            ...Arr::flatten($keys),
+        ])));
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the once props to refresh from the session.
+     *
+     * @return array<int, string>
+     */
+    public function getRefreshed(?HttpRequest $request = null): array
+    {
+        $request ??= request();
+
+        return $request->hasSession() ? $request->session()->get(SessionKey::Refresh->value, []) : [];
+    }
 }

--- a/src/SessionKey.php
+++ b/src/SessionKey.php
@@ -13,4 +13,9 @@ enum SessionKey: string
      * Session key for flash data.
      */
     case FlashData = 'inertia.flash_data';
+
+    /**
+     * Session key for props to refresh.
+     */
+    case Refresh = 'inertia.refresh';
 }

--- a/tests/RefreshPropsTest.php
+++ b/tests/RefreshPropsTest.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+use Inertia\Response;
+use Inertia\SessionKey;
+use Inertia\Tests\Stubs\ExampleMiddleware;
+
+class RefreshPropsTest extends TestCase
+{
+    public function test_refresh_stores_keys_in_session(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::refresh('foo');
+
+            $this->assertSame(['foo'], session(SessionKey::Refresh->value));
+
+            return response('ok');
+        });
+
+        $this->get('/')->assertSuccessful();
+    }
+
+    public function test_refresh_is_chainable(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            $result = Inertia::refresh('foo', 'bar');
+
+            $this->assertInstanceOf(\Inertia\ResponseFactory::class, $result);
+
+            return response('ok');
+        });
+
+        $this->get('/')->assertSuccessful();
+    }
+
+    public function test_refresh_accepts_an_array_of_keys(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::refresh(['foo', 'bar']);
+
+            $this->assertSame(['foo', 'bar'], session(SessionKey::Refresh->value));
+
+            return response('ok');
+        });
+
+        $this->get('/')->assertSuccessful();
+    }
+
+    public function test_refresh_accepts_strings_keys(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::refresh('foo', 'bar', 'baz');
+
+            $this->assertSame(['foo', 'bar', 'baz'], session(SessionKey::Refresh->value));
+
+            return response('ok');
+        });
+
+        $this->get('/')->assertSuccessful();
+    }
+
+    public function test_refresh_accumulates_multiple_calls(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::refresh('foo');
+            Inertia::refresh('bar');
+
+            $this->assertSame(['foo', 'bar'], session(SessionKey::Refresh->value));
+
+            return response('ok');
+        });
+
+        $this->get('/')->assertSuccessful();
+    }
+
+    public function test_refresh_deduplicates_keys(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/', function () {
+            Inertia::refresh('foo', 'bar', 'foo');
+
+            $this->assertSame(['foo', 'bar'], session(SessionKey::Refresh->value));
+
+            return response('ok');
+        });
+
+        $this->get('/')->assertSuccessful();
+    }
+
+    public function test_once_prop_is_re_sent_when_key_is_in_refresh(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
+
+        $session = new \Illuminate\Session\Store('test', new \Illuminate\Session\NullSessionHandler);
+        $session->put(SessionKey::Refresh->value, ['foo']);
+        $request->setLaravelSession($session);
+
+        $response = new Response('User/Edit', [
+            'foo' => Inertia::once(fn () => 'bar'),
+        ], 'app', '123');
+
+        $response = $response->toResponse($request);
+        /** @var JsonResponse $response */
+        $page = $response->getData();
+
+        $this->assertSame('bar', $page->props->foo);
+    }
+
+    public function test_once_prop_is_not_re_sent_when_key_is_not_in_refresh(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
+
+        $session = new \Illuminate\Session\Store('test', new \Illuminate\Session\NullSessionHandler);
+        $session->put(SessionKey::Refresh->value, ['other']);
+        $request->setLaravelSession($session);
+
+        $response = new Response('User/Edit', [
+            'foo' => Inertia::once(fn () => 'bar'),
+        ], 'app', '123');
+
+        $response = $response->toResponse($request);
+        /** @var JsonResponse $response */
+        $page = $response->getData();
+
+        $this->assertFalse(isset($page->props->foo));
+    }
+
+    public function test_once_prop_is_re_sent_on_partial_request_when_key_is_in_refresh(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Partial-Component' => 'User/Edit']);
+        $request->headers->add(['X-Inertia-Partial-Data' => 'foo']);
+        $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
+
+        $session = new \Illuminate\Session\Store('test', new \Illuminate\Session\NullSessionHandler);
+        $session->put(SessionKey::Refresh->value, ['foo']);
+        $request->setLaravelSession($session);
+
+        $response = new Response('User/Edit', [
+            'foo' => Inertia::once(fn () => 'bar'),
+        ], 'app', '123');
+
+        $response = $response->toResponse($request);
+        /** @var JsonResponse $response */
+        $page = $response->getData();
+
+        $this->assertSame('bar', $page->props->foo);
+    }
+
+    public function test_once_prop_is_not_sent_on_partial_request_when_refreshed_but_not_asked(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Partial-Component' => 'User/Edit']);
+        $request->headers->add(['X-Inertia-Partial-Data' => 'test']);
+        $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
+
+        $session = new \Illuminate\Session\Store('test', new \Illuminate\Session\NullSessionHandler);
+        $session->put(SessionKey::Refresh->value, ['foo']);
+        $request->setLaravelSession($session);
+
+        $response = new Response('User/Edit', [
+            'test' => 'value',
+            'foo' => Inertia::once(fn () => 'bar'),
+        ], 'app', '123');
+
+        $response = $response->toResponse($request);
+        /** @var JsonResponse $response */
+        $page = $response->getData();
+
+        $this->assertSame('value', $page->props->test);
+        $this->assertFalse(isset($page->props->foo));
+    }
+
+    public function test_once_prop_with_custom_key_is_re_sent_when_key_is_in_refresh(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Except-Once-Props' => 'my-foo']);
+
+        $session = new \Illuminate\Session\Store('test', new \Illuminate\Session\NullSessionHandler);
+        $session->put(SessionKey::Refresh->value, ['my-foo']);
+        $request->setLaravelSession($session);
+
+        $response = new Response('User/Edit', [
+            'foo' => Inertia::once(fn () => 'bar')->as('my-foo'),
+        ], 'app', '123');
+
+        $response = $response->toResponse($request);
+        /** @var JsonResponse $response */
+        $page = $response->getData();
+
+        $this->assertSame('bar', $page->props->foo);
+    }
+
+    public function test_defer_once_prop_is_re_queued_when_key_is_in_refresh(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
+
+        $session = new \Illuminate\Session\Store('test', new \Illuminate\Session\NullSessionHandler);
+        $session->put(SessionKey::Refresh->value, ['foo']);
+        $request->setLaravelSession($session);
+
+        $response = new Response('User/Edit', [
+            'foo' => Inertia::defer(fn () => 'bar')->once(),
+        ], 'app', '123');
+
+        $response = $response->toResponse($request);
+        /** @var JsonResponse $response */
+        $page = $response->getData();
+
+        $this->assertSame(['default' => ['foo']], (array) $page->deferredProps);
+    }
+
+    public function test_defer_once_prop_is_not_re_queued_when_key_is_not_in_refresh(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
+
+        $session = new \Illuminate\Session\Store('test', new \Illuminate\Session\NullSessionHandler);
+        $session->put(SessionKey::Refresh->value, ['other']);
+        $request->setLaravelSession($session);
+
+        $response = new Response('User/Edit', [
+            'foo' => Inertia::defer(fn () => 'bar')->once(),
+        ], 'app', '123');
+
+        $response = $response->toResponse($request);
+        /** @var JsonResponse $response */
+        $page = $response->getData();
+
+        $this->assertFalse(isset($page->deferredProps));
+    }
+
+    public function test_defer_once_prop_without_refresh_stays_excluded(): void
+    {
+        $request = Request::create('/user/123', 'GET');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Except-Once-Props' => 'foo']);
+
+        $response = new Response('User/Edit', [
+            'foo' => Inertia::defer(fn () => 'bar')->once(),
+        ], 'app', '123');
+
+        $response = $response->toResponse($request);
+        /** @var JsonResponse $response */
+        $page = $response->getData();
+
+        $this->assertFalse(isset($page->deferredProps));
+    }
+
+    public function test_refresh_keys_are_reflashed_on_redirect(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->post('/logout', function () {
+            Inertia::refresh('foo');
+
+            return redirect('/login');
+        });
+
+        $response = $this->post('/logout', [], ['X-Inertia' => 'true']);
+
+        $response->assertRedirect('/login');
+        $response->assertSessionHas(SessionKey::Refresh->value, ['foo']);
+    }
+
+    public function test_get_refreshed_returns_session_keys(): void
+    {
+        $factory = new \Inertia\ResponseFactory;
+        $request = Request::create('/');
+        $session = new \Illuminate\Session\Store('test', new \Illuminate\Session\NullSessionHandler);
+        $session->put(SessionKey::Refresh->value, ['foo', 'bar']);
+        $request->setLaravelSession($session);
+
+        $this->assertSame(['foo', 'bar'], $factory->getRefreshed($request));
+    }
+
+    public function test_get_refreshed_returns_empty_array_without_session(): void
+    {
+        $factory = new \Inertia\ResponseFactory;
+        $request = Request::create('/');
+
+        $this->assertSame([], $factory->getRefreshed($request));
+    }
+
+    public function test_complete_refresh_example(): void
+    {
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->post('/dashboard', function () {
+            return Inertia::render('Dashboard', [
+                'foo' => Inertia::once(fn () => 'bar'),
+            ]);
+        });
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->post('/logout', function () {
+            Inertia::refresh('foo');
+
+            return redirect('/login');
+        });
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/login', function () {
+            return Inertia::render('Auth/Login', [
+                'foo' => Inertia::once(fn () => 'baz'),
+            ]);
+        });
+
+        $dashboardResponse = $this->post('/dashboard', [], ['X-Inertia' => 'true']);
+        $dashboardResponse->assertSuccessful();
+        $dashboardResponse->assertJson(['props' => ['foo' => 'bar']]);
+        $dashboardResponse->assertSessionMissing(SessionKey::Refresh->value);
+
+        $logoutResponse = $this->post('/logout', [], ['X-Inertia' => 'true']);
+        $logoutResponse->assertRedirect('/login');
+        $logoutResponse->assertSessionHas(SessionKey::Refresh->value, ['foo']);
+
+        $loginResponse = $this->get('/login', [
+            'X-Inertia' => 'true',
+            'X-Inertia-Except-Once-Props' => 'foo',
+        ]);
+
+        $loginResponse->assertSuccessful();
+        $loginResponse->assertJson(['props' => ['foo' => 'baz']]);
+        $loginResponse->assertSessionMissing(SessionKey::Refresh->value);
+    }
+}


### PR DESCRIPTION
Hi,
This PR fixes #839.

It adds a `Inertia::refresh('prop')` method, to force refresh once prop.
Everything is summarized in the last test (of course, consider `sharedData` instead of manual render):


```php
public function test_complete_refresh_example(): void
{
    Route::middleware([StartSession::class, ExampleMiddleware::class])->post('/dashboard', function () {
        return Inertia::render('Dashboard', [
            'foo' => Inertia::once(fn () => 'bar'),
        ]);
    });

    Route::middleware([StartSession::class, ExampleMiddleware::class])->post('/logout', function () {
        Inertia::refresh('foo');

        return redirect('/login');
    });

    Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/login', function () {
        return Inertia::render('Auth/Login', [
            'foo' => Inertia::once(fn () => 'baz'),
        ]);
    });

    $dashboardResponse = $this->post('/dashboard', [], ['X-Inertia' => 'true']);
    $dashboardResponse->assertSuccessful();
    $dashboardResponse->assertJson(['props' => ['foo' => 'bar']]);
    $dashboardResponse->assertSessionMissing(SessionKey::Refresh->value);

    $logoutResponse = $this->post('/logout', [], ['X-Inertia' => 'true']);
    $logoutResponse->assertRedirect('/login');
    $logoutResponse->assertSessionHas(SessionKey::Refresh->value, ['foo']);

    $loginResponse = $this->get('/login', [
        'X-Inertia' => 'true',
        'X-Inertia-Except-Once-Props' => 'foo',
    ]);

    $loginResponse->assertSuccessful();
    $loginResponse->assertJson(['props' => ['foo' => 'baz']]);
    $loginResponse->assertSessionMissing(SessionKey::Refresh->value);
}
```

Thanks for your awesome work!