### PR TITLE
Support Boost 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "ext-pcntl": "Recommended when running the Inertia SSR server via the `inertia:start-ssr` artisan command."
     },
     "conflict": {
-        "laravel/boost": "<2.2.0"
+        "laravel/boost": "<2.5.0"
     },
     "scripts": {
         "test": "phpunit",

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -3,11 +3,11 @@
 - Inertia creates fully client-side rendered SPAs without modern SPA complexity, leveraging existing server-side patterns.
 - Components live in `{{ $assist->inertia()->pagesDirectory() }}` (unless specified in `vite.config.js`). Use `Inertia::render()` for server-side routing instead of Blade views.
 - ALWAYS use `search-docs` tool for version-specific Inertia documentation and updated code examples.
-@if($assist->hasPackage(\Laravel\Roster\Enums\Packages::INERTIA_REACT))
+@if($assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_REACT))
 - IMPORTANT: Activate `inertia-react-development` when working with Inertia client-side patterns.
-@elseif($assist->hasPackage(\Laravel\Roster\Enums\Packages::INERTIA_VUE))
+@elseif($assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_VUE))
 - IMPORTANT: Activate `inertia-vue-development` when working with Inertia Vue client-side patterns.
-@elseif($assist->hasPackage(\Laravel\Roster\Enums\Packages::INERTIA_SVELTE))
+@elseif($assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_SVELTE))
 - IMPORTANT: Activate `inertia-svelte-development` when working with Inertia Svelte client-side patterns.
 @endif
 


### PR DESCRIPTION
Boost 2.5 removed the `Laravel\Roster\Enums\Packages` enum in favour of string constants on `Laravel\Boost\Support\PackageRegistry`, so the guideline currently fails to render and gets skipped during `boost:install`. This updates the three package checks and bumps the `laravel/boost` conflict to `<2.5.0`.

