### PR TITLE
[3.x] Fix loadDeferredProps() crashing when a group name matches a helper function

### DIFF
--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -141,9 +141,11 @@ class AssertableInertia extends AssertableJson
      */
     public function loadDeferredProps(Closure|array|string $groupsOrCallback, ?Closure $callback = null): self
     {
-        $callback = is_callable($groupsOrCallback) ? $groupsOrCallback : $callback;
+        $isCallback = $groupsOrCallback instanceof Closure;
 
-        $groups = is_callable($groupsOrCallback) ? array_keys($this->deferredProps) : Arr::wrap($groupsOrCallback);
+        $callback = $isCallback ? $groupsOrCallback : $callback;
+
+        $groups = $isCallback ? array_keys($this->deferredProps) : Arr::wrap($groupsOrCallback);
 
         $props = collect($groups)->flatMap(function ($group) {
             return $this->deferredProps[$group] ?? [];

--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -141,11 +141,9 @@ class AssertableInertia extends AssertableJson
      */
     public function loadDeferredProps(Closure|array|string $groupsOrCallback, ?Closure $callback = null): self
     {
-        $isCallback = $groupsOrCallback instanceof Closure;
+        $callback = $groupsOrCallback instanceof Closure ? $groupsOrCallback : $callback;
 
-        $callback = $isCallback ? $groupsOrCallback : $callback;
-
-        $groups = $isCallback ? array_keys($this->deferredProps) : Arr::wrap($groupsOrCallback);
+        $groups = $groupsOrCallback instanceof Closure ? array_keys($this->deferredProps) : Arr::wrap($groupsOrCallback);
 
         $props = collect($groups)->flatMap(function ($group) {
             return $this->deferredProps[$group] ?? [];

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -361,30 +361,6 @@ class AssertableInertiaTest extends TestCase
         $this->assertTrue($called);
     }
 
-    public function test_load_deferred_props_with_group_name_matching_a_global_function(): void
-    {
-        // Group names that collide with a global function/helper name (e.g. `auth`,
-        // `session`, `collect`) used to be misidentified as the callback argument,
-        // because `is_callable()` returns true for any string naming an existing
-        // function, not just for closures passed to `loadDeferredProps()`.
-        $response = $this->makeMockRequest(
-            Inertia::render('foo', [
-                'deferred1' => Inertia::defer(fn () => 'baz', 'auth'),
-            ])
-        );
-
-        $called = 0;
-
-        $response->assertInertia(function (AssertableInertia $inertia) use (&$called) {
-            $inertia->loadDeferredProps('auth', function (AssertableInertia $inertia) use (&$called) {
-                $inertia->where('deferred1', 'baz');
-                $called++;
-            });
-        });
-
-        $this->assertSame(1, $called);
-    }
-
     public function test_assert_against_deferred_props(): void
     {
         $response = $this->makeMockRequest(
@@ -434,6 +410,28 @@ class AssertableInertiaTest extends TestCase
         });
 
         $this->assertSame(4, $called);
+    }
+
+    public function test_deferred_props_can_be_loaded_from_a_group_named_after_a_global_function(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', [
+                'deferred1' => Inertia::defer(fn () => 'baz', 'auth'),
+                'deferred2' => Inertia::defer(fn () => 'qux', 'custom'),
+            ])
+        );
+
+        $called = false;
+
+        $response->assertInertia(function (AssertableInertia $inertia) use (&$called) {
+            $inertia->loadDeferredProps('auth', function (AssertableInertia $inertia) use (&$called) {
+                $inertia->where('deferred1', 'baz');
+                $inertia->missing('deferred2');
+                $called = true;
+            });
+        });
+
+        $this->assertTrue($called);
     }
 
     public function test_the_flash_data_can_be_asserted(): void

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -361,6 +361,30 @@ class AssertableInertiaTest extends TestCase
         $this->assertTrue($called);
     }
 
+    public function test_load_deferred_props_with_group_name_matching_a_global_function(): void
+    {
+        // Group names that collide with a global function/helper name (e.g. `auth`,
+        // `session`, `collect`) used to be misidentified as the callback argument,
+        // because `is_callable()` returns true for any string naming an existing
+        // function, not just for closures passed to `loadDeferredProps()`.
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', [
+                'deferred1' => Inertia::defer(fn () => 'baz', 'auth'),
+            ])
+        );
+
+        $called = 0;
+
+        $response->assertInertia(function (AssertableInertia $inertia) use (&$called) {
+            $inertia->loadDeferredProps('auth', function (AssertableInertia $inertia) use (&$called) {
+                $inertia->where('deferred1', 'baz');
+                $called++;
+            });
+        });
+
+        $this->assertSame(1, $called);
+    }
+
     public function test_assert_against_deferred_props(): void
     {
         $response = $this->makeMockRequest(


### PR DESCRIPTION
`loadDeferredProps()` uses `is_callable()` to check if you passed a closure or a group name. The problem is `is_callable('auth')` returns `true`, because `is_callable()` on a string just checks if a function with that name exists — and Laravel has a global `auth()` function.

So if you name a deferred prop group something like `'auth'`, `'session'`, or `'collect'` (all totally normal group names), this:

```php
$page->loadDeferredProps('auth', function ($page) {
    $page->where('user', $user);
});
```

crashes with:

```
TypeError: reloadOnly(): Argument #2 ($callback) must be of type ?Closure, string given
```

because it silently treats `'auth'` as the callback and drops your real closure.

The fix just checks `instanceof Closure` instead, which is what the method's own type hint (`Closure|array|string`) already says it should be.

Added a test that reproduces the crash with a group named `auth` and confirms it's fixed. Full test suite, Pint, and Larastan all pass.