### PR TITLE
Store previous locations for Inertia visits

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -3,7 +3,9 @@
 namespace Inertia;
 
 use Closure;
+use Illuminate\Contracts\Session\Session as SessionContract;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
 use Illuminate\Session\Store;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\MessageBag;
@@ -146,6 +148,8 @@ class Middleware
             return $response;
         }
 
+        $this->storeCurrentUrl($request);
+
         if ($request->method() === 'GET' && $request->header(Header::VERSION, '') !== Inertia::getVersion()) {
             $response = $this->onVersionChange($request, $response);
         }
@@ -163,6 +167,37 @@ class Middleware
         }
 
         return $response;
+    }
+
+    /**
+     * Store the current URL for Inertia visits skipped by Laravel's session middleware.
+     */
+    protected function storeCurrentUrl(Request $request): void
+    {
+        if (! $request->hasSession() ||
+            ! $request->isMethod('GET') ||
+            ! $request->route() instanceof Route ||
+            ! $request->ajax() ||
+            $request->prefetch() ||
+            $request->isPrecognitive()) {
+            return;
+        }
+
+        /** @var Store $session */
+        $session = $request->session();
+        $session->setPreviousUrl($request->fullUrl());
+
+        $this->storeCurrentRoute($session, $request->route()->getName());
+    }
+
+    /**
+     * Store the current route when supported by the Laravel version.
+     */
+    protected function storeCurrentRoute(SessionContract $session, ?string $route): void
+    {
+        if (method_exists($session, 'setPreviousRoute')) {
+            $session->setPreviousRoute($route);
+        }
     }
 
     /**

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -16,6 +16,7 @@ use Inertia\Middleware;
 use Inertia\Ssr\HttpGateway;
 use Inertia\Tests\Stubs\CustomUrlResolverMiddleware;
 use Inertia\Tests\Stubs\ExampleMiddleware;
+use Inertia\Tests\Stubs\PrecognitiveRequestMiddleware;
 use Inertia\Tests\Stubs\SsrExceptMiddleware;
 use Inertia\Tests\Stubs\WithAllErrorsMiddleware;
 use LogicException;
@@ -431,6 +432,77 @@ class MiddlewareTest extends TestCase
         ]);
     }
 
+    public function test_inertia_visits_are_stored_as_the_previous_url_and_route(): void
+    {
+        $this->preparePreviousLocationEndpoints();
+
+        $this->get('/initial')->assertOk();
+
+        $this->get('/users?filter=active', [
+            'X-Inertia' => 'true',
+            'X-Requested-With' => 'XMLHttpRequest',
+        ])->assertOk();
+
+        $this->assertPreviousLocation($this->baseUrl.'/users?filter=active', 'users.index');
+    }
+
+    public function test_inertia_prefetch_visits_are_not_stored_as_the_previous_url_and_route(): void
+    {
+        $this->preparePreviousLocationEndpoints();
+
+        $this->get('/initial')->assertOk();
+
+        $this->get('/users', [
+            'X-Inertia' => 'true',
+            'X-Requested-With' => 'XMLHttpRequest',
+            'Purpose' => 'prefetch',
+        ])->assertOk();
+
+        $this->assertPreviousLocation($this->baseUrl.'/initial', 'initial');
+    }
+
+    public function test_non_inertia_ajax_requests_are_not_stored_as_the_previous_url_and_route(): void
+    {
+        $this->preparePreviousLocationEndpoints();
+
+        $this->get('/initial')->assertOk();
+
+        $this->get('/users', [
+            'X-Requested-With' => 'XMLHttpRequest',
+        ])->assertOk();
+
+        $this->assertPreviousLocation($this->baseUrl.'/initial', 'initial');
+    }
+
+    public function test_non_get_inertia_requests_are_not_stored_as_the_previous_url_and_route(): void
+    {
+        $this->preparePreviousLocationEndpoints();
+
+        $this->get('/initial')->assertOk();
+
+        $this->post('/users', [], [
+            'X-Inertia' => 'true',
+            'X-Requested-With' => 'XMLHttpRequest',
+        ])->assertOk();
+
+        $this->assertPreviousLocation($this->baseUrl.'/initial', 'initial');
+    }
+
+    public function test_precognitive_inertia_requests_are_not_stored_as_the_previous_url_and_route(): void
+    {
+        $this->preparePreviousLocationEndpoints();
+
+        $this->get('/initial')->assertOk();
+
+        $this->get('/users', [
+            'X-Inertia' => 'true',
+            'X-Requested-With' => 'XMLHttpRequest',
+            'Precognition' => 'true',
+        ])->assertSuccessful();
+
+        $this->assertPreviousLocation($this->baseUrl.'/initial', 'initial');
+    }
+
     public function test_redirect_with_hash_fragment_returns_409_for_inertia_requests(): void
     {
         Route::middleware([StartSession::class, Middleware::class])->get('/action', function () {
@@ -529,6 +601,44 @@ class MiddlewareTest extends TestCase
             return $middleware->handle($request, function ($request) {
                 return Inertia::render('User/Edit', ['user' => ['name' => 'Jonathan']])->toResponse($request);
             });
+        });
+    }
+
+    private function assertPreviousLocation(string $url, string $route): void
+    {
+        $response = $this->post('/inspect-previous');
+
+        $response->assertJsonPath('url', $url);
+
+        if ($response->json('supportsRouteHistory')) {
+            $response->assertJsonPath('route', $route);
+        } else {
+            $response->assertJsonPath('route', null);
+        }
+    }
+
+    private function preparePreviousLocationEndpoints(): void
+    {
+        Route::middleware([StartSession::class, Middleware::class])->get('/initial', function () {
+            return response('Initial page');
+        })->name('initial');
+
+        Route::middleware([
+            StartSession::class,
+            PrecognitiveRequestMiddleware::class,
+            Middleware::class,
+        ])->match(['GET', 'POST'], '/users', function () {
+            return Inertia::render('Users/Index');
+        })->name('users.index');
+
+        Route::middleware(StartSession::class)->post('/inspect-previous', function (Request $request) {
+            return response()->json([
+                'url' => $request->session()->previousUrl(),
+                'route' => method_exists($request->session(), 'previousRoute')
+                    ? $request->session()->previousRoute()
+                    : null,
+                'supportsRouteHistory' => method_exists($request->session(), 'previousRoute'),
+            ]);
         });
     }
 }

--- a/tests/Stubs/PrecognitiveRequestMiddleware.php
+++ b/tests/Stubs/PrecognitiveRequestMiddleware.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Inertia\Tests\Stubs;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class PrecognitiveRequestMiddleware
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->header('Precognition') === 'true') {
+            $request->attributes->set('precognitive', true);
+        }
+
+        /** @var Response $response */
+        $response = $next($request);
+
+        return $response;
+    }
+}


### PR DESCRIPTION
## Summary

Inertia page visits include the `X-Requested-With: XMLHttpRequest` header, so Laravel's session middleware intentionally skips updating the previous URL and route. As a result, session navigation history can remain stuck on the last full-page visit.

This change stores the current URL and route for Inertia GET visits that Laravel skips, while preserving the existing exclusions for regular AJAX requests, prefetches, precognitive requests, and non-GET requests. Route history is detected as an optional session capability so Laravel 11 remains supported.

Fixes #886.

## User impact

Applications can reliably use `previousUrl()` / `previousUri()` and, on supported Laravel versions, `previousRoute()` after client-side Inertia navigation. Existing non-navigation requests keep their current behavior.

## Validation

- Added five middleware regression tests covering a real Inertia visit and the AJAX, prefetch, precognitive, and non-GET boundaries.
- Confirmed the main regression test fails on the current `3.x` implementation before the fix.
- Laravel 11.55: 413 tests, 1,513 assertions.
- Laravel 12.64: 413 tests, 1,513 assertions; full PHPStan passes.
- Laravel 13.21: 413 tests, 1,513 assertions.
- Pint and PHPStan pass for all changed files across the tested framework versions.
- `composer validate --strict` and `composer audit` pass with current dependencies.
