### PR TITLE
[3.x] Report the base path to DevTools

### DIFF
--- a/src/DevTools/DevToolsHeader.php
+++ b/src/DevTools/DevToolsHeader.php
@@ -12,6 +12,13 @@ class DevToolsHeader
     public const DEVTOOLS_ID = 'X-Inertia-Devtools-Id';
 
     /**
+     * Response header carrying the path the app is served from, set only when it is not
+     * the origin root. The extension fetches the entry endpoint itself, and knows the
+     * origin but not where within it the app lives.
+     */
+    public const DEVTOOLS_BASE_PATH = 'X-Inertia-Devtools-Base-Path';
+
+    /**
      * Response header set on every response, carrying the batch root id. The client
      * forwards it as DEVTOOLS_INCOMING_PARENT on the next same-batch request so
      * follow-ups (including those after a redirect) attach to the batch root.

--- a/src/DevTools/RequestRecorder.php
+++ b/src/DevTools/RequestRecorder.php
@@ -202,11 +202,17 @@ class RequestRecorder
         $isPrefetch = $request->prefetch();
         [$batchId, $parentOut] = $this->resolveLineage($request, $id);
 
+        $basePath = $request->getBaseUrl();
+
         $response->headers->set(DevToolsHeader::DEVTOOLS_ID, $id);
         $response->headers->set(DevToolsHeader::DEVTOOLS_OUTGOING_PARENT, $parentOut);
 
+        if ($basePath !== '') {
+            $response->headers->set(DevToolsHeader::DEVTOOLS_BASE_PATH, $basePath);
+        }
+
         if ($this->isInitialHtmlResponse($request, $response)) {
-            $this->injectDevToolsIdTag($response, $id);
+            $this->injectDevToolsIdTag($response, $id, $basePath);
         }
 
         $entry = app(IncomingEntryBuilder::class)->build($request, $response, $id, $batchId, $isPrefetch);
@@ -273,7 +279,12 @@ class RequestRecorder
         return str_contains(strtolower($contentType), 'text/html');
     }
 
-    protected function injectDevToolsIdTag(SymfonyResponse $response, string $id): void
+    /**
+     * Render the entry id into the page, along with the path the app is mounted on. A panel
+     * that attaches after the initial load has only the DOM to read, and the entry endpoint
+     * lives under that same path.
+     */
+    protected function injectDevToolsIdTag(SymfonyResponse $response, string $id, string $basePath): void
     {
         $content = $response->getContent();
 
@@ -281,7 +292,11 @@ class RequestRecorder
             return;
         }
 
-        $tag = '<script data-inertia-devtools-id type="application/json">'.json_encode($id).'</script>';
+        $basePathAttribute = $basePath === ''
+            ? ''
+            : ' data-inertia-devtools-base-path="'.e($basePath).'"';
+
+        $tag = '<script data-inertia-devtools-id'.$basePathAttribute.' type="application/json">'.json_encode($id).'</script>';
 
         $response->setContent(Str::replaceLast('</body>', $tag.'</body>', $content));
     }

--- a/tests/DevTools/HttpEndpointsTest.php
+++ b/tests/DevTools/HttpEndpointsTest.php
@@ -75,6 +75,21 @@ class HttpEndpointsTest extends TestCase
             ->assertStatus(404);
     }
 
+    public function test_show_resolves_under_the_base_path_an_app_is_served_from(): void
+    {
+        $entry = $this->envelope();
+        $id = $entry['__meta']['id'];
+        $this->repo->save($id, $entry);
+
+        $this->call('GET', "/portal/_inertia/devtools/entries/{$id}", server: [
+            'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
+            'SCRIPT_NAME' => '/portal/index.php',
+            'PHP_SELF' => '/portal/index.php',
+        ])
+            ->assertOk()
+            ->assertJsonPath('__meta.id', $id);
+    }
+
     public function test_show_rejects_non_entry_ids_before_lookup(): void
     {
         $this->getJson('/_inertia/devtools/entries/../secret')

--- a/tests/DevTools/MiddlewareDevToolsTest.php
+++ b/tests/DevTools/MiddlewareDevToolsTest.php
@@ -93,6 +93,35 @@ class MiddlewareDevToolsTest extends TestCase
         $this->assertMatchesRegularExpression('/<script data-inertia-devtools-id type="application\/json">"[A-Z0-9]+"<\/script><\/body>/', $content);
     }
 
+    public function test_the_base_path_is_reported_when_the_app_is_served_from_a_subdirectory(): void
+    {
+        Route::middleware(DevToolsRootViewMiddleware::class)->get('/devtools-html', fn () => Inertia::render('Users/Index', ['name' => 'Alice']));
+
+        $response = $this->call('GET', '/portal/devtools-html', server: [
+            'SCRIPT_FILENAME' => '/var/www/app/public/index.php',
+            'SCRIPT_NAME' => '/portal/index.php',
+            'PHP_SELF' => '/portal/index.php',
+        ]);
+
+        $response->assertOk();
+        $this->assertSame('/portal', $response->headers->get(DevToolsHeader::DEVTOOLS_BASE_PATH));
+        $this->assertMatchesRegularExpression(
+            '/<script data-inertia-devtools-id data-inertia-devtools-base-path="\/portal" type="application\/json">"[A-Z0-9]+"<\/script><\/body>/',
+            (string) $response->getContent()
+        );
+    }
+
+    public function test_no_base_path_is_reported_for_an_app_served_from_the_root_of_its_origin(): void
+    {
+        Route::middleware(DevToolsRootViewMiddleware::class)->get('/devtools-html', fn () => Inertia::render('Users/Index', ['name' => 'Alice']));
+
+        $response = $this->get('/devtools-html');
+
+        $response->assertOk();
+        $this->assertNull($response->headers->get(DevToolsHeader::DEVTOOLS_BASE_PATH));
+        $this->assertStringNotContainsString('data-inertia-devtools-base-path', (string) $response->getContent());
+    }
+
     public function test_html_responses_that_render_no_inertia_page_are_left_untouched(): void
     {
         Route::middleware(Middleware::class)->get('/devtools-plain-html', function () {


### PR DESCRIPTION
The DevTools extension fetches the entry endpoint itself, but it only knows the origin of the page, not where within that origin the app lives. Apps served from a subdirectory or behind a path-prefixed proxy would have their entry lookups resolve against the wrong URL.

Every recorded response now carries an `X-Inertia-Devtools-Base-Path` header, and the injected script tag on initial page loads carries a matching `data-inertia-devtools-base-path` attribute for panels that attach after the initial load. The base path comes from `Request::getBaseUrl()`, so it covers both subdirectory installs and trusted proxies that set `X-Forwarded-Prefix`. Nothing is emitted when the app is served from the origin root.