### PR TITLE
[2.x] Fix loadDeferredProps() crashing when a group name matches a helper function

### DIFF
--- a/src/Testing/AssertableInertia.php
+++ b/src/Testing/AssertableInertia.php
@@ -143,9 +143,9 @@ class AssertableInertia extends AssertableJson
      */
     public function loadDeferredProps(Closure|array|string $groupsOrCallback, ?Closure $callback = null): self
     {
-        $callback = is_callable($groupsOrCallback) ? $groupsOrCallback : $callback;
+        $callback = $groupsOrCallback instanceof Closure ? $groupsOrCallback : $callback;
 
-        $groups = is_callable($groupsOrCallback) ? array_keys($this->deferredProps) : Arr::wrap($groupsOrCallback);
+        $groups = $groupsOrCallback instanceof Closure ? array_keys($this->deferredProps) : Arr::wrap($groupsOrCallback);
 
         $props = collect($groups)->flatMap(function ($group) {
             return $this->deferredProps[$group] ?? [];

--- a/tests/Testing/AssertableInertiaTest.php
+++ b/tests/Testing/AssertableInertiaTest.php
@@ -389,6 +389,28 @@ class AssertableInertiaTest extends TestCase
         $this->assertSame(4, $called);
     }
 
+    public function test_deferred_props_can_be_loaded_from_a_group_named_after_a_global_function(): void
+    {
+        $response = $this->makeMockRequest(
+            Inertia::render('foo', [
+                'deferred1' => Inertia::defer(fn () => 'baz', 'auth'),
+                'deferred2' => Inertia::defer(fn () => 'qux', 'custom'),
+            ])
+        );
+
+        $called = false;
+
+        $response->assertInertia(function (AssertableInertia $inertia) use (&$called) {
+            $inertia->loadDeferredProps('auth', function (AssertableInertia $inertia) use (&$called) {
+                $inertia->where('deferred1', 'baz');
+                $inertia->missing('deferred2');
+                $called = true;
+            });
+        });
+
+        $this->assertTrue($called);
+    }
+
     public function test_the_flash_data_can_be_asserted(): void
     {
         $response = $this->makeMockRequest(


### PR DESCRIPTION
Backport of #908 