### PR TITLE
[3.x] fix: use rtrim for SSR shutdown URL construction

### DIFF
--- a/src/Commands/StopSsr.php
+++ b/src/Commands/StopSsr.php
@@ -27,7 +27,7 @@ class StopSsr extends Command
      */
     public function handle(): int
     {
-        $url = str_replace('/render', '', config('inertia.ssr.url', 'http://127.0.0.1:13714')).'/shutdown';
+        $url = rtrim(config('inertia.ssr.url', 'http://127.0.0.1:13714'), '/').'/shutdown';
 
         $ch = curl_init($url);
         curl_exec($ch);

--- a/src/Commands/StopSsr.php
+++ b/src/Commands/StopSsr.php
@@ -3,6 +3,7 @@
 namespace Inertia\Commands;
 
 use Illuminate\Console\Command;
+use Inertia\Ssr\HttpGateway;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'inertia:stop-ssr')]
@@ -25,9 +26,9 @@ class StopSsr extends Command
     /**
      * Stop the Inertia SSR server.
      */
-    public function handle(): int
+    public function handle(HttpGateway $gateway): int
     {
-        $url = rtrim(config('inertia.ssr.url', 'http://127.0.0.1:13714'), '/').'/shutdown';
+        $url = $gateway->getProductionUrl('/shutdown');
 
         $ch = curl_init($url);
         curl_exec($ch);

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -279,6 +279,15 @@ class HttpGatewayTest extends TestCase
         $this->assertNull($this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]));
     }
 
+    public function test_production_url_strips_trailing_slash(): void
+    {
+        config(['inertia.ssr.url' => 'http://127.0.0.1:13714/']);
+
+        $gateway = app(HttpGateway::class);
+
+        $this->assertEquals('http://127.0.0.1:13714/render', $gateway->getProductionUrl('/render'));
+    }
+
     public function test_except_can_be_called_multiple_times(): void
     {
         config([


### PR DESCRIPTION
## Problem

`StopSsr` builds the shutdown URL using `str_replace('/render', '', ...)`, which is a leftover from when `inertia.ssr.url` pointed directly to the render endpoint. Since v3, `inertia.ssr.url` is a **base URL** with no path.

As a result, a trailing slash in `INERTIA_SSR_URL` produces a double slash in the shutdown URL:

```env
INERTIA_SSR_URL=http://127.0.0.1:13714/
```

```
http://127.0.0.1:13714//shutdown  ❌
```

## Fix

Replace `str_replace('/render', '', ...)` with `rtrim(..., '/')`, which strips any trailing slash before appending `/shutdown`:

```
http://127.0.0.1:13714/   →  http://127.0.0.1:13714/shutdown  ✅
http://127.0.0.1:13714    →  http://127.0.0.1:13714/shutdown  ✅
```

This is consistent with how `HttpGateway::getProductionUrl()` already handles the same config value:

```php
$baseUrl = rtrim(config('inertia.ssr.url', 'http://127.0.0.1:13714'), '/');
```
