### PR TITLE
[3.x] Support big integers as native BigInt values

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -201,6 +201,7 @@ return [
         ],
 
     ],
+
     /*
     |--------------------------------------------------------------------------
     | Big Integers
@@ -209,7 +210,7 @@ return [
     | When enabled, integers outside JavaScript's safe integer range are
     | wrapped as `{"$bigint": "<value>"}` so the frontend can revive them
     | as native BigInt values instead of silently losing precision when
-    | JSON is parsed. The frontend picks this up automatically.
+    | JSON is parsed. Enable `preserveBigIntegers` on the client as well.
     |
     */
 

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -201,5 +201,18 @@ return [
         ],
 
     ],
+    /*
+    |--------------------------------------------------------------------------
+    | Big Integers
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, integers outside JavaScript's safe integer range are
+    | wrapped as `{"$bigint": "<value>"}` so the frontend can revive them
+    | as native BigInt values instead of silently losing precision when
+    | JSON is parsed. The frontend picks this up automatically.
+    |
+    */
+
+    'preserve_big_integers' => (bool) env('INERTIA_PRESERVE_BIG_INTEGERS', false),
 
 ];

--- a/src/EncodesBigIntegers.php
+++ b/src/EncodesBigIntegers.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Inertia;
+
+use stdClass;
+
+trait EncodesBigIntegers
+{
+    /**
+     * Determine whether integers outside JavaScript's safe range should be wrapped.
+     */
+    protected function shouldEncodeBigIntegers(): bool
+    {
+        return config()->boolean('inertia.preserve_big_integers', false);
+    }
+
+    /**
+     * Wrap integers outside JavaScript's safe integer range as a marker so the
+     * frontend can revive them as native BigInt values without losing
+     * precision when the JSON response is parsed.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
+     */
+    protected function encodeBigIntegers(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            return array_map(fn ($nested) => $this->encodeBigIntegers($nested), $value);
+        }
+
+        // Objects the props resolver left alone (empty or numerically keyed) are
+        // cast back so they keep serializing as a JSON object, not an array.
+        if ($value instanceof stdClass) {
+            return (object) array_map(fn ($nested) => $this->encodeBigIntegers($nested), get_object_vars($value));
+        }
+
+        if (is_int($value) && ($value > 9007199254740991 || $value < -9007199254740991)) {
+            return ['$bigint' => (string) $value];
+        }
+
+        return $value;
+    }
+}

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -114,7 +114,7 @@ class Middleware
 
         $recorder?->requestStarted($request);
 
