### PR TITLE
[3.x] Pin GitHub Actions to commit SHAs and harden CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "2.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   lint:
-    uses: laravel/.github/.github/workflows/coding-standards.yml@main
+    uses: laravel/.github/.github/workflows/coding-standards.yml@4bf890cc0e48724d6f2061c28f2e6ff48911adbd # main
     with:
       php: "8.3"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   tests:
-    uses: laravel/.github/.github/workflows/static-analysis.yml@main
+    uses: laravel/.github/.github/workflows/static-analysis.yml@4bf890cc0e48724d6f2061c28f2e6ff48911adbd # main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-24.04
@@ -22,10 +25,12 @@ jobs:
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} (w/ ${{ matrix.stability }})
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip
@@ -34,14 +39,14 @@ jobs:
           coverage: none
 
       - name: Set Laravel version
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 5
           max_attempts: 5
           command: composer require "laravel/framework=^${{ matrix.laravel }}" --no-interaction --no-update
 
       - name: Install dependencies
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           timeout_minutes: 5
           max_attempts: 5

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: write
+
 jobs:
   update:
-    uses: laravel/.github/.github/workflows/update-changelog.yml@main
+    uses: laravel/.github/.github/workflows/update-changelog.yml@4bf890cc0e48724d6f2061c28f2e6ff48911adbd # main


### PR DESCRIPTION
This PR mirrors the changes from inertiajs/inertia#3097 for the Laravel adapter. All third-party GitHub Actions are pinned to specific commit SHAs (with version comments) across every workflow file.

The `tests.yml` workflow also gains `persist-credentials: false` on `actions/checkout` to drop the `GITHUB_TOKEN` from the runner after checkout.

Here's an overview of the pinned actions:

| Action                 | Version | Hash                                       | Release                                                                            |
| ---------------------- | ------- | ------------------------------------------ | ---------------------------------------------------------------------------------- |
| actions/checkout       | v4.3.1  | `34e114876b0b11c390a56381ad16ebd13914f8d5` | https://github.com/actions/checkout/releases/tag/v4.3.1                            |
| shivammathur/setup-php | 2.37.0  | `accd6127cb78bee3e8082180cb391013d204ef9f` | https://github.com/shivammathur/setup-php/releases/tag/2.37.0                      |
| nick-fields/retry      | v3.0.2  | `ce71cc2ab81d554ebbe88c79ab5975992d79ba08` | https://github.com/nick-fields/retry/releases/tag/v3.0.2                           |
| laravel/.github        | main    | `4bf890cc0e48724d6f2061c28f2e6ff48911adbd` | https://github.com/laravel/.github/commit/4bf890cc0e48724d6f2061c28f2e6ff48911adbd |