### PR TITLE
[3.x] Add `Inertia::disableSsr()` method

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -36,7 +36,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Inertia\ResponseFactory
+ * @see ResponseFactory
  */
 class Inertia extends Facade
 {

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void clearHistory()
  * @method static void preserveFragment()
  * @method static void encryptHistory(bool $encrypt = true)
+ * @method static void disableSsr(\Closure|bool $condition = true)
  * @method static void withoutSsr(array<int, string>|string $paths)
  * @method static \Inertia\OptionalProp optional(callable $callback)
  * @method static \Inertia\DeferProp defer(callable $callback, string $group = 'default')

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -187,6 +187,20 @@ class ResponseFactory
     }
 
     /**
+     * Disable server-side rendering, optionally based on a condition.
+     */
+    public function disableSsr(Closure|bool $condition = true): void
+    {
+        $gateway = app(Gateway::class);
+
+        if (! $gateway instanceof Ssr\HttpGateway) {
+            throw new LogicException('The configured SSR gateway does not support conditionally disabling server-side rendering.');
+        }
+
+        $gateway->disableWhen($condition);
+    }
+
+    /**
      * Exclude the given paths from server-side rendering.
      *
      * @param  array<int, string>|string  $paths

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -2,6 +2,7 @@
 
 namespace Inertia\Ssr;
 
+use Closure;
 use Exception;
 use Illuminate\Foundation\Http\Middleware\Concerns\ExcludesPaths;
 use Illuminate\Http\Client\StrayRequestException;
@@ -10,10 +11,12 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\Str;
+use Inertia\ResolvesCallables;
 
 class HttpGateway implements ExcludesSsrPaths, Gateway, HasHealthCheck
 {
     use ExcludesPaths;
+    use ResolvesCallables;
 
     /**
      * The paths that should be excluded from server-side rendering.
@@ -21,6 +24,11 @@ class HttpGateway implements ExcludesSsrPaths, Gateway, HasHealthCheck
      * @var array<int, string>
      */
     protected $except = [];
+
+    /**
+     * The condition that determines if SSR is disabled.
+     */
+    protected Closure|bool|null $disabled = null;
 
     /**
      * Dispatch the Inertia page to the SSR engine via HTTP.
@@ -75,6 +83,14 @@ class HttpGateway implements ExcludesSsrPaths, Gateway, HasHealthCheck
     }
 
     /**
+     * Set the condition that determines if SSR should be disabled.
+     */
+    public function disableWhen(Closure|bool $condition): void
+    {
+        $this->disabled = $condition;
+    }
+
+    /**
      * Exclude the given paths from server-side rendering.
      *
      * @param  array<int, string>|string  $paths
@@ -126,7 +142,11 @@ class HttpGateway implements ExcludesSsrPaths, Gateway, HasHealthCheck
      */
     protected function ssrIsEnabled(Request $request): bool
     {
-        return config('inertia.ssr.enabled', true) && ! $this->inExceptArray($request);
+        $enabled = $this->disabled !== null
+            ? ! $this->resolveCallable($this->disabled)
+            : config('inertia.ssr.enabled', true);
+
+        return $enabled && ! $this->inExceptArray($request);
     }
 
     /**

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -431,6 +431,49 @@ class HttpGatewayTest extends TestCase
         $this->gateway->dispatch(self::EXAMPLE_PAGE_OBJECT);
     }
 
+    public function test_it_returns_null_when_disabled_with_boolean(): void
+    {
+        config([
+            'inertia.ssr.enabled' => true,
+            'inertia.ssr.bundle' => __DIR__.'/Stubs/ssr-bundle.js',
+        ]);
+
+        $this->gateway->disableWhen(true);
+
+        $this->assertNull($this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]));
+    }
+
+    public function test_it_returns_null_when_disabled_with_closure(): void
+    {
+        config([
+            'inertia.ssr.enabled' => true,
+            'inertia.ssr.bundle' => __DIR__.'/Stubs/ssr-bundle.js',
+        ]);
+
+        $this->gateway->disableWhen(fn () => true);
+
+        $this->assertNull($this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]));
+    }
+
+    public function test_disable_when_takes_precedence_over_config(): void
+    {
+        config([
+            'inertia.ssr.enabled' => true,
+            'inertia.ssr.bundle' => __DIR__.'/Stubs/ssr-bundle.js',
+        ]);
+
+        $this->gateway->disableWhen(false);
+
+        Http::fake([
+            $this->renderUrl => Http::response(json_encode([
+                'head' => ['<title>SSR Test</title>'],
+                'body' => '<div id="app">SSR Response</div>',
+            ])),
+        ]);
+
+        $this->assertNotNull($this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]));
+    }
+
     public function test_it_does_not_throw_exception_when_throw_on_error_is_disabled(): void
     {
         Event::fake([SsrRenderFailed::class]);


### PR DESCRIPTION
This PR adds an `Inertia::disableSsr()` method to programmatically disable server-side rendering. It accepts an optional closure or boolean, defaulting to `true`.

When running PHP tests while the Vite dev server is active, SSR requests are dispatched to the dev server's `/__inertia_ssr` endpoint. This breaks tests that use `Http::preventStrayRequests()`. You may now disable SSR in your test setup or service provider:

```php
// Disable SSR entirely...
Inertia::disableSsr();

// Disable SSR conditionally...
Inertia::disableSsr(app()->runningUnitTests());

// With callback...
Inertia::disableSsr(fn () => app()->runningUnitTests());
```

Fixes #853.