-        if (config('inertia.preserve_big_integers', false) && $request->isJson()) {
+        if (config()->boolean('inertia.preserve_big_integers', false) && $request->isJson()) {
             $request->json()->replace($this->decodeBigIntegers($request->json()->all()));
         }
 
@@ -221,7 +221,7 @@ class Middleware
         return count($value) === 1
             && isset($value['$bigint'])
             && is_string($value['$bigint'])
-            && preg_match('/^-?\d+$/', $value['$bigint']) === 1;
+            && preg_match('/^(0|-?[1-9]\d*)$/', $value['$bigint']) === 1;
     }
 
     /**

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -114,6 +114,10 @@ class Middleware
 
         $recorder?->requestStarted($request);
 
+        if (config('inertia.preserve_big_integers', false) && $request->isJson()) {
+            $request->json()->replace($this->decodeBigIntegers($request->json()->all()));
+        }
+
         Inertia::version(function () use ($request) {
             return $this->version($request);
         });
@@ -176,6 +180,60 @@ class Middleware
         $recorder?->respondedWith($request, $response);
 
         return $response;
+    }
+
+    /**
+     * Recursively revive `{"$bigint": "<value>"}` markers in the request data
+     * back into integers so controllers and validation receive the original
+     * value the frontend sent as a native BigInt.
+     *
+     * @param  array<array-key, mixed>  $input
+     * @return array<array-key, mixed>
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
+     */
+    protected function decodeBigIntegers(array $input): array
+    {
+        $result = [];
+
+        foreach ($input as $key => $value) {
+            if (! is_array($value)) {
+                $result[$key] = $value;
+
+                continue;
+            }
+
+            $result[$key] = $this->isBigIntegerMarker($value)
+                ? $this->reviveBigInteger($value['$bigint'])
+                : $this->decodeBigIntegers($value);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Determine if the given array is a big integer marker.
+     *
+     * @param  array<array-key, mixed>  $value
+     */
+    protected function isBigIntegerMarker(array $value): bool
+    {
+        return count($value) === 1
+            && isset($value['$bigint'])
+            && is_string($value['$bigint'])
+            && preg_match('/^-?\d+$/', $value['$bigint']) === 1;
+    }
+
+    /**
+     * Revive a big integer marker's digits. Values within PHP's integer range
+     * become a native integer; anything larger is kept as a string since PHP
+     * cannot represent it as an integer without losing precision.
+     */
+    protected function reviveBigInteger(string $digits): int|string
+    {
+        $asInteger = (int) $digits;
+
+        return (string) $asInteger === $digits ? $asInteger : $digits;
     }
 
     /**

--- a/src/PropsResolver.php
+++ b/src/PropsResolver.php
@@ -12,11 +12,13 @@ use Illuminate\Support\Facades\App;
 use Inertia\DevTools\DevTools;
 use Inertia\DevTools\RequestRecorder;
 use Inertia\Support\Header;
+use JsonSerializable;
+use stdClass;
 use Throwable;
 
 class PropsResolver
 {
-    use ResolvesCallables;
+    use EncodesBigIntegers, ResolvesCallables;
 
     /**
      * The current request instance.
@@ -149,14 +151,7 @@ class PropsResolver
      *
      * @var bool
      */
-    protected $encodeBigIntegers;
-
-    /**
-     * Whether at least one integer was wrapped while resolving props.
-     *
-     * @var bool
-     */
-    protected $wrappedBigIntegers = false;
+    protected $preserveBigIntegers;
 
     /**
      * Create a new props resolver instance.
@@ -174,7 +169,7 @@ class PropsResolver
         $this->loadedOnceProps = $this->parseHeader(Header::EXCEPT_ONCE_PROPS) ?? [];
 
         $this->recorder = DevTools::recorder($request);
-        $this->encodeBigIntegers = (bool) config('inertia.preserve_big_integers', false);
+        $this->preserveBigIntegers = $this->shouldEncodeBigIntegers();
     }
 
     /**
@@ -325,26 +320,10 @@ class PropsResolver
             // returned one), its children bypass partial filtering.
             $result[$key] = is_array($value)
                 ? $this->resolveProps($value, $path, $parentWasResolved || ! is_array($prop))
-                : $this->encodeBigInteger($value);
+                : ($this->preserveBigIntegers ? $this->encodeBigIntegers($value) : $value);
         }
 
         return $result;
-    }
-
-    /**
-     * Wrap integers outside JavaScript's safe integer range as a marker so
-     * the frontend can revive them as native BigInt values without losing
-     * precision when the JSON response is parsed.
-     *
-     * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
-     */
-    protected function encodeBigInteger(mixed $value): mixed
-    {
-        if ($this->encodeBigIntegers && is_int($value) && ($value > 9007199254740991 || $value < -9007199254740991)) {
-            return ['$bigint' => (string) $value];
-        }
-
-        return $value;
     }
 
     /**
@@ -500,6 +479,19 @@ class PropsResolver
                 if (method_exists($response, 'getData')) {
                     $value = $response->getData(true);
                 }
+            }
+
+            // Unwrapping these last keeps types that are both JsonSerializable and
+            // Responsable (e.g. API resources) on the branch above, while still
+            // letting the resolver descend into plain objects and DTOs.
+            if ($value instanceof JsonSerializable) {
+                $value = $value->jsonSerialize();
+            }
+
+            // A list would serialize as a JSON array instead of an object, so
+            // empty and numerically keyed objects are left as they are.
+            if ($value instanceof stdClass && ! array_is_list($vars = get_object_vars($value))) {
+                $value = $vars;
             }
 
             return $value;

--- a/src/PropsResolver.php
+++ b/src/PropsResolver.php
@@ -145,6 +145,20 @@ class PropsResolver
     protected ?RequestRecorder $recorder = null;
 
     /**
+     * Whether integers outside JavaScript's safe range should be wrapped.
+     *
+     * @var bool
+     */
+    protected $encodeBigIntegers;
+
+    /**
+     * Whether at least one integer was wrapped while resolving props.
+     *
+     * @var bool
+     */
+    protected $wrappedBigIntegers = false;
+
+    /**
      * Create a new props resolver instance.
      */
     public function __construct(Request $request, string $component)
@@ -160,6 +174,7 @@ class PropsResolver
         $this->loadedOnceProps = $this->parseHeader(Header::EXCEPT_ONCE_PROPS) ?? [];
 
         $this->recorder = DevTools::recorder($request);
+        $this->encodeBigIntegers = (bool) config('inertia.preserve_big_integers', false);
     }
 
     /**
@@ -310,10 +325,26 @@ class PropsResolver
             // returned one), its children bypass partial filtering.
             $result[$key] = is_array($value)
                 ? $this->resolveProps($value, $path, $parentWasResolved || ! is_array($prop))
-                : $value;
+                : $this->encodeBigInteger($value);
         }
 
         return $result;
+    }
+
+    /**
+     * Wrap integers outside JavaScript's safe integer range as a marker so
+     * the frontend can revive them as native BigInt values without losing
+     * precision when the JSON response is parsed.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
+     */
+    protected function encodeBigInteger(mixed $value): mixed
+    {
+        if ($this->encodeBigIntegers && is_int($value) && ($value > 9007199254740991 || $value < -9007199254740991)) {
+            return ['$bigint' => (string) $value];
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -19,6 +19,7 @@ use UnitEnum;
 
 class Response implements Responsable
 {
+    use EncodesBigIntegers;
     use Macroable;
 
     /**
@@ -243,7 +244,13 @@ class Response implements Responsable
     {
         $flash = Inertia::pullFlashed($request);
 
-        return $flash ? ['flash' => $flash] : [];
+        if (! $flash) {
+            return [];
+        }
+
+        // Flash data is merged into the page after the props are resolved, so it
+        // needs the same big integer treatment the props resolver applies.
+        return ['flash' => $this->shouldEncodeBigIntegers() ? $this->encodeBigIntegers($flash) : $flash];
     }
 
     /**

--- a/src/Ssr/HttpGateway.php
+++ b/src/Ssr/HttpGateway.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\Str;
 use Inertia\ResolvesCallables;
+use Inertia\Support\Header;
 
 class HttpGateway implements DisablesSsr, ExcludesSsrPaths, Gateway, HasHealthCheck
 {
@@ -52,7 +53,7 @@ class HttpGateway implements DisablesSsr, ExcludesSsrPaths, Gateway, HasHealthCh
             : $this->getProductionUrl('/render');
 
         try {
-            $response = Http::post($url, $page);
+            $response = Http::withHeaders($this->ssrHeaders())->post($url, $page);
 
             if ($response->failed()) {
                 $this->handleSsrFailure($page, $response->json());
@@ -135,6 +136,20 @@ class HttpGateway implements DisablesSsr, ExcludesSsrPaths, Gateway, HasHealthCh
         if (config('inertia.ssr.throw_on_error', false)) {
             throw SsrException::fromEvent($event);
         }
+    }
+
+    /**
+     * The headers to send along with the page to the SSR server. Parsing big
+     * integer markers cannot be gated by the client config there, since the
+     * config is set by the callback that receives the already-parsed page.
+     *
+     * @return array<string, string>
+     */
+    protected function ssrHeaders(): array
+    {
+        return config()->boolean('inertia.preserve_big_integers', false)
+            ? [Header::PRESERVE_BIG_INTEGERS => 'true']
+            : [];
     }
 
     /**

--- a/src/Support/Header.php
+++ b/src/Support/Header.php
@@ -63,4 +63,9 @@ class Header
      * Header specifying which once props to exclude from the response.
      */
     public const EXCEPT_ONCE_PROPS = 'X-Inertia-Except-Once-Props';
+
+    /**
+     * Header telling the SSR server that the page may contain big integer markers.
+     */
+    public const PRESERVE_BIG_INTEGERS = 'X-Inertia-Preserve-Big-Integers';
 }

--- a/tests/HttpGatewayTest.php
+++ b/tests/HttpGatewayTest.php
@@ -12,6 +12,7 @@ use Inertia\Ssr\HttpGateway;
 use Inertia\Ssr\SsrErrorType;
 use Inertia\Ssr\SsrException;
 use Inertia\Ssr\SsrRenderFailed;
+use Inertia\Support\Header;
 
 class HttpGatewayTest extends TestCase
 {
@@ -89,6 +90,40 @@ class HttpGatewayTest extends TestCase
 
         $this->assertEquals("<title>SSR Test</title>\n<style></style>", $response->head);
         $this->assertEquals('<div id="app">SSR Response</div>', $response->body);
+    }
+
+    public function test_it_tells_the_ssr_server_when_big_integers_may_be_wrapped(): void
+    {
+        config([
+            'inertia.ssr.enabled' => true,
+            'inertia.ssr.bundle' => __DIR__.'/Stubs/ssr-bundle.js',
+            'inertia.preserve_big_integers' => true,
+        ]);
+
+        Http::fake([
+            $this->renderUrl => Http::response(json_encode(['head' => [], 'body' => ''])),
+        ]);
+
+        $this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]);
+
+        Http::assertSent(fn ($request) => $request->hasHeader(Header::PRESERVE_BIG_INTEGERS, 'true'));
+    }
+
+    public function test_it_omits_the_big_integer_header_when_the_config_is_disabled(): void
+    {
+        config([
+            'inertia.ssr.enabled' => true,
+            'inertia.ssr.bundle' => __DIR__.'/Stubs/ssr-bundle.js',
+            'inertia.preserve_big_integers' => false,
+        ]);
+
+        Http::fake([
+            $this->renderUrl => Http::response(json_encode(['head' => [], 'body' => ''])),
+        ]);
+
+        $this->gateway->dispatch(['page' => self::EXAMPLE_PAGE_OBJECT]);
+
+        Http::assertSent(fn ($request) => ! $request->hasHeader(Header::PRESERVE_BIG_INTEGERS));
     }
 
     public function test_it_uses_the_configured_http_url_when_bundle_file_detection_is_disabled(): void

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -70,6 +70,30 @@ class MiddlewareTest extends TestCase
         $this->assertSame(-900719925474099988, $received['nested']['deep']);
     }
 
