### PR TITLE
[3.x] Add SSR runtime config option

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -23,6 +23,10 @@ return [
 
         'enabled' => (bool) env('INERTIA_SSR_ENABLED', true),
 
+        'runtime' => env('INERTIA_SSR_RUNTIME', 'node'),
+
+        'ensure_runtime_exists' => (bool) env('INERTIA_SSR_ENSURE_RUNTIME_EXISTS', false),
+
         'url' => env('INERTIA_SSR_URL', 'http://127.0.0.1:13714'),
 
         'ensure_bundle_exists' => (bool) env('INERTIA_SSR_ENSURE_BUNDLE_EXISTS', true),

--- a/src/Commands/StartSsr.php
+++ b/src/Commands/StartSsr.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Inertia\Ssr\BundleDetector;
 use Inertia\Ssr\SsrException;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 #[AsCommand(name: 'inertia:start-ssr')]
@@ -16,7 +17,7 @@ class StartSsr extends Command
      *
      * @var string
      */
-    protected $signature = 'inertia:start-ssr {--runtime=node : The runtime to use (`node` or `bun`)}';
+    protected $signature = 'inertia:start-ssr {--runtime= : The runtime to use (e.g. `node`, `bun`, or an absolute path)}';
 
     /**
      * The console command description.
@@ -52,17 +53,17 @@ class StartSsr extends Command
             $this->warn('Using a default bundle instead: "'.$bundle.'"');
         }
 
-        $runtime = $this->option('runtime');
+        $runtime = $this->option('runtime') ?? config('inertia.ssr.runtime', 'node');
 
-        if (! in_array($runtime, ['node', 'bun'])) {
-            $this->error('Unsupported runtime: "'.$runtime.'". Supported runtimes are `node` and `bun`.');
+        if (config('inertia.ssr.ensure_runtime_exists', false) && ! (new ExecutableFinder)->find($runtime)) {
+            $this->error('SSR runtime "'.$runtime.'" could not be found.');
 
-            return self::INVALID;
+            return self::FAILURE;
         }
 
         $this->callSilently('inertia:stop-ssr');
 
-        $process = new Process([$runtime, $bundle]);
+        $process = app(Process::class, ['command' => [$runtime, $bundle]]);
         $process->setTimeout(null);
         $process->start();
 

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -36,7 +36,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Inertia\ResponseFactory
+ * @see ResponseFactory
  */
 class Inertia extends Facade
 {

--- a/tests/Commands/StartSsrTest.php
+++ b/tests/Commands/StartSsrTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Inertia\Tests\Commands;
+
+use Inertia\Tests\TestCase;
+use Symfony\Component\Process\Process;
+
+class StartSsrTest extends TestCase
+{
+    /** @var list<string>|null */
+    protected ?array $processCommand = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('inertia.ssr.enabled', true);
+        config()->set('inertia.ssr.bundle', __FILE__);
+    }
+
+    protected function fakeProcess(): void
+    {
+        $this->app->bind(Process::class, function ($app, $params) {
+            $this->processCommand = $params['command'];
+
+            return new Process(['true']);
+        });
+    }
+
+    public function test_error_when_ssr_is_disabled(): void
+    {
+        config()->set('inertia.ssr.enabled', false);
+
+        $this->artisan('inertia:start-ssr')
+            ->expectsOutput('Inertia SSR is not enabled. Enable it via the `inertia.ssr.enabled` config option.')
+            ->assertExitCode(1);
+    }
+
+    public function test_error_when_configured_bundle_not_found(): void
+    {
+        config()->set('inertia.ssr.bundle', '/nonexistent/path/ssr.mjs');
+
+        $this->artisan('inertia:start-ssr')
+            ->expectsOutput('Inertia SSR bundle not found at the configured path: "/nonexistent/path/ssr.mjs"')
+            ->assertExitCode(1);
+    }
+
+    public function test_error_when_no_bundle_configured_and_detection_fails(): void
+    {
+        config()->set('inertia.ssr.bundle', null);
+
+        $this->artisan('inertia:start-ssr')
+            ->expectsOutput('Inertia SSR bundle not found. Set the correct Inertia SSR bundle path in your `inertia.ssr.bundle` config.')
+            ->assertExitCode(1);
+    }
+
+    public function test_bundle_is_auto_detected_when_not_configured(): void
+    {
+        $this->fakeProcess();
+        config()->set('inertia.ssr.bundle', null);
+
+        $bundlePath = base_path('bootstrap/ssr/ssr.mjs');
+        @mkdir(dirname($bundlePath), recursive: true);
+        file_put_contents($bundlePath, '');
+
+        try {
+            $this->artisan('inertia:start-ssr')->assertExitCode(0);
+
+            $this->assertSame($bundlePath, $this->processCommand[1]);
+        } finally {
+            @unlink($bundlePath);
+            @rmdir(base_path('bootstrap/ssr'));
+        }
+    }
+
+    public function test_runtime_defaults_to_node(): void
+    {
+        $this->fakeProcess();
+
+        $this->artisan('inertia:start-ssr')->assertExitCode(0);
+
+        $this->assertSame('node', $this->processCommand[0]);
+    }
+
+    public function test_runtime_can_be_configured(): void
+    {
+        $this->fakeProcess();
+        config()->set('inertia.ssr.runtime', 'bun');
+
+        $this->artisan('inertia:start-ssr')->assertExitCode(0);
+
+        $this->assertSame('bun', $this->processCommand[0]);
+    }
+
+    public function test_runtime_can_be_an_absolute_path(): void
+    {
+        $this->fakeProcess();
+        config()->set('inertia.ssr.runtime', '/usr/local/bin/node');
+
+        $this->artisan('inertia:start-ssr')->assertExitCode(0);
+
+        $this->assertSame('/usr/local/bin/node', $this->processCommand[0]);
+    }
+
+    public function test_runtime_option_overrides_config(): void
+    {
+        $this->fakeProcess();
+        config()->set('inertia.ssr.runtime', 'bun');
+
+        $this->artisan('inertia:start-ssr', ['--runtime' => '/custom/path/node'])->assertExitCode(0);
+
+        $this->assertSame('/custom/path/node', $this->processCommand[0]);
+    }
+
+    public function test_ensure_runtime_exists_fails_when_runtime_not_found(): void
+    {
+        config()->set('inertia.ssr.ensure_runtime_exists', true);
+        config()->set('inertia.ssr.runtime', 'nonexistent-runtime-binary');
+
+        $this->artisan('inertia:start-ssr')
+            ->expectsOutput('SSR runtime "nonexistent-runtime-binary" could not be found.')
+            ->assertExitCode(1);
+    }
+
+    public function test_ensure_runtime_exists_passes_when_runtime_found(): void
+    {
+        $this->fakeProcess();
+        config()->set('inertia.ssr.ensure_runtime_exists', true);
+        config()->set('inertia.ssr.runtime', 'php');
+
+        $this->artisan('inertia:start-ssr')->assertExitCode(0);
+    }
+
+    public function test_runtime_is_not_checked_by_default(): void
+    {
+        $this->fakeProcess();
+        config()->set('inertia.ssr.runtime', 'nonexistent-runtime-binary');
+
+        $this->artisan('inertia:start-ssr')->assertExitCode(0);
+
+        $this->assertSame('nonexistent-runtime-binary', $this->processCommand[0]);
+    }
+}


### PR DESCRIPTION
This PR adds a configurable SSR runtime so you can point to a specific binary instead of relying on `node` being available on the system PATH.

- New `inertia.ssr.runtime` config option
- `--runtime` CLI option on `inertia:start-ssr` overrides the config value
- Optional `inertia.ssr.ensure_runtime_exists` config to verify the runtime binary exists before starting the SSR server
- Removes the hardcoded `node`/`bun` allowlist
- Resolves `Process` through the container for testability

Based on #852 by @shaffe-fr.