### PR TITLE
[3.x] Include asset version on version-mismatch location response

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -212,7 +212,8 @@ class Middleware
             $session->reflash();
         }
 
-        return Inertia::location($request->fullUrl());
+        return Inertia::location($request->fullUrl())
+            ->header(Header::VERSION, Inertia::getVersion());
     }
 
     /**

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -212,8 +212,10 @@ class Middleware
             $session->reflash();
         }
 
-        return Inertia::location($request->fullUrl())
-            ->header(Header::VERSION, Inertia::getVersion());
+        $response = Inertia::location($request->fullUrl());
+        $response->headers->set(Header::VERSION, Inertia::getVersion());
+
+        return $response;
     }
 
     /**

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -132,6 +132,7 @@ class MiddlewareTest extends TestCase
 
         $response->assertStatus(409);
         $response->assertHeader('X-Inertia-Location', $this->baseUrl);
+        $response->assertHeader('X-Inertia-Version', '1234');
         self::assertEmpty($response->getContent());
     }
 


### PR DESCRIPTION
On an asset version mismatch, the middleware responds with a 409 location visit so the client performs a full-page reload and picks up the new assets. This response was indistinguishable from a manual `Inertia::location()` redirect, since both carry only the `X-Inertia-Location` header.

This PR adds the current asset version to the `X-Inertia-Version` header on that response. The client uses it to tell an automatic version change apart from an explicit redirect, so it may defer the forced reload on background requests, like polling or a websocket-driven `router.reload()`, and pick up the new assets on the next user-initiated visit instead. 

See also inertiajs/inertia#3180.