+    public function test_only_canonical_big_integer_markers_are_decoded(): void
+    {
+        config(['inertia.preserve_big_integers' => true]);
+
+        $received = null;
+        Route::middleware(Middleware::class)->post('/', function (Request $request) use (&$received) {
+            $received = $request->all();
+        });
+
+        $this->postJson('/', [
+            'padded' => ['$bigint' => '007'],
+            'negativeZero' => ['$bigint' => '-0'],
+            'fraction' => ['$bigint' => '12.5'],
+            'extraKey' => ['$bigint' => '1', 'other' => 2],
+            'zero' => ['$bigint' => '0'],
+        ]);
+
+        $this->assertSame(['$bigint' => '007'], $received['padded']);
+        $this->assertSame(['$bigint' => '-0'], $received['negativeZero']);
+        $this->assertSame(['$bigint' => '12.5'], $received['fraction']);
+        $this->assertSame(['$bigint' => '1', 'other' => 2], $received['extraKey']);
+        $this->assertSame(0, $received['zero']);
+    }
+
     public function test_incoming_big_integer_markers_are_left_untouched_when_disabled(): void
     {
         config(['inertia.preserve_big_integers' => false]);

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -48,6 +48,44 @@ class MiddlewareTest extends TestCase
         $this->assertTrue($fooCalled);
     }
 
