### PR TITLE
[3.x] Handle redirect status codes with global middleware

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -32,6 +32,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Inertia\ResponseFactory flash(\BackedEnum|\UnitEnum|string|array<string, mixed> $key, mixed $value = null)
  * @method static \Symfony\Component\HttpFoundation\RedirectResponse back(int $status = 302, array<string, string> $headers = [], mixed $fallback = false)
  * @method static array<string, mixed> getFlashed(\Illuminate\Http\Request|null $request = null)
+ * @method static array<string, mixed> pullFlashed(\Illuminate\Http\Request|null $request = null)
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static bool hasMacro(string $name)

--- a/src/Middleware/EnsureGetOnRedirect.php
+++ b/src/Middleware/EnsureGetOnRedirect.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Inertia\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Inertia\Support\Header;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureGetOnRedirect
+{
+    /**
+     * Ensure redirects after PUT/PATCH/DELETE requests result in a
+     * GET request by converting 302 responses to 303.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        /** @var Response $response */
+        $response = $next($request);
+
+        if ($response->getStatusCode() === 302
+            && $request->header(Header::INERTIA)
+            && in_array($request->method(), ['PUT', 'PATCH', 'DELETE'])
+        ) {
+            $response->setStatusCode(303);
+        }
+
+        return $response;
+    }
+}

--- a/src/Response.php
+++ b/src/Response.php
@@ -238,7 +238,7 @@ class Response implements Responsable
      */
     protected function resolveFlashData(Request $request): array
     {
-        $flash = Inertia::getFlashed($request);
+        $flash = Inertia::pullFlashed($request);
 
         return $flash ? ['flash' => $flash] : [];
     }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -451,7 +451,7 @@ class ResponseFactory
             $flash = [$key => $value];
         }
 
