### PR TITLE
[3.x] Preserve the original response when DevTools injects its ID tag

### DIFF
--- a/src/DevTools/RequestRecorder.php
+++ b/src/DevTools/RequestRecorder.php
@@ -3,6 +3,7 @@
 namespace Inertia\DevTools;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 use Inertia\Response;
@@ -298,7 +299,16 @@ class RequestRecorder
 
         $tag = '<script data-inertia-devtools-id'.$basePathAttribute.' type="application/json">'.json_encode($id).'</script>';
 
+        // Illuminate's setContent() replaces the response's original value with the string it is
+        // given. For an Inertia page that value is the root view, which is where the testing
+        // assertions read the page object from, so it is put back.
+        $original = $response instanceof HttpResponse ? $response->original : null;
+
         $response->setContent(Str::replaceLast('</body>', $tag.'</body>', $content));
+
+        if ($response instanceof HttpResponse) {
+            $response->original = $original;
+        }
     }
 
     protected function resolveOutgoingParentId(bool $isPrefetch, string $id, ?string $batchId): string

--- a/tests/DevTools/MiddlewareDevToolsTest.php
+++ b/tests/DevTools/MiddlewareDevToolsTest.php
@@ -10,6 +10,7 @@ use Inertia\DevTools\EntryStore;
 use Inertia\Inertia;
 use Inertia\Middleware;
 use Inertia\Support\Header;
+use Inertia\Testing\AssertableInertia;
 use Inertia\Tests\Stubs\DevToolsRootViewMiddleware;
 use Inertia\Tests\TestCase;
 use JsonSerializable;
@@ -91,6 +92,20 @@ class MiddlewareDevToolsTest extends TestCase
         $this->assertStringContainsString('data-inertia-devtools-id', $content);
         $this->assertStringContainsString('</body>', $content);
         $this->assertMatchesRegularExpression('/<script data-inertia-devtools-id type="application\/json">"[A-Z0-9]+"<\/script><\/body>/', $content);
+    }
+
+    public function test_an_injected_id_tag_leaves_the_page_object_assertable(): void
+    {
+        Route::middleware(DevToolsRootViewMiddleware::class)->get('/devtools-html', fn () => Inertia::render('Users/Index', ['name' => 'Alice']));
+
+        $response = $this->get('/devtools-html');
+
+        $response->assertOk();
+        $this->assertStringContainsString('data-inertia-devtools-id', (string) $response->getContent());
+
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('Users/Index')
+            ->where('name', 'Alice'));
     }
 
     public function test_the_base_path_is_reported_when_the_app_is_served_from_a_subdirectory(): void


### PR DESCRIPTION
This PR keeps `assertInertia()` and `inertiaPage()` working in test suites that run with DevTools enabled.

The request recorder injects its ID script tag into the root view's HTML using `setContent()`. Illuminate replaces the response's original value with the string it is given, discarding the root view that the testing assertions read the page object from. The original response is now preserved after the content is set, so the page object stays assertable.