### PR TITLE
[3.x] Return Illuminate's RedirectResponse from back()

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -30,7 +30,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Symfony\Component\HttpFoundation\Response location(string|\Symfony\Component\HttpFoundation\RedirectResponse $url)
  * @method static void handleExceptionsUsing(callable $callback)
  * @method static \Inertia\ResponseFactory flash(\BackedEnum|\UnitEnum|string|array<string, mixed> $key, mixed $value = null)
- * @method static \Symfony\Component\HttpFoundation\RedirectResponse back(int $status = 302, array<string, string> $headers = [], mixed $fallback = false)
+ * @method static \Illuminate\Http\RedirectResponse back(int $status = 302, array<string, string> $headers = [], mixed $fallback = false)
  * @method static array<string, mixed> getFlashed(\Illuminate\Http\Request|null $request = null)
  * @method static array<string, mixed> pullFlashed(\Illuminate\Http\Request|null $request = null)
  * @method static void macro(string $name, object|callable $macro)

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\RedirectResponse as IlluminateRedirectResponse;
 use Illuminate\Http\Request as HttpRequest;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Arr;
@@ -473,7 +474,7 @@ class ResponseFactory
      *
      * @param  array<string, string>  $headers
      */
-    public function back(int $status = 302, array $headers = [], mixed $fallback = false): RedirectResponse
+    public function back(int $status = 302, array $headers = [], mixed $fallback = false): IlluminateRedirectResponse
     {
         return Redirect::back($status, $headers, $fallback);
     }


### PR DESCRIPTION
`ResponseFactory::back()` is declared as returning `Symfony\Component\HttpFoundation\RedirectResponse`, but it just returns `Redirect::back(...)`, which is an `Illuminate\Http\RedirectResponse`. The facade docblock in `Inertia.php` repeats the Symfony type.

In practice this bites any controller that's typed the Laravel way:

```php
public function update(Request $request): \Illuminate\Http\RedirectResponse
{
    // ...
    return Inertia::flash('toast', ['message' => __('Saved.')])->back();
}
```

PHPStan (level 8 here, but any level that checks return types) reports `Method ... should return Illuminate\Http\RedirectResponse but returns Symfony\Component\HttpFoundation\RedirectResponse`, so the chained form ends up being avoided in favour of `redirect()->back()` plus a separate `Inertia::flash()` call. Runtime was always fine; only the declared type was too wide.

This narrows the return type to the class that's actually returned (the Illuminate one extends the Symfony one, so nothing that accepted the old type breaks) and fixes the `@method` line on the facade to match. `location()` is untouched: it genuinely accepts and returns the Symfony types.

No behaviour change. `vendor/bin/phpunit` passes (560 tests), `pint` is clean, and `phpstan` reports the same single pre-existing warning in `ExceptionResponse.php:157` before and after this change.