-        session()->now(SessionKey::FLASH_DATA, [
+        session()->flash(SessionKey::FLASH_DATA, [
             ...$this->getFlashed(),
             ...$flash,
         ]);
@@ -479,5 +479,17 @@ class ResponseFactory
         $request ??= request();
 
         return $request->hasSession() ? $request->session()->get(SessionKey::FLASH_DATA, []) : [];
+    }
+
+    /**
+     * Retrieve and remove the flashed data from the session.
+     *
+     * @return array<string, mixed>
+     */
+    public function pullFlashed(?HttpRequest $request = null): array
+    {
+        $request ??= request();
+
+        return $request->hasSession() ? $request->session()->pull(SessionKey::FLASH_DATA, []) : [];
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -66,8 +66,7 @@ class ServiceProvider extends BaseServiceProvider
     }
 
     /**
-     * Ensure redirects after PUT/PATCH/DELETE Inertia requests result
-     * in a GET request, even when other middleware short-circuits.
+     * Register the global redirect middleware for Inertia requests.
      */
     protected function pushRedirectMiddleware(): void
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,11 +2,11 @@
 
 namespace Inertia;
 
+use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
-use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Illuminate\Testing\TestResponse;
@@ -58,7 +58,7 @@ class ServiceProvider extends BaseServiceProvider
     public function boot(): void
     {
         $this->registerConsoleCommands();
-        $this->configureMiddlewarePriority();
+        $this->pushRedirectMiddleware();
 
         $this->publishes([
             __DIR__.'/../config/inertia.php' => config_path('inertia.php'),
@@ -66,13 +66,15 @@ class ServiceProvider extends BaseServiceProvider
     }
 
     /**
-     * Configure middleware priority to ensure Inertia can intercept
-     * redirect responses from other middleware (like throttle).
+     * Ensure redirects after PUT/PATCH/DELETE Inertia requests result
+     * in a GET request, even when other middleware short-circuits.
      */
-    protected function configureMiddlewarePriority(): void
+    protected function pushRedirectMiddleware(): void
     {
-        $this->app->afterResolving(Kernel::class, function (Kernel $kernel) {
-            $kernel->addToMiddlewarePriorityAfter(StartSession::class, Middleware::class);
+        $this->callAfterResolving(HttpKernelContract::class, function ($kernel) {
+            if ($kernel instanceof Kernel) {
+                $kernel->pushMiddleware(Middleware\EnsureGetOnRedirect::class);
+            }
         });
     }
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -3,14 +3,13 @@
 namespace Inertia\Tests;
 
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Http\Request;
-use Illuminate\Routing\Middleware\ThrottleRequests;
-use Illuminate\Routing\Router;
-use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
+use Inertia\Middleware\EnsureGetOnRedirect;
 use Inertia\Tests\Stubs\ExampleMiddleware;
 
 class ServiceProviderTest extends TestCase
@@ -47,33 +46,12 @@ class ServiceProviderTest extends TestCase
         $this->assertEquals(['component' => 'User/Edit', 'props' => ['user' => ['name' => 'Jonathan']]], $inertiaRoute->defaults);
     }
 
-    public function test_inertia_middleware_is_prioritized_after_start_session(): void
+    public function test_ensure_get_on_redirect_middleware_is_registered_globally(): void
     {
-        $route = Route::middleware(['web', ExampleMiddleware::class, 'throttle:api'])
-            ->delete('/foo', fn () => 'ok');
+        /** @var Kernel $kernel */
+        $kernel = $this->app->make(HttpKernelContract::class);
 
-        // Resolve Kernel to register middleware groups
-        app(Kernel::class);
-
-        $middleware = app(Router::class)->resolveMiddleware($route->gatherMiddleware());
-
-        $startSessionIndex = array_search(StartSession::class, $middleware);
-        $inertiaIndex = array_search(ExampleMiddleware::class, $middleware);
-        $throttleIndex = array_search(ThrottleRequests::class.':api', $middleware);
-
-        $this->assertNotFalse($startSessionIndex);
-        $this->assertNotFalse($inertiaIndex);
-        $this->assertNotFalse($throttleIndex);
-
-        $this->assertTrue(
-            $startSessionIndex < $inertiaIndex,
-            'StartSession middleware must run before Inertia middleware.'
-        );
-
-        $this->assertTrue(
-            $inertiaIndex < $throttleIndex,
-            'Inertia middleware must run before ThrottleRequests middleware.'
-        );
+        $this->assertTrue($kernel->hasMiddleware(EnsureGetOnRedirect::class));
     }
 
     public function test_redirect_response_from_rate_limiter_is_converted_to_303(): void

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -484,4 +484,27 @@ class AssertableInertiaTest extends TestCase
         $this->get('/action')->assertRedirect('/dashboard');
         $this->get('/dashboard')->assertInertia(fn (AssertableInertia $inertia) => $inertia->hasFlash('message', 'Success!'));
     }
+
+    public function test_the_flash_data_is_available_after_double_redirect(): void
+    {
+        $middleware = [StartSession::class, Middleware::class];
+
+        Route::middleware($middleware)->get('/action', function () {
+            Inertia::flash('message', 'Success!');
+
+            return redirect('/intermediate');
+        });
+
+        Route::middleware($middleware)->get('/intermediate', function () {
+            return redirect('/dashboard');
+        });
+
+        Route::middleware($middleware)->get('/dashboard', function () {
+            return Inertia::render('Dashboard');
+        });
+
+        $this->get('/action')->assertRedirect('/intermediate');
+        $this->get('/intermediate')->assertRedirect('/dashboard');
+        $this->get('/dashboard')->assertInertia(fn (AssertableInertia $inertia) => $inertia->hasFlash('message', 'Success!'));
+    }
 }


### PR DESCRIPTION
The Inertia middleware previously had its position forced before `ThrottleRequests` in the middleware priority list (#801 / #854), which also placed it before `SubstituteBindings`. This meant `$request->route('model')` in the middleware's `share()` method returned the raw route parameter instead of the resolved model (#858).

This PR takes a different approach. Instead of manipulating the middleware priority, it registers a lightweight global middleware (`EnsureGetOnRedirect`) that converts 302 redirects to 303 for Inertia PUT/PATCH/DELETE requests.

Fixes #858.