### PR TITLE
[3.x] Custom SSR Hot URL

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -29,7 +29,7 @@ return [
 
         'url' => env('INERTIA_SSR_URL', 'http://127.0.0.1:13714'),
 
-        'hot_url' => env('INERTIA_SSR_DEV_URL'),
+        'hot_url' => env('INERTIA_SSR_HOT_URL'),
 
         'ensure_bundle_exists' => (bool) env('INERTIA_SSR_ENSURE_BUNDLE_EXISTS', true),
 

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -29,7 +29,7 @@ return [
 
         'url' => env('INERTIA_SSR_URL', 'http://127.0.0.1:13714'),
 
-        'dev_url' => env('INERTIA_SSR_DEV_URL'),
+        'hot_url' => env('INERTIA_SSR_DEV_URL'),
 
         'ensure_bundle_exists' => (bool) env('INERTIA_SSR_ENSURE_BUNDLE_EXISTS', true),
 

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -29,6 +29,8 @@ return [
 
         'url' => env('INERTIA_SSR_URL', 'http://127.0.0.1:13714'),
 
+        'dev_url' => env('INERTIA_SSR_DEV_URL'),
+
         'ensure_bundle_exists' => (bool) env('INERTIA_SSR_ENSURE_BUNDLE_EXISTS', true),
 
         // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -197,6 +197,10 @@ class HttpGateway implements DisablesSsr, ExcludesSsrPaths, Gateway, HasHealthCh
      */
     protected function getHotUrl(string $path = '/'): string
     {
+        if ($devUrl = config('inertia.ssr.dev_url')) {
+            return rtrim($devUrl, '/').$path;
+        }
+        
         return rtrim(file_get_contents(Vite::hotFile())).$path;
     }
 }

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -197,8 +197,8 @@ class HttpGateway implements DisablesSsr, ExcludesSsrPaths, Gateway, HasHealthCh
      */
     protected function getHotUrl(string $path = '/'): string
     {
-        if ($devUrl = config('inertia.ssr.hot_url', false)) {
-            return rtrim($devUrl, '/').$path;
+        if ($hotUrl = config('inertia.ssr.hot_url', false)) {
+            return rtrim($hotUrl, '/').$path;
         }
         
         return rtrim(file_get_contents(Vite::hotFile())).$path;

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -197,7 +197,7 @@ class HttpGateway implements DisablesSsr, ExcludesSsrPaths, Gateway, HasHealthCh
      */
     protected function getHotUrl(string $path = '/'): string
     {
-        if ($devUrl = config('inertia.ssr.dev_url', false)) {
+        if ($devUrl = config('inertia.ssr.hot_url', false)) {
             return rtrim($devUrl, '/').$path;
         }
         

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -197,10 +197,9 @@ class HttpGateway implements DisablesSsr, ExcludesSsrPaths, Gateway, HasHealthCh
      */
     protected function getHotUrl(string $path = '/'): string
     {
-        if ($hotUrl = config('inertia.ssr.hot_url', false)) {
-            return rtrim($hotUrl, '/').$path;
-        }
-        
-        return rtrim(file_get_contents(Vite::hotFile())).$path;
+        $path = Str::start($path, '/');
+        $baseUrl = rtrim(trim(config('inertia.ssr.hot_url') ?: file_get_contents(Vite::hotFile())), '/');
+
+        return $baseUrl.$path;
     }
 }

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -197,7 +197,7 @@ class HttpGateway implements DisablesSsr, ExcludesSsrPaths, Gateway, HasHealthCh
      */
     protected function getHotUrl(string $path = '/'): string
     {
-        if ($devUrl = config('inertia.ssr.dev_url')) {
+        if ($devUrl = config('inertia.ssr.dev_url', false)) {
             return rtrim($devUrl, '/').$path;
         }
         

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -216,24 +216,24 @@ class HttpGatewayTest extends TestCase
         $this->assertEquals('<div id="app">Hot Response</div>', $response->body);
     }
 
-    public function test_it_uses_configured_dev_url_when_running_hot(): void
+    public function test_it_uses_configured_hot_url_when_running_hot(): void
     {
         config([
             'inertia.ssr.enabled' => true,
-            'inertia.ssr.hot_url' => 'http://custom-hot-server:5173',
+            'inertia.ssr.hot_url' => 'http://custom-hot-server:5173/',
         ]);
 
         $this->createHotFile('http://localhost:5173');
 
         Http::fake([
             'http://custom-hot-server:5173/__inertia_ssr' => Http::response(json_encode([
-                    'head' => ['<title>Custom Hot SSR</title>'],
-                    'body' => '<div id="app">Custom Hot Response</div>',
+                'head' => ['<title>Custom Hot SSR</title>'],
+                'body' => '<div id="app">Custom Hot Response</div>',
             ])),
         ]);
 
         $response = $this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]);
-        
+
         $this->assertNotNull($response);
         $this->assertEquals('<title>Custom Hot SSR</title>', $response->head);
         $this->assertEquals('<div id="app">Custom Hot Response</div>', $response->body);

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -220,23 +220,23 @@ class HttpGatewayTest extends TestCase
     {
         config([
             'inertia.ssr.enabled' => true,
-            'inertia.ssr.dev_url' => 'http://custom-dev-server:5173',
+            'inertia.ssr.hot_url' => 'http://custom-hot-server:5173',
         ]);
 
         $this->createHotFile('http://localhost:5173');
 
         Http::fake([
-            'http://custom-dev-server:5173/__inertia_ssr' => Http::response(json_encode([
-                    'head' => ['<title>Custom Dev SSR</title>'],
-                    'body' => '<div id="app">Custom Dev Response</div>',
+            'http://custom-hot-server:5173/__inertia_ssr' => Http::response(json_encode([
+                    'head' => ['<title>Custom Hot SSR</title>'],
+                    'body' => '<div id="app">Custom Hot Response</div>',
             ])),
         ]);
 
         $response = $this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]);
         
         $this->assertNotNull($response);
-        $this->assertEquals('<title>Custom Dev SSR</title>', $response->head);
-        $this->assertEquals('<div id="app">Custom Dev Response</div>', $response->body);
+        $this->assertEquals('<title>Custom Hot SSR</title>', $response->head);
+        $this->assertEquals('<div id="app">Custom Hot Response</div>', $response->body);
     }
 
     public function test_it_returns_null_when_path_is_excluded_from_ssr(): void

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -216,6 +216,29 @@ class HttpGatewayTest extends TestCase
         $this->assertEquals('<div id="app">Hot Response</div>', $response->body);
     }
 
+    public function test_it_uses_configured_dev_url_when_running_hot(): void
+    {
+        config([
+            'inertia.ssr.enabled' => true,
+            'inertia.ssr.dev_url' => 'http://custom-dev-server:5173',
+        ]);
+
+        $this->createHotFile('http://localhost:5173');
+
+        Http::fake([
+            'http://custom-dev-server:5173/__inertia_ssr' => Http::response(json_encode([
+                    'head' => ['<title>Custom Dev SSR</title>'],
+                    'body' => '<div id="app">Custom Dev Response</div>',
+            ])),
+        ]);
+
+        $response = $this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]);
+        
+        $this->assertNotNull($response);
+        $this->assertEquals('<title>Custom Dev SSR</title>', $response->head);
+        $this->assertEquals('<div id="app">Custom Dev Response</div>', $response->body);
+    }
+
     public function test_it_returns_null_when_path_is_excluded_from_ssr(): void
     {
         config([


### PR DESCRIPTION
## 1. The Problem

When running Laravel inside a Docker container (e.g., Laravel Sail) and Vite on the host machine (or in a separate container), the `Vite::hotFile()` contains the URL resolved from the browser's perspective (e.g., `http://localhost:5173` or `https://vite.app.test`).

```js
// vite.config.js

server: {
    hmr: {
        host: "vite.app.test",
        protocol: "wss",
        clientPort: 443,
    },
    watch: {
        ignored: ["**/storage/**", "**/*.md"],
    },
},

```

When Inertia SSR is running in development mode (hot), the `HttpGateway` attempts to dispatch SSR requests using the URL retrieved from `Vite::hotFile()`:

```php
protected function getHotUrl(string $path = '/'): string
{
    return rtrim(file_get_contents(Vite::hotFile())).$path;
}
```

This causes connection failures inside containerized environments:
- **Loopback Issues:** `localhost` inside the Docker PHP container resolves to the container's loopback interface instead of the host machine (where Vite dev server is running).
- **DNS/SSL Errors:** Custom local domains (e.g., `https://vite.app.test`) may not resolve inside the container, or curl requests will fail due to untrusted local SSL certificates.

Since there is currently no way to configure the Vite dev server URL specifically for SSR requests in `HttpGateway`, developers must override the class manually.

---

## 2. Proposed Solution

Introduce a new hot_url` configuration option under `ssr` in `config/inertia.php` (e.g., pointing to `http://127.0.0.1:5173` or `http://host.docker.internal:5173`). If `hot_url` is provided, `HttpGateway` will use it to route local SSR requests instead of reading `Vite::hotFile()`.