+    public function test_incoming_big_integer_markers_are_decoded_when_enabled(): void
+    {
+        config(['inertia.preserve_big_integers' => true]);
+
+        $received = null;
+        Route::middleware(Middleware::class)->post('/', function (Request $request) use (&$received) {
+            $received = $request->all();
+        });
+
+        $this->postJson('/', [
+            'id' => ['$bigint' => '900719925474099988'],
+            'safe' => 42,
+            'huge' => ['$bigint' => '99999999999999999999999'],
+            'nested' => ['deep' => ['$bigint' => '-900719925474099988']],
+        ]);
+
+        $this->assertSame(900719925474099988, $received['id']);
+        $this->assertSame(42, $received['safe']);
+        $this->assertSame('99999999999999999999999', $received['huge']);
+        $this->assertSame(-900719925474099988, $received['nested']['deep']);
+    }
+
+    public function test_incoming_big_integer_markers_are_left_untouched_when_disabled(): void
+    {
+        config(['inertia.preserve_big_integers' => false]);
+
+        $received = null;
+        Route::middleware(Middleware::class)->post('/', function (Request $request) use (&$received) {
+            $received = $request->all();
+        });
+
+        $this->postJson('/', [
+            'id' => ['$bigint' => '900719925474099988'],
+        ]);
+
+        $this->assertSame(['$bigint' => '900719925474099988'], $received['id']);
+    }
+
     public function test_no_response_value_can_be_customized_by_overriding_the_middleware_method(): void
     {
         Route::middleware(ExampleMiddleware::class)->get('/', function () {

--- a/tests/PropsResolverTest.php
+++ b/tests/PropsResolverTest.php
@@ -1106,6 +1106,37 @@ class PropsResolverTest extends TestCase
         $this->assertGreaterThan(0, $spy->calls);
     }
 
+    public function test_big_integers_are_wrapped_when_enabled(): void
+    {
+        config(['inertia.preserve_big_integers' => true]);
+
+        $page = $this->makePage(Request::create('/'), [
+            'safe' => 42,
+            'boundary' => 9007199254740991,
+            'big' => 900719925474099988,
+            'negative' => -900719925474099988,
+            'nested' => ['deep' => [900719925474099988, 2]],
+        ]);
+
+        $this->assertSame(42, $page['props']['safe']);
+        $this->assertSame(9007199254740991, $page['props']['boundary']);
+        $this->assertSame(['$bigint' => '900719925474099988'], $page['props']['big']);
+        $this->assertSame(['$bigint' => '-900719925474099988'], $page['props']['negative']);
+        $this->assertSame(['$bigint' => '900719925474099988'], $page['props']['nested']['deep'][0]);
+        $this->assertSame(2, $page['props']['nested']['deep'][1]);
+    }
+
+    public function test_big_integers_are_not_wrapped_when_disabled(): void
+    {
+        config(['inertia.preserve_big_integers' => false]);
+
+        $page = $this->makePage(Request::create('/'), [
+            'big' => 900719925474099988,
+        ]);
+
+        $this->assertSame(900719925474099988, $page['props']['big']);
+    }
+
     /**
      * Resolve the given props through the Inertia response and return the page data.
      *

--- a/tests/PropsResolverTest.php
+++ b/tests/PropsResolverTest.php
@@ -15,6 +15,8 @@ use Inertia\ProvidesScrollMetadata;
 use Inertia\RenderContext;
 use Inertia\Response;
 use Inertia\ScrollProp;
+use JsonSerializable;
+use stdClass;
 
 class PropsResolverTest extends TestCase
 {
@@ -1104,6 +1106,86 @@ class PropsResolverTest extends TestCase
         ]);
 
         $this->assertGreaterThan(0, $spy->calls);
+    }
+
+    public function test_it_descends_into_plain_objects_and_json_serializable_props(): void
+    {
+        $dto = new class implements JsonSerializable
+        {
+            public function jsonSerialize(): mixed
+            {
+                return ['nested' => ['name' => 'John']];
+            }
+        };
+
+        $page = $this->makePage(Request::create('/'), [
+            'dto' => $dto,
+            'object' => (object) ['name' => 'Jane', 'nested' => (object) ['role' => 'admin']],
+            'empty' => new stdClass,
+            'list' => (object) ['0' => 'first', '1' => 'second'],
+        ]);
+
+        $this->assertSame(['nested' => ['name' => 'John']], $page['props']['dto']);
+        $this->assertSame(['name' => 'Jane', 'nested' => ['role' => 'admin']], $page['props']['object']);
+        $this->assertInstanceOf(stdClass::class, $page['props']['empty']);
+        $this->assertInstanceOf(stdClass::class, $page['props']['list']);
+    }
+
+    public function test_prop_types_nested_in_plain_objects_are_resolved(): void
+    {
+        $props = fn () => [
+            'object' => (object) ['thing' => Inertia::defer(fn () => 'deferred value'), 'plain' => 1],
+        ];
+
+        $page = $this->makePage(Request::create('/'), $props());
+
+        $this->assertSame(['plain' => 1], $page['props']['object']);
+        $this->assertSame(['default' => ['object.thing']], $page['deferredProps']);
+
+        $request = Request::create('/');
+        $request->headers->add(['X-Inertia' => 'true']);
+        $request->headers->add(['X-Inertia-Partial-Component' => 'TestComponent']);
+        $request->headers->add(['X-Inertia-Partial-Data' => 'object.thing']);
+
+        $page = $this->makePage($request, $props());
+
+        $this->assertSame('deferred value', $page['props']['object']['thing']);
+    }
+
+    public function test_big_integers_inside_plain_objects_are_wrapped_when_enabled(): void
+    {
+        config(['inertia.preserve_big_integers' => true]);
+
+        $page = $this->makePage(Request::create('/'), [
+            'object' => (object) ['id' => 900719925474099988],
+            'dto' => new class implements JsonSerializable
+            {
+                public function jsonSerialize(): mixed
+                {
+                    return ['id' => 900719925474099988];
+                }
+            },
+        ]);
+
+        $this->assertSame(['$bigint' => '900719925474099988'], $page['props']['object']['id']);
+        $this->assertSame(['$bigint' => '900719925474099988'], $page['props']['dto']['id']);
+    }
+
+    public function test_big_integers_inside_numerically_keyed_objects_are_wrapped_without_changing_the_shape(): void
+    {
+        config(['inertia.preserve_big_integers' => true]);
+
+        $page = $this->makePage(Request::create('/'), [
+            'list' => (object) ['0' => 900719925474099988, '1' => -900719925474099988],
+            'empty' => new stdClass,
+        ]);
+
+        $this->assertInstanceOf(stdClass::class, $page['props']['list']);
+        $this->assertSame(
+            '{"0":{"$bigint":"900719925474099988"},"1":{"$bigint":"-900719925474099988"}}',
+            json_encode($page['props']['list'])
+        );
+        $this->assertSame('{}', json_encode($page['props']['empty']));
     }
 
     public function test_big_integers_are_wrapped_when_enabled(): void

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -749,6 +749,41 @@ class ResponseFactoryTest extends TestCase
         $this->assertNull(session('inertia.flash_data'));
     }
 
+    public function test_big_integers_in_flash_data_are_wrapped_when_enabled(): void
+    {
+        config(['inertia.preserve_big_integers' => true]);
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->post('/flash-big-integer', function () {
+            return Inertia::flash('id', 900719925474099988)
+                ->flash('safe', 42)
+                ->render('User/Edit');
+        });
+
+        $response = $this->post('/flash-big-integer', [], ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson([
+            'flash' => [
+                'id' => ['$bigint' => '900719925474099988'],
+                'safe' => 42,
+            ],
+        ]);
+    }
+
+    public function test_big_integers_in_flash_data_are_untouched_when_disabled(): void
+    {
+        config(['inertia.preserve_big_integers' => false]);
+
+        Route::middleware([StartSession::class, ExampleMiddleware::class])->post('/flash-big-integer', function () {
+            return Inertia::flash('id', 900719925474099988)->render('User/Edit');
+        });
+
+        $response = $this->post('/flash-big-integer', [], ['X-Inertia' => 'true']);
+
+        $response->assertSuccessful();
+        $response->assertJson(['flash' => ['id' => 900719925474099988]]);
+    }
+
     public function test_render_without_flash_does_not_include_flash_key(): void
     {
         Route::middleware([StartSession::class, ExampleMiddleware::class])->get('/no-flash', function () {


### PR DESCRIPTION
Integers that exceed JavaScript's safe integer range are silently rounded when the browser parses the page JSON, so a snowflake identifier or a 64-bit column value arrives in your components as a different number. Enabling `preserve_big_integers` wraps those values in props and flash data as a marker that the client revives as a native `BigInt`, and decodes them back to integers on incoming JSON requests.

```php
// config/inertia.php

'preserve_big_integers' => true,
```

Requires the client-side counterpart, see inertiajs/inertia#3237. Both are opt-in, and nothing changes for applications that leave the config disabled.