### PR TITLE
[3.x] Add Blade components for rendering Inertia head and body

### DIFF
--- a/src/Directive.php
+++ b/src/Directive.php
@@ -16,10 +16,7 @@ class Directive
         $id = trim(trim($expression), "\'\"") ?: 'app';
 
         $template = '<?php
-            if (!isset($__inertiaSsrDispatched)) {
-                $__inertiaSsrDispatched = true;
-                $__inertiaSsrResponse = app(\Inertia\Ssr\Gateway::class)->dispatch($page);
-            }
+            $__inertiaSsrResponse = app(\Inertia\Ssr\SsrState::class)->setPage($page)->dispatch();
 
             if ($__inertiaSsrResponse) {
                 echo $__inertiaSsrResponse->body;
@@ -41,10 +38,7 @@ class Directive
     public static function compileHead($expression = ''): string
     {
         $template = '<?php
-            if (!isset($__inertiaSsrDispatched)) {
-                $__inertiaSsrDispatched = true;
-                $__inertiaSsrResponse = app(\Inertia\Ssr\Gateway::class)->dispatch($page);
-            }
+            $__inertiaSsrResponse = app(\Inertia\Ssr\SsrState::class)->setPage($page)->dispatch();
 
             if ($__inertiaSsrResponse) {
                 echo $__inertiaSsrResponse->head;

--- a/src/Response.php
+++ b/src/Response.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Response as ResponseFactory;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Inertia\Ssr\SsrState;
 use Inertia\Support\Header;
 use Inertia\Support\SessionKey;
 use UnitEnum;
@@ -204,6 +205,8 @@ class Response implements Responsable
         if ($request->header(Header::INERTIA)) {
             return new JsonResponse($page, 200, [Header::INERTIA => 'true']);
         }
+
+        App::make(SsrState::class)->setPage($page);
 
         return ResponseFactory::view($this->rootView, $this->viewData + ['page' => $page]);
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,11 +7,13 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Illuminate\Testing\TestResponse;
 use Illuminate\View\FileViewFinder;
 use Inertia\Ssr\Gateway;
 use Inertia\Ssr\HttpGateway;
+use Inertia\Ssr\SsrState;
 use Inertia\Support\Header;
 use Inertia\Testing\TestResponseMacros;
 use LogicException;
@@ -25,6 +27,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->app->singleton(HttpGateway::class);
         $this->app->singleton(ResponseFactory::class);
+        $this->app->scoped(SsrState::class);
         $this->app->bind(Gateway::class, HttpGateway::class);
 
         $this->mergeConfigFrom(
@@ -32,6 +35,7 @@ class ServiceProvider extends BaseServiceProvider
             'inertia'
         );
 
+        $this->registerBladeComponents();
         $this->registerBladeDirectives();
         $this->registerRedirectMacro();
         $this->registerRequestMacro();
@@ -69,6 +73,16 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->app->afterResolving(Kernel::class, function (Kernel $kernel) {
             $kernel->addToMiddlewarePriorityAfter(StartSession::class, Middleware::class);
+        });
+    }
+
+    /**
+     * Register Blade components for rendering Inertia head and body content.
+     */
+    protected function registerBladeComponents(): void
+    {
+        $this->callAfterResolving('blade.compiler', function () {
+            Blade::componentNamespace('Inertia\\View\\Components', 'inertia');
         });
     }
 

--- a/src/Ssr/SsrState.php
+++ b/src/Ssr/SsrState.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Inertia\Ssr;
+
+class SsrState
+{
+    /**
+     * The page data for the current request.
+     *
+     * @var array<string, mixed>
+     */
+    public array $page = [];
+
+    /**
+     * The SSR response for the current request.
+     */
+    public ?Response $response = null;
+
+    /**
+     * Whether the SSR gateway has been dispatched.
+     */
+    protected bool $dispatched = false;
+
+    /**
+     * Set the page data for the current request.
+     *
+     * @param  array<string, mixed>  $page
+     */
+    public function setPage(array $page): static
+    {
+        $this->page = $page;
+
+        return $this;
+    }
+
+    /**
+     * Dispatch the page to the SSR gateway, or return the cached response.
+     */
+    public function dispatch(): ?Response
+    {
+        if (! $this->dispatched) {
+            $this->dispatched = true;
+            $this->response = app(Gateway::class)->dispatch($this->page);
+        }
+
+        return $this->response;
+    }
+}

--- a/src/View/Components/Body.php
+++ b/src/View/Components/Body.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Inertia\View\Components;
+
+use Closure;
+use Illuminate\View\Component;
+use Inertia\Ssr\SsrState;
+
+class Body extends Component
+{
+    public function __construct(
+        public string $id = 'app',
+    ) {}
+
+    public function render(): Closure
+    {
+        return function () {
+            $state = app(SsrState::class);
+            $response = $state->dispatch();
+
+            if ($response) {
+                return $response->body;
+            }
+
+            return '<script data-page="'.$this->id.'" type="application/json">'.json_encode($state->page).'</script><div id="'.$this->id.'"></div>';
+        };
+    }
+}

--- a/src/View/Components/Head.php
+++ b/src/View/Components/Head.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Inertia\View\Components;
+
+use Closure;
+use Illuminate\View\Component;
+use Inertia\Ssr\SsrState;
+
+class Head extends Component
+{
+    public function render(): Closure
+    {
+        return function (array $data) {
+            $response = app(SsrState::class)->dispatch();
+
+            if ($response) {
+                return $response->head;
+            }
+
+            return (string) $data['slot'];
+        };
+    }
+}

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Inertia\Tests;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Config;
+use Inertia\Ssr\Gateway;
+use Inertia\Ssr\SsrState;
+use Inertia\Tests\Stubs\FakeGateway;
+
+class ComponentTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->bind(Gateway::class, FakeGateway::class);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function renderView(string $contents, array $data = []): string
+    {
+        app(SsrState::class)->setPage($data['page'] ?? []);
+
+        return Blade::render($contents, $data, true);
+    }
+
+    public function test_head_component_renders_fallback_slot_when_ssr_is_disabled(): void
+    {
+        Config::set(['inertia.ssr.enabled' => false]);
+
+        $view = '<x-inertia::head><title>Fallback Title</title></x-inertia::head>';
+
+        $this->assertStringContainsString(
+            '<title>Fallback Title</title>',
+            $this->renderView($view, ['page' => self::EXAMPLE_PAGE_OBJECT])
+        );
+    }
+
+    public function test_head_component_renders_ssr_head_when_ssr_is_enabled(): void
+    {
+        Config::set(['inertia.ssr.enabled' => true]);
+
+        $view = '<x-inertia::head><title>Fallback Title</title></x-inertia::head>';
+        $rendered = $this->renderView($view, ['page' => self::EXAMPLE_PAGE_OBJECT]);
+
+        $this->assertStringContainsString('<title inertia>Example SSR Title</title>', $rendered);
+        $this->assertStringNotContainsString('<title>Fallback Title</title>', $rendered);
+    }
+
+    public function test_body_component_renders_client_side_div_when_ssr_is_disabled(): void
+    {
+        Config::set(['inertia.ssr.enabled' => false]);
+
+        $view = '<x-inertia::body />';
+        $rendered = $this->renderView($view, ['page' => self::EXAMPLE_PAGE_OBJECT]);
+
+        $this->assertStringContainsString('<div id="app"></div>', $rendered);
+        $this->assertStringContainsString('data-page="app"', $rendered);
+    }
+
+    public function test_body_component_renders_ssr_body_when_ssr_is_enabled(): void
+    {
+        Config::set(['inertia.ssr.enabled' => true]);
+
+        $view = '<x-inertia::body />';
+
+        $this->assertSame(
+            '<p>This is some example SSR content</p>',
+            trim($this->renderView($view, ['page' => self::EXAMPLE_PAGE_OBJECT]))
+        );
+    }
+
+    public function test_body_component_accepts_custom_id(): void
+    {
+        Config::set(['inertia.ssr.enabled' => false]);
+
+        $view = '<x-inertia::body id="custom" />';
+        $rendered = $this->renderView($view, ['page' => self::EXAMPLE_PAGE_OBJECT]);
+
+        $this->assertStringContainsString('<div id="custom"></div>', $rendered);
+        $this->assertStringContainsString('data-page="custom"', $rendered);
+    }
+
+    public function test_ssr_is_only_dispatched_once_with_components(): void
+    {
+        Config::set(['inertia.ssr.enabled' => true]);
+        $this->app->instance(Gateway::class, $gateway = new FakeGateway);
+
+        $view = '<x-inertia::head><title>Fallback</title></x-inertia::head><x-inertia::body />';
+        $this->renderView($view, ['page' => self::EXAMPLE_PAGE_OBJECT]);
+
+        $this->assertSame(1, $gateway->times);
+    }
+
+    public function test_body_component_matches_directive_output_when_ssr_is_disabled(): void
+    {
+        Config::set(['inertia.ssr.enabled' => false]);
+
+        $directive = $this->renderView('@inertia', ['page' => self::EXAMPLE_PAGE_OBJECT]);
+
+        $this->app->forgetScopedInstances();
+
+        $component = trim($this->renderView('<x-inertia::body />', ['page' => self::EXAMPLE_PAGE_OBJECT]));
+
+        $this->assertSame($directive, $component);
+    }
+
+    public function test_body_component_matches_directive_output_when_ssr_is_enabled(): void
+    {
+        Config::set(['inertia.ssr.enabled' => true]);
+
+        $directive = $this->renderView('@inertia', ['page' => self::EXAMPLE_PAGE_OBJECT]);
+
+        $this->app->forgetScopedInstances();
+
+        $component = trim($this->renderView('<x-inertia::body />', ['page' => self::EXAMPLE_PAGE_OBJECT]));
+
+        $this->assertSame($directive, $component);
+    }
+
+    public function test_body_component_with_custom_id_matches_directive_output(): void
+    {
+        Config::set(['inertia.ssr.enabled' => false]);
+
+        $directive = $this->renderView('@inertia("foo")', ['page' => self::EXAMPLE_PAGE_OBJECT]);
+
+        $this->app->forgetScopedInstances();
+
+        $component = trim($this->renderView('<x-inertia::body id="foo" />', ['page' => self::EXAMPLE_PAGE_OBJECT]));
+
+        $this->assertSame($directive, $component);
+    }
+
+    public function test_head_component_without_slot_matches_directive_output_when_ssr_is_disabled(): void
+    {
+        Config::set(['inertia.ssr.enabled' => false]);
+
+        $directive = $this->renderView('@inertiaHead', ['page' => self::EXAMPLE_PAGE_OBJECT]);
+
+        $this->app->forgetScopedInstances();
+
+        $component = trim($this->renderView('<x-inertia::head />', ['page' => self::EXAMPLE_PAGE_OBJECT]));
+
+        $this->assertSame($directive, $component);
+    }
+
+    public function test_head_component_without_slot_matches_directive_output_when_ssr_is_enabled(): void
+    {
+        Config::set(['inertia.ssr.enabled' => true]);
+
+        $directive = trim($this->renderView('@inertiaHead', ['page' => self::EXAMPLE_PAGE_OBJECT]));
+
+        $this->app->forgetScopedInstances();
+
+        $component = trim($this->renderView('<x-inertia::head />', ['page' => self::EXAMPLE_PAGE_OBJECT]));
+
+        $this->assertSame($directive, $component);
+    }
+
+    public function test_ssr_state_is_scoped_and_does_not_leak_between_requests(): void
+    {
+        Config::set(['inertia.ssr.enabled' => true]);
+
+        $state1 = app(SsrState::class);
+        $state1->setPage(self::EXAMPLE_PAGE_OBJECT);
+        $state1->dispatch();
+
+        $this->assertNotNull($state1->response);
+
+        // Simulate Octane request boundary by flushing scoped instances
+        $this->app->forgetScopedInstances();
+
+        $state2 = app(SsrState::class);
+
+        $this->assertNotSame($state1, $state2);
+        $this->assertNull($state2->response);
+    }
+}


### PR DESCRIPTION
This PR adds `<x-inertia::head>` and `<x-inertia::body>` Blade components as an alternative to the `@inertiaHead` and `@inertia` directives.

The head component solves a long-standing issue where SSR-enabled apps end up with duplicate `<title>` tags because both the SSR response and the Blade template fallback render their own. With the component, the slot content acts as a natural fallback that only renders when SSR is not active:

```blade
<x-inertia::head>
    <title>{{ config('app.name') }}</title>
</x-inertia::head>

<x-inertia::body />
```

Fixes #666.