### PR TITLE
[3.x] Fix DevTools entry requests wiping flashed validation errors

### DIFF
--- a/src/DevTools/DevToolsServiceProvider.php
+++ b/src/DevTools/DevToolsServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Inertia\DevTools\Http\Authorize;
 use Inertia\DevTools\Http\EntriesController;
+use Inertia\DevTools\Http\PreserveFlashData;
 use Inertia\DevTools\Http\PreventPreviousUrlTracking;
 
 class DevToolsServiceProvider extends ServiceProvider
@@ -53,9 +54,14 @@ class DevToolsServiceProvider extends ServiceProvider
             return;
         }
 
-        // Authorize is appended last so it always runs, after any middleware the
-        // configured stack needs to resolve the user.
-        Route::middleware([PreventPreviousUrlTracking::class, ...$this->routeMiddleware(), Authorize::class])
+        $middleware = [
+            PreventPreviousUrlTracking::class,
+            ...$this->routeMiddleware(),
+            PreserveFlashData::class,
+            Authorize::class,
+        ];
+
+        Route::middleware($middleware)
             ->prefix('_inertia/devtools')
             ->group(function () {
                 Route::get('entries', [EntriesController::class, 'index']);

--- a/src/DevTools/Http/PreserveFlashData.php
+++ b/src/DevTools/Http/PreserveFlashData.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Inertia\DevTools\Http;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Reflashes the session so the save closing an entry request does not age the flash data. Entries
+ * are fetched the moment response headers arrive, racing the redirect the app is about to follow,
+ * so the errors a POST flashed for that redirect would be gone before the page could read them.
+ */
+class PreserveFlashData
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if ($request->hasSession()) {
+            $request->session()->reflash();
+        }
+
+        return $response;
+    }
+}

--- a/tests/DevTools/FlashDataTest.php
+++ b/tests/DevTools/FlashDataTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Inertia\Tests\DevTools;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Inertia\Tests\TestCase;
+
+class FlashDataTest extends TestCase
+{
+    use InteractsWithDevToolsStorage;
+
+    protected function defineEnvironment($app): void
+    {
+        // The entry endpoints run the `web` middleware group, which encrypts cookies.
+        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        $app['config']->set('inertia.devtools.enabled', true);
+        $app['config']->set('inertia.devtools.gate', 'viewInertiaDevtools');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->bindEntriesRepository();
+        Gate::define('viewInertiaDevtools', fn ($user = null) => true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearDevToolsStorage();
+
+        parent::tearDown();
+    }
+
+    public function test_validation_errors_survive_the_entry_request_racing_the_redirect(): void
+    {
+        Route::middleware('web')->post('/users', fn (Request $request) => $request->validate(['name' => 'required']));
+        Route::middleware('web')->get('/users/create', fn () => session('errors')?->get('name') ?? []);
+
+        $this->post('/users')->assertStatus(302);
+
+        // The extension fetches the entry the moment the failed POST responds, so this lands
+        // between the redirect and the request the browser makes to follow it.
+        $this->getJson('/_inertia/devtools/entries')->assertOk();
+        $this->getJson('/_inertia/devtools/entries/'.$this->savedEntryId())->assertOk();
+
+        $this->get('/users/create')->assertSee('The name field is required.');
+    }
+
+    public function test_flashed_data_is_still_read_once_by_the_app(): void
+    {
+        Route::middleware('web')->get('/app-page', fn () => (string) session('status'));
+
+        $this->session(['status' => 'saved', '_flash' => ['old' => ['status'], 'new' => []]]);
+
+        $this->getJson('/_inertia/devtools/entries')->assertOk();
+
+        $this->get('/app-page')->assertSee('saved');
+        $this->get('/app-page')->assertDontSee('saved');
+    }
+
+    protected function savedEntryId(): string
+    {
+        $id = (string) Str::ulid();
+
+        $this->repo->save($id, ['__meta' => ['id' => $id]]);
+
+        return $id;
+    }
+}


### PR DESCRIPTION
The DevTools entry endpoints run the `web` middleware group so the gate can authorize the user, which means the session gets saved when such a request finishes, aging the flash data. Since the extension fetches an entry as soon as the response headers arrive, that request races the redirect the app is about to follow, and the validation errors flashed by a failed POST are gone before the page can read them. This PR reflashes the session at the end of an entry request.