### PR TITLE
[3.x] Fix DevTools recording under Laravel Octane

### DIFF
--- a/src/DevTools/DevToolsServiceProvider.php
+++ b/src/DevTools/DevToolsServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Inertia\DevTools;
 
+use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -30,14 +31,16 @@ class DevToolsServiceProvider extends ServiceProvider
         // callbacks. It self-disables (every method no-ops) when devtools is off.
         $this->app->scoped(RequestRecorder::class, fn () => new RequestRecorder);
 
-        $this->app->terminating(function () {
+        // Flush on RequestHandled, not terminating(): under Octane the app instance persists,
+        // so terminating never fires per request. Resolve from the active (sandbox) container.
+        $this->app['events']->listen(RequestHandled::class, function () {
             if (! DevTools::enabled()) {
                 return;
             }
 
-            $repository = $this->app->make(EntriesRepository::class);
+            $repository = app(EntriesRepository::class);
 
-            $this->app->make(EntryStore::class)->flush($repository);
+            app(EntryStore::class)->flush($repository);
 
             $repository->pruneIfDue();
         });

--- a/src/DevTools/DevToolsServiceProvider.php
+++ b/src/DevTools/DevToolsServiceProvider.php
@@ -18,12 +18,12 @@ class DevToolsServiceProvider extends ServiceProvider
 
         $this->app->scoped(SourceLocator::class, fn () => new SourceLocator);
 
-        $this->app->singleton(EntriesRepository::class, function ($app) {
-            $path = $app['config']->get('inertia.devtools.storage.path');
+        $this->app->singleton(EntriesRepository::class, function () {
+            $path = config('inertia.devtools.storage.path');
 
             return new EntriesRepository(
                 path: is_string($path) ? $path : storage_path('inertia-devtools'),
-                autoPruneHours: $app['config']->integer('inertia.devtools.storage.ttl', 24),
+                autoPruneHours: config()->integer('inertia.devtools.storage.ttl', 24),
             );
         });
 
@@ -31,8 +31,9 @@ class DevToolsServiceProvider extends ServiceProvider
         // callbacks. It self-disables (every method no-ops) when devtools is off.
         $this->app->scoped(RequestRecorder::class, fn () => new RequestRecorder);
 
-        // Flush on RequestHandled, not terminating(): under Octane the app instance persists,
-        // so terminating never fires per request. Resolve from the active (sandbox) container.
+        // Only requests are recorded, so the entry is flushed once the request has been handled.
+        // Everything is resolved from the current container because Octane serves each request
+        // from a clone of the application, and that clone is where the entry was recorded.
         $this->app['events']->listen(RequestHandled::class, function () {
             if (! DevTools::enabled()) {
                 return;

--- a/tests/DevTools/MiddlewareDevToolsTest.php
+++ b/tests/DevTools/MiddlewareDevToolsTest.php
@@ -2,9 +2,13 @@
 
 namespace Inertia\Tests\DevTools;
 
+use Illuminate\Foundation\Http\Events\RequestHandled;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
+use Inertia\DevTools\Data\IncomingEntry;
 use Inertia\DevTools\DevToolsHeader;
 use Inertia\DevTools\EntryStore;
 use Inertia\Inertia;
@@ -134,6 +138,25 @@ class MiddlewareDevToolsTest extends TestCase
         $this->assertNotNull($entry);
         $this->assertSame('http', $entry['__meta']['requestType']);
         $this->assertNull($entry['__meta']['component']);
+    }
+
+    public function test_recorded_entry_is_flushed_on_the_request_handled_event(): void
+    {
+        $entry = new IncomingEntry;
+        $entry->component = 'Users/Index';
+
+        $this->app->make(EntryStore::class)->record($entry);
+
+        $this->assertNull($this->latestRecordedEntry());
+
+        // Octane keeps the app instance alive, so the terminating callback never fires per request;
+        // the flush hangs off RequestHandled instead, which does fire, so dispatching it must persist.
+        event(new RequestHandled(Request::create('/'), new Response('ok')));
+
+        $saved = $this->latestRecordedEntry();
+
+        $this->assertNotNull($saved);
+        $this->assertSame('Users/Index', $saved['__meta']['component']);
     }
 
     public function test_inertia_json_response_is_not_html_injected(): void

--- a/tests/DevTools/MiddlewareDevToolsTest.php
+++ b/tests/DevTools/MiddlewareDevToolsTest.php
@@ -2,13 +2,9 @@
 
 namespace Inertia\Tests\DevTools;
 
-use Illuminate\Foundation\Http\Events\RequestHandled;
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
-use Inertia\DevTools\Data\IncomingEntry;
 use Inertia\DevTools\DevToolsHeader;
 use Inertia\DevTools\EntryStore;
 use Inertia\Inertia;
@@ -138,25 +134,6 @@ class MiddlewareDevToolsTest extends TestCase
         $this->assertNotNull($entry);
         $this->assertSame('http', $entry['__meta']['requestType']);
         $this->assertNull($entry['__meta']['component']);
-    }
-
-    public function test_recorded_entry_is_flushed_on_the_request_handled_event(): void
-    {
-        $entry = new IncomingEntry;
-        $entry->component = 'Users/Index';
-
-        $this->app->make(EntryStore::class)->record($entry);
-
-        $this->assertNull($this->latestRecordedEntry());
-
-        // Octane keeps the app instance alive, so the terminating callback never fires per request;
-        // the flush hangs off RequestHandled instead, which does fire, so dispatching it must persist.
-        event(new RequestHandled(Request::create('/'), new Response('ok')));
-
-        $saved = $this->latestRecordedEntry();
-
-        $this->assertNotNull($saved);
-        $this->assertSame('Users/Index', $saved['__meta']['component']);
     }
 
     public function test_inertia_json_response_is_not_html_injected(): void

--- a/tests/DevTools/OctaneDevToolsTest.php
+++ b/tests/DevTools/OctaneDevToolsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Inertia\Tests\DevTools;
+
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Http\Events\RequestHandled;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Facade;
+use Inertia\DevTools\Data\IncomingEntry;
+use Inertia\DevTools\EntryStore;
+use Inertia\Tests\TestCase;
+
+class OctaneDevToolsTest extends TestCase
+{
+    use InteractsWithDevToolsStorage;
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('inertia.devtools.enabled', true);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->bindEntriesRepository();
+
+        EntryStore::resetCircuitBreaker();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearDevToolsStorage();
+
+        parent::tearDown();
+    }
+
+    public function test_entry_recorded_in_an_octane_sandbox_is_flushed_when_the_request_is_handled(): void
+    {
+        $entry = new IncomingEntry;
+        $entry->component = 'Users/Index';
+
+        $this->withOctaneSandbox(function (Application $sandbox) use ($entry) {
+            $sandbox->make(EntryStore::class)->record($entry);
+
+            // Octane hands the sandbox to the HTTP kernel, so the entry to persist lives on
+            // the sandbox and not on the application the provider registered its listener on.
+            $sandbox->make('events')->dispatch(new RequestHandled(Request::create('/'), new Response('ok')));
+        });
+
+        $saved = $this->latestRecordedEntry();
+
+        $this->assertNotNull($saved);
+        $this->assertSame('Users/Index', $saved['__meta']['component']);
+    }
+
+    /**
+     * Run the callback against a clone of the application, the way Octane's Worker::handle()
+     * serves every request from a sandbox container that it makes the current one.
+     *
+     * @see https://github.com/laravel/octane/blob/2.x/src/Worker.php
+     */
+    protected function withOctaneSandbox(callable $callback): void
+    {
+        $base = $this->app;
+
+        $sandbox = clone $base;
+
+        Container::setInstance($sandbox);
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication($sandbox);
+
+        try {
+            $callback($sandbox);
+        } finally {
+            Container::setInstance($base);
+            Facade::clearResolvedInstances();
+            Facade::setFacadeApplication($base);
+        }
+    }
+}


### PR DESCRIPTION
The DevTools recorder flushes its collected entries from an `app->terminating()` callback registered in the service provider. Under Octane the application instance is reused across requests and that callback never fires per request, so nothing is written to storage and the extension shows no entries. Moving the flush to a `RequestHandled` listener, resolved from the active container, persists the entry at the end of every request under both Octane and a normal FPM setup.

Fixes #893