### PR TITLE
[3.x] Migrate Blade components to inline syntax

### DIFF
--- a/src/View/Components/App.php
+++ b/src/View/Components/App.php
@@ -2,35 +2,32 @@
 
 namespace Inertia\View\Components;
 
-use Closure;
-use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
+use Inertia\Ssr\Response;
 use Inertia\Ssr\SsrState;
 
 class App extends Component
 {
+    public ?Response $response;
+
+    public string $pageJson;
+
     public function __construct(
         public string $id = 'app',
-    ) {}
-
-    public function render(): Closure
-    {
-        return function () {
-            $state = app(SsrState::class);
-            $response = $state->dispatch();
-
-            if ($response) {
-                return new HtmlString($response->body);
-            }
-
-            return new HtmlString('<script data-page="'.$this->id.'" type="application/json">'.json_encode($state->page).'</script><div id="'.$this->id.'"></div>');
-        };
+    ) {
+        $state = app(SsrState::class);
+        $this->response = $state->dispatch();
+        $this->pageJson = json_encode($state->page);
     }
 
-    public function resolveView()
+    public function render(): string
     {
-        $view = $this->render();
-
-        return fn (array $data = []) => $view($data);
+        return <<<'blade'
+@if($response)
+{!! $response->body !!}
+@else
+<script data-page="{{ $id }}" type="application/json">{!! $pageJson !!}</script><div id="{{ $id }}"></div>
+@endif
+blade;
     }
 }

--- a/src/View/Components/App.php
+++ b/src/View/Components/App.php
@@ -3,6 +3,7 @@
 namespace Inertia\View\Components;
 
 use Closure;
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 use Inertia\Ssr\SsrState;
 
@@ -19,10 +20,17 @@ class App extends Component
             $response = $state->dispatch();
 
             if ($response) {
-                return $response->body;
+                return new HtmlString($response->body);
             }
 
-            return '<script data-page="'.$this->id.'" type="application/json">'.json_encode($state->page).'</script><div id="'.$this->id.'"></div>';
+            return new HtmlString('<script data-page="'.$this->id.'" type="application/json">'.json_encode($state->page).'</script><div id="'.$this->id.'"></div>');
         };
+    }
+
+    public function resolveView()
+    {
+        $view = $this->render();
+
+        return fn (array $data = []) => $view($data);
     }
 }

--- a/src/View/Components/Head.php
+++ b/src/View/Components/Head.php
@@ -3,6 +3,7 @@
 namespace Inertia\View\Components;
 
 use Closure;
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 use Inertia\Ssr\SsrState;
 
@@ -14,10 +15,17 @@ class Head extends Component
             $response = app(SsrState::class)->dispatch();
 
             if ($response) {
-                return $response->head;
+                return new HtmlString($response->head);
             }
 
-            return (string) $data['slot'];
+            return new HtmlString((string) $data['slot']);
         };
+    }
+
+    public function resolveView()
+    {
+        $view = $this->render();
+
+        return fn (array $data = []) => $view($data);
     }
 }

--- a/src/View/Components/Head.php
+++ b/src/View/Components/Head.php
@@ -2,30 +2,27 @@
 
 namespace Inertia\View\Components;
 
-use Closure;
-use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
+use Inertia\Ssr\Response;
 use Inertia\Ssr\SsrState;
 
 class Head extends Component
 {
-    public function render(): Closure
+    public ?Response $response;
+
+    public function __construct()
     {
-        return function (array $data) {
-            $response = app(SsrState::class)->dispatch();
-
-            if ($response) {
-                return new HtmlString($response->head);
-            }
-
-            return new HtmlString((string) $data['slot']);
-        };
+        $this->response = app(SsrState::class)->dispatch();
     }
 
-    public function resolveView()
+    public function render(): string
     {
-        $view = $this->render();
-
-        return fn (array $data = []) => $view($data);
+        return <<<'blade'
+@if($response)
+{!! $response->head !!}
+@else
+{!! $slot !!}
+@endif
+blade;
     }
 }

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -160,6 +160,22 @@ class ComponentTest extends TestCase
         $this->assertSame($directive, $component);
     }
 
+    public function test_components_do_not_create_cached_view_files_per_request(): void
+    {
+        Config::set(['inertia.ssr.enabled' => true]);
+
+        $viewCachePath = $this->app['config']['view.compiled'];
+        $view = '<x-inertia::head><title>Fallback</title></x-inertia::head><x-inertia::app />';
+
+        $this->renderView($view, ['page' => self::EXAMPLE_PAGE_OBJECT]);
+        $cachedViews = glob($viewCachePath.'/*.php');
+
+        $this->app->forgetScopedInstances();
+
+        $this->renderView($view, ['page' => ['component' => 'Different', 'props' => ['foo' => 'bar']]]);
+        $this->assertSame($cachedViews, glob($viewCachePath.'/*.php'));
+    }
+
     public function test_ssr_state_is_scoped_and_does_not_leak_between_requests(): void
     {
         Config::set(['inertia.ssr.enabled' => true]);


### PR DESCRIPTION
The `<x-inertia::app>` and `<x-inertia::head>` Blade components were returning dynamic HTML strings from their render closures. Laravel treats these as inline Blade templates and writes a compiled cache file to `storage/framework/views` for each unique string. 

This PR switches to static inline Blade templates with public properties for the dynamic data. The template string is always identical, so it compiles and caches exactly once. The SSR content flows through variables instead of being embedded in the template itself.