### PR TITLE
[3.x] Default config page_paths to lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Release Notes
 
-## [Unreleased](https://github.com/inertiajs/inertia-laravel/compare/v2.0.21...2.x)
+## [Unreleased](https://github.com/inertiajs/inertia-laravel/compare/v2.0.22...2.x)
 
 - Nothing!
+
+## [v2.0.22](https://github.com/inertiajs/inertia-laravel/compare/v2.0.21...v2.0.22) - 2026-03-11
+
+### What's Changed
+
+* [2.x] Prevent Boost conflict by [@pascalbaljet](https://github.com/pascalbaljet) in https://github.com/inertiajs/inertia-laravel/pull/838
+* [2.x] Fix SSR shutdown URL construction by [@pascalbaljet](https://github.com/pascalbaljet) in https://github.com/inertiajs/inertia-laravel/pull/843
+
+**Full Changelog**: https://github.com/inertiajs/inertia-laravel/compare/v2.0.21...v2.0.22
 
 ## [v2.0.21](https://github.com/inertiajs/inertia-laravel/compare/v2.0.20...v2.0.21) - 2026-02-24
 

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,9 @@
     "suggest": {
         "ext-pcntl": "Recommended when running the Inertia SSR server via the `inertia:start-ssr` artisan command."
     },
+    "conflict": {
+        "laravel/boost": "<2.2.0"
+    },
     "scripts": {
         "test": "phpunit",
         "lint": "pint",

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -49,7 +49,7 @@ return [
 
     'page_paths' => [
 
-        resource_path('js/Pages'),
+        resource_path('js/pages'),
 
     ],
 
@@ -88,7 +88,7 @@ return [
 
         'page_paths' => [
 
-            resource_path('js/Pages'),
+            resource_path('js/pages'),
 
         ],
 

--- a/helpers.php
+++ b/helpers.php
@@ -1,16 +1,21 @@
 <?php
 
+use Illuminate\Contracts\Support\Arrayable;
+use Inertia\Inertia;
+use Inertia\Response;
+use Inertia\ResponseFactory;
+
 if (! function_exists('inertia')) {
     /**
      * Inertia helper.
      *
      * @param  null|string  $component
-     * @param  array|\Illuminate\Contracts\Support\Arrayable  $props
-     * @return ($component is null ? \Inertia\ResponseFactory : \Inertia\Response)
+     * @param  array|Arrayable  $props
+     * @return ($component is null ? ResponseFactory : Response)
      */
     function inertia($component = null, $props = [])
     {
-        $instance = \Inertia\Inertia::getFacadeRoot();
+        $instance = Inertia::getFacadeRoot();
 
         if ($component) {
             return $instance->render($component, $props);
@@ -25,11 +30,11 @@ if (! function_exists('inertia_location')) {
      * Inertia location helper.
      *
      * @param  string  url
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Symfony\Component\HttpFoundation\Response
      */
     function inertia_location($url)
     {
-        $instance = \Inertia\Inertia::getFacadeRoot();
+        $instance = Inertia::getFacadeRoot();
 
         return $instance->location($url);
     }

--- a/src/Commands/StopSsr.php
+++ b/src/Commands/StopSsr.php
@@ -3,6 +3,7 @@
 namespace Inertia\Commands;
 
 use Illuminate\Console\Command;
+use Inertia\Ssr\HttpGateway;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'inertia:stop-ssr')]
@@ -25,9 +26,9 @@ class StopSsr extends Command
     /**
      * Stop the Inertia SSR server.
      */
-    public function handle(): int
+    public function handle(HttpGateway $gateway): int
     {
-        $url = str_replace('/render', '', config('inertia.ssr.url', 'http://127.0.0.1:13714')).'/shutdown';
+        $url = $gateway->getUrl('/shutdown');
 
         $ch = curl_init($url);
         curl_exec($ch);

--- a/src/EncryptHistoryMiddleware.php
+++ b/src/EncryptHistoryMiddleware.php
@@ -4,6 +4,7 @@ namespace Inertia;
 
 use Closure;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class EncryptHistoryMiddleware
 {
@@ -12,7 +13,7 @@ class EncryptHistoryMiddleware
      * enables encryption of the browser history state, providing additional
      * security for sensitive data in Inertia responses.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function handle(Request $request, Closure $next)
     {

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -32,7 +32,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Inertia\ResponseFactory
+ * @see ResponseFactory
  */
 class Inertia extends Facade
 {

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -85,7 +85,7 @@ class Middleware
     /**
      * Define a callback that returns the relative URL.
      *
-     * @return \Closure|null
+     * @return Closure|null
      */
     public function urlResolver()
     {
@@ -95,7 +95,7 @@ class Middleware
     /**
      * Handle the incoming request.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function handle(Request $request, Closure $next)
     {

--- a/src/Response.php
+++ b/src/Response.php
@@ -88,7 +88,7 @@ class Response implements Responsable
     /**
      * Create a new Inertia response instance.
      *
-     * @param  array<array-key, mixed|\Inertia\ProvidesInertiaProperties>  $props
+     * @param  array<array-key, mixed|ProvidesInertiaProperties>  $props
      */
     public function __construct(
         string $component,
@@ -173,7 +173,7 @@ class Response implements Responsable
     /**
      * Add flash data to the response.
      *
-     * @param  \BackedEnum|\UnitEnum|string|array<string, mixed>  $key
+     * @param  BackedEnum|UnitEnum|string|array<string, mixed>  $key
      * @return $this
      */
     public function flash(BackedEnum|UnitEnum|string|array $key, mixed $value = null): self
@@ -186,7 +186,7 @@ class Response implements Responsable
     /**
      * Create an HTTP response that represents the object.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function toResponse($request)
@@ -550,7 +550,7 @@ class Response implements Responsable
     /**
      * Get the props that should be considered for merging based on the request headers.
      *
-     * @return \Illuminate\Support\Collection<string, \Inertia\Mergeable>
+     * @return Collection<string, Mergeable>
      */
     protected function getMergePropsForRequest(Request $request, bool $rejectResetProps = true): Collection
     {
@@ -581,7 +581,7 @@ class Response implements Responsable
     /**
      * Resolve props that should be appended during merging.
      *
-     * @param  \Illuminate\Support\Collection<string, \Inertia\Mergeable>  $mergeProps
+     * @param  Collection<string, Mergeable>  $mergeProps
      * @return array<int, string>
      */
     protected function resolveAppendMergeProps(Collection $mergeProps): array
@@ -601,7 +601,7 @@ class Response implements Responsable
     /**
      * Resolve props that should be prepended during merging.
      *
-     * @param  \Illuminate\Support\Collection<string, \Inertia\Mergeable>  $mergeProps
+     * @param  Collection<string, Mergeable>  $mergeProps
      * @return array<int, string>
      */
     protected function resolvePrependMergeProps(Collection $mergeProps): array
@@ -621,7 +621,7 @@ class Response implements Responsable
     /**
      * Resolve props that should be deep merged.
      *
-     * @param  \Illuminate\Support\Collection<string, \Inertia\Mergeable>  $mergeProps
+     * @param  Collection<string, Mergeable>  $mergeProps
      * @return array<int, string>
      */
     protected function resolveDeepMergeProps(Collection $mergeProps): array
@@ -635,7 +635,7 @@ class Response implements Responsable
     /**
      * Resolve the matching keys for merge props.
      *
-     * @param  \Illuminate\Support\Collection<string, \Inertia\Mergeable>  $mergeProps
+     * @param  Collection<string, Mergeable>  $mergeProps
      * @return array<int, string>
      */
     protected function resolveMergeMatchingKeys(Collection $mergeProps): array

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -79,7 +79,7 @@ class ResponseFactory
      * included with every response, making it ideal for user authentication
      * state, flash messages, etc.
      *
-     * @param  string|array<array-key, mixed>|\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|\Inertia\ProvidesInertiaProperties  $key
+     * @param  string|array<array-key, mixed>|Arrayable<array-key, mixed>|ProvidesInertiaProperties  $key
      * @param  mixed  $value
      */
     public function share($key, $value = null): void
@@ -125,7 +125,7 @@ class ResponseFactory
     /**
      * Set the asset version.
      *
-     * @param  \Closure|string|null  $version
+     * @param  Closure|string|null  $version
      */
     public function version($version): void
     {
@@ -260,7 +260,7 @@ class ResponseFactory
     /**
      * Find the component or fail.
      *
-     * @throws \Inertia\ComponentNotFoundException
+     * @throws ComponentNotFoundException
      */
     protected function findComponentOrFail(string $component): void
     {
@@ -274,7 +274,7 @@ class ResponseFactory
     /**
      * Create an Inertia response.
      *
-     * @param  array<array-key, mixed>|\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|ProvidesInertiaProperties  $props
+     * @param  array<array-key, mixed>|Arrayable<array-key, mixed>|ProvidesInertiaProperties  $props
      */
     public function render(string $component, $props = []): Response
     {
@@ -318,7 +318,7 @@ class ResponseFactory
      * flash data is not persisted in the browser's history state, making it
      * ideal for one-time notifications like toasts or highlights.
      *
-     * @param  \BackedEnum|\UnitEnum|string|array<string, mixed>  $key
+     * @param  BackedEnum|UnitEnum|string|array<string, mixed>  $key
      */
     public function flash(BackedEnum|UnitEnum|string|array $key, mixed $value = null): self
     {

--- a/src/ScrollProp.php
+++ b/src/ScrollProp.php
@@ -43,7 +43,7 @@ class ScrollProp implements Deferrable, Mergeable
     /**
      * The scroll metadata provider.
      *
-     * @var ProvidesScrollMetadata|callable(T): \Inertia\ProvidesScrollMetadata|null
+     * @var ProvidesScrollMetadata|callable(T): ProvidesScrollMetadata|null
      */
     protected $metadata;
 
@@ -53,7 +53,7 @@ class ScrollProp implements Deferrable, Mergeable
      * completely replacing the property value.
      *
      * @param  T  $value
-     * @param  ProvidesScrollMetadata|callable(T): \Inertia\ProvidesScrollMetadata|null  $metadata
+     * @param  ProvidesScrollMetadata|callable(T): ProvidesScrollMetadata|null  $metadata
      */
     public function __construct(mixed $value, string $wrapper = 'data', ProvidesScrollMetadata|callable|null $metadata = null)
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -122,7 +122,7 @@ class ServiceProvider extends BaseServiceProvider
     /**
      * Register the testing macros.
      *
-     * @throws \LogicException
+     * @throws LogicException
      */
     protected function registerTestingMacros(): void
     {

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -144,4 +144,13 @@ class HttpGatewayTest extends TestCase
         $this->assertFalse($this->gateway->isHealthy());
         $this->assertFalse($this->gateway->isHealthy());
     }
+
+    public function test_url_strips_trailing_slash(): void
+    {
+        config(['inertia.ssr.url' => 'http://127.0.0.1:13714/']);
+
+        $gateway = new HttpGateway;
+
+        $this->assertEquals('http://127.0.0.1:13714/render', $gateway->getUrl('/render'));
+    }
 }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -20,6 +20,8 @@ use Inertia\MergeProp;
 use Inertia\OnceProp;
 use Inertia\OptionalProp;
 use Inertia\ResponseFactory;
+use Inertia\ScrollMetadata;
+use Inertia\ScrollProp;
 use Inertia\Tests\Stubs\ExampleInertiaPropsProvider;
 use Inertia\Tests\Stubs\ExampleMiddleware;
 
@@ -352,7 +354,7 @@ class ResponseFactoryTest extends TestCase
 
         $scrollProp = $factory->scroll($data);
 
-        $this->assertInstanceOf(\Inertia\ScrollProp::class, $scrollProp);
+        $this->assertInstanceOf(ScrollProp::class, $scrollProp);
         $this->assertSame($data, $scrollProp());
     }
 
@@ -360,11 +362,11 @@ class ResponseFactoryTest extends TestCase
     {
         $factory = new ResponseFactory;
         $data = ['item1', 'item2'];
-        $metadataProvider = new \Inertia\ScrollMetadata('custom', 1, 3, 2);
+        $metadataProvider = new ScrollMetadata('custom', 1, 3, 2);
 
         $scrollProp = $factory->scroll($data, 'data', $metadataProvider);
 
-        $this->assertInstanceOf(\Inertia\ScrollProp::class, $scrollProp);
+        $this->assertInstanceOf(ScrollProp::class, $scrollProp);
         $this->assertSame($data, $scrollProp());
         $this->assertEquals([
             'pageName' => 'custom',

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1109,7 +1109,7 @@ class ResponseTest extends TestCase
             new class implements ProvidesInertiaProperties
             {
                 /**
-                 * @return \Illuminate\Support\Collection<string, string>
+                 * @return Collection<string, string>
                  */
                 public function toInertiaProperties(RenderContext $context): iterable
                 {
@@ -1221,7 +1221,7 @@ class ResponseTest extends TestCase
             ->with(new class implements ProvidesInertiaProperties
             {
                 /**
-                 * @return \Illuminate\Support\Collection<string, string>
+                 * @return Collection<string, string>
                  */
                 public function toInertiaProperties(RenderContext $context): iterable
                 {

--- a/tests/Stubs/FakeResource.php
+++ b/tests/Stubs/FakeResource.php
@@ -2,6 +2,7 @@
 
 namespace Inertia\Tests\Stubs;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class FakeResource extends JsonResource
@@ -32,7 +33,7 @@ class FakeResource extends JsonResource
     /**
      * Transform the resource into an array.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return array<string, mixed>
      */
     public function toArray($request): array


### PR DESCRIPTION
This commit changes the Inertia config file to match the Laravel Inertia starter kit default page components directory of `resources/js/pages`. The Inertia config had `page_paths` and `testing.page_paths` set to include `resource_path('js/Pages')`. This is case-sensitive, resulting in `ensure_pages_exist => true` being unable to find any page components.