### PR TITLE
[3.x] Resolve props nested in `JsonSerializable` objects

### DIFF
--- a/src/PropsResolver.php
+++ b/src/PropsResolver.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\App;
 use Inertia\DevTools\DevTools;
 use Inertia\DevTools\RequestRecorder;
 use Inertia\Support\Header;
+use JsonSerializable;
 use Throwable;
 
 class PropsResolver
@@ -469,6 +470,10 @@ class PropsResolver
                 if (method_exists($response, 'getData')) {
                     $value = $response->getData(true);
                 }
+            }
+
+            if ($value instanceof JsonSerializable) {
+                $value = $value->jsonSerialize();
             }
 
             return $value;

--- a/tests/PropsResolverTest.php
+++ b/tests/PropsResolverTest.php
@@ -15,6 +15,7 @@ use Inertia\ProvidesScrollMetadata;
 use Inertia\RenderContext;
 use Inertia\Response;
 use Inertia\ScrollProp;
+use JsonSerializable;
 
 class PropsResolverTest extends TestCase
 {
@@ -1104,6 +1105,48 @@ class PropsResolverTest extends TestCase
         ]);
 
         $this->assertGreaterThan(0, $spy->calls);
+    }
+
+    public function test_it_descends_into_json_serializable_props(): void
+    {
+        $dto = new class implements JsonSerializable
+        {
+            public function jsonSerialize(): mixed
+            {
+                return ['nested' => ['name' => 'John']];
+            }
+        };
+
+        $page = $this->makePage(Request::create('/'), ['dto' => $dto]);
+
+        $this->assertSame(['nested' => ['name' => 'John']], $page['props']['dto']);
+    }
+
+    public function test_prop_types_nested_in_json_serializable_props_are_resolved(): void
+    {
+        $props = fn () => [
+            'dto' => new class implements JsonSerializable
+            {
+                public function jsonSerialize(): mixed
+                {
+                    return ['thing' => Inertia::defer(fn () => 'deferred value'), 'plain' => 1];
+                }
+            },
+        ];
+
+        $page = $this->makePage(Request::create('/'), $props());
+
+        $this->assertSame(['plain' => 1], $page['props']['dto']);
+        $this->assertSame(['default' => ['dto.thing']], $page['deferredProps']);
+
+        $request = Request::create('/');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Partial-Component' => 'TestComponent']);
+        $request->headers->add(['X-Inertia-Partial-Data' => 'dto.thing']);
+
+        $page = $this->makePage($request, $props());
+
+        $this->assertSame('deferred value', $page['props']['dto']['thing']);
     }
 
     /**


### PR DESCRIPTION
Props nested inside a `JsonSerializable` object were never unwrapped, so the resolver could not see them.

```php
class Dashboard implements JsonSerializable
{
    public function jsonSerialize(): array
    {
        return [
            'stats' => Inertia::defer(fn () => Stats::compute()),
        ];
    }
}
```

The `stats` prop silently serialized to `{}` and emitted no metadata, so the client never requested it. The resolver now unwraps `JsonSerializable` values, after the `Responsable` branch so API resources keep their wrapping and `additional()` metadata.