### PR TITLE
[3.x] Fix middleware priority

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -72,12 +72,11 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected function configureMiddlewarePriority(): void
     {
-        $kernel = $this->app->make(HttpKernelContract::class);
-
-        // @phpstan-ignore-next-line
-        if ($kernel instanceof Kernel) {
-            $kernel->addToMiddlewarePriorityAfter(StartSession::class, Middleware::class);
-        }
+        $this->callAfterResolving(HttpKernelContract::class, function ($kernel) {
+            if ($kernel instanceof Kernel) {
+                $kernel->addToMiddlewarePriorityAfter(StartSession::class, Middleware::class);
+            }
+        });
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -74,6 +74,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         $kernel = $this->app->make(HttpKernelContract::class);
 
+        // @phpstan-ignore-next-line
         if ($kernel instanceof Kernel) {
             $kernel->addToMiddlewarePriorityAfter(StartSession::class, Middleware::class);
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Inertia;
 
 use Illuminate\Foundation\Http\Kernel;
+use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
@@ -71,9 +72,11 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected function configureMiddlewarePriority(): void
     {
-        $this->app->afterResolving(Kernel::class, function (Kernel $kernel) {
+        $kernel = $this->app->make(HttpKernelContract::class);
+
+        if ($kernel instanceof Kernel) {
             $kernel->addToMiddlewarePriorityAfter(StartSession::class, Middleware::class);
-        });
+        }
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Inertia;
 
-use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
+use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -3,7 +3,7 @@
 namespace Inertia\Tests;
 
 use Illuminate\Cache\RateLimiting\Limit;
-use Illuminate\Foundation\Http\Kernel;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\ThrottleRequests;
 use Illuminate\Routing\Router;

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -3,14 +3,17 @@
 namespace Inertia\Tests;
 
 use Illuminate\Cache\RateLimiting\Limit;
-use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\ThrottleRequests;
-use Illuminate\Routing\Router;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
+use Inertia\Middleware;
+use Inertia\ServiceProvider;
 use Inertia\Tests\Stubs\ExampleMiddleware;
 
 class ServiceProviderTest extends TestCase
@@ -49,17 +52,22 @@ class ServiceProviderTest extends TestCase
 
     public function test_inertia_middleware_is_prioritized_after_start_session(): void
     {
-        $route = Route::middleware(['web', ExampleMiddleware::class, 'throttle:api'])
-            ->delete('/foo', fn () => 'ok');
+        // Simulate the production boot order where the Kernel is resolved
+        // in Application::handleRequest() BEFORE service providers boot
+        // in Kernel::sendRequestThroughRouter().
+        $app = new Application(__DIR__);
+        $app->singleton(HttpKernelContract::class, Kernel::class);
 
-        // Resolve Kernel to register middleware groups
-        app(Kernel::class);
+        /** @var Kernel $kernel */
+        $kernel = $app->make(HttpKernelContract::class);
 
-        $middleware = app(Router::class)->resolveMiddleware($route->gatherMiddleware());
+        (new ServiceProvider($app))->boot();
+
+        $middleware = $kernel->getMiddlewarePriority();
 
         $startSessionIndex = array_search(StartSession::class, $middleware);
-        $inertiaIndex = array_search(ExampleMiddleware::class, $middleware);
-        $throttleIndex = array_search(ThrottleRequests::class.':api', $middleware);
+        $inertiaIndex = array_search(Middleware::class, $middleware);
+        $throttleIndex = array_search(ThrottleRequests::class, $middleware);
 
         $this->assertNotFalse($startSessionIndex);
         $this->assertNotFalse($inertiaIndex);
@@ -67,7 +75,7 @@ class ServiceProviderTest extends TestCase
 
         $this->assertTrue(
             $startSessionIndex < $inertiaIndex,
-            'StartSession middleware must run before Inertia middleware.'
+            'Inertia middleware must run after StartSession.'
         );
 
         $this->assertTrue(


### PR DESCRIPTION
Fix for PR #801
### Problem
I was pulling my hair out over this and finally figured out what was happening. The `afterResolving` callback in `ServiceProvider::configureMiddlewarePriority` doesn't actually run during a real request. The service provider registers that callback to run `addToMiddlewarePriorityAfter` when `Illuminate\Foundation\Http\Kernel` is resolved from the container, but the Kernel is resolved in `Illuminate\Foundation\Application::handleRequest`, before the application is bootstrapped. The tests are misleading because the application is bootstrapped before any of the tests run.

### Proposed solution
Don't rely on an `afterResolving` callback to set the middleware priority. Just set it right away when the service provider